### PR TITLE
fix: tighten CORS origin validation and remove wildcards

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -38,32 +38,33 @@ const allowedOrigins = new Set(originEnvList);
 
 app.use((req, res, next) => {
   const origin = req.headers.origin;
-  const renderPattern =
-    /^https:\/\/(?:interview-prep(?:aration)?-ai|preppilot-backend)-[a-z0-9-]+\.onrender\.com$/;
-  const localhostPattern =
-    /^http:\/\/(localhost|127\.0\.0\.1):(5\d{3}|3\d{3})$/;
-  if (
+
+  const isAllowed =
     origin &&
     (allowedOrigins.has(origin) ||
-      renderPattern.test(origin) ||
-      localhostPattern.test(origin))
-  ) {
+      (isDev &&
+        /^http:\/\/(localhost|127\.0\.0\.1):(5\d{3}|3\d{3})$/.test(origin)));
+
+  if (isAllowed) {
     res.header("Access-Control-Allow-Origin", origin);
     res.header("Vary", "Origin");
     res.header("Access-Control-Allow-Credentials", "true");
-  } else if (origin) {
-    // Debug log for rejected origins (only once per process for each origin)
-    if (!global.__rejectedCors) global.__rejectedCors = new Set();
-    if (!global.__rejectedCors.has(origin)) {
-      global.__rejectedCors.add(origin);
-      console.warn("[CORS] Rejected origin:", origin);
-    }
   }
-  res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
-  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+
+  res.header(
+    "Access-Control-Allow-Methods",
+    "GET,POST,PUT,DELETE,OPTIONS",
+  );
+
+  res.header(
+    "Access-Control-Allow-Headers",
+    "Content-Type, Authorization",
+  );
+
   if (req.method === "OPTIONS") {
     return res.sendStatus(200);
   }
+
   next();
 });
 


### PR DESCRIPTION
### Summary
Refactored the CORS middleware to strictly validate incoming request origins. This change removes legacy wildcard/regex patterns for production URLs and ensures development patterns are only evaluated in a local environment.

### Key Changes
* **Strict Origin Check:** Refactored origin matching to rely primarily on `allowedOrigins.has(origin)`, ensuring only explicitly allowlisted domains gain access.
* **Conditional Dev Patterns:** Limited the localhost/127.0.0.1 regex matching to only execute when `isDev` is true, preventing development rules from leaking into production environments.
* **Removed Legacy Patterns:** Cleaned up unused and overly broad `onrender.com` regex validation patterns (`renderPattern`).
* **Code Cleanup:** Removed redundant global debug error logging (`global.__rejectedCors`) to keep logs clean and optimized the formatting of header assignments.