### PR TITLE
fix: allow application/pdf in uploadMiddleware for resume uploads

### DIFF
--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -3,7 +3,7 @@ const multer = require("multer");
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
 // Configure storage
-const storage = multer.diskStorage({
+const diskStorage = multer.diskStorage({
   destination: (req, file, cb) => {
     cb(null, "uploads/");
   },
@@ -12,8 +12,8 @@ const storage = multer.diskStorage({
   },
 });
 
-// File filter
-const fileFilter = (req, file, cb) => {
+// File filter for image uploads
+const imageFileFilter = (req, file, cb) => {
   const allowedTypes = ["image/jpeg", "image/png", "image/jpg"];
   if (allowedTypes.includes(file.mimetype)) {
     cb(null, true);
@@ -22,13 +22,27 @@ const fileFilter = (req, file, cb) => {
   }
 };
 
-// Initialize upload
+// File filter for resume (PDF) uploads
+const resumeFileFilter = (req, file, cb) => {
+  if (file.mimetype === "application/pdf") {
+    cb(null, true);
+  } else {
+    cb(new Error("Only .pdf format is allowed for resume uploads"), false);
+  }
+};
+
+// Upload instance for images (disk storage)
 const upload = multer({
-  storage,
-  fileFilter,
-  limits: {
-    fileSize: MAX_FILE_SIZE,
-  },
+  storage: diskStorage,
+  fileFilter: imageFileFilter,
+  limits: { fileSize: MAX_FILE_SIZE },
 });
 
-module.exports = upload;
+// Upload instance for resumes (memory storage, buffer needed by controller)
+const uploadResume = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: resumeFileFilter,
+  limits: { fileSize: MAX_FILE_SIZE },
+});
+
+module.exports = { upload, uploadResume };

--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { compileResume, analyzeResume, saveResume, getMyResumes } = require('../controllers/resumeController');
 const { protect } = require('../middlewares/authMiddleware');
-const upload = require('../middlewares/uploadMiddleware');
+const { upload, uploadResume } = require('../middlewares/uploadMiddleware');
 
 // @route   POST /api/resume/compile
 // @desc    Compile LaTeX code to PDF
@@ -10,7 +10,7 @@ router.post('/compile', compileResume);
 
 // @route   POST /api/resume/analyze
 // @desc    Analyze resume using Gemini API
-router.post('/analyze', upload.single("resume"), analyzeResume);
+router.post('/analyze', uploadResume.single("resume"), analyzeResume);
 
 // @route   POST /api/resume/save
 // @desc    Save or update a resume


### PR DESCRIPTION
Fixes #36 

### Problem
The `/analyze` endpoint was rejecting PDF files because `uploadMiddleware.js` only allowed image MIME types (`image/jpeg`, `image/png`, `image/jpg`). This prevented valid PDF resumes from reaching the controller.

### Changes
- **`uploadMiddleware.js`** — Added a separate `uploadResume` multer instance with `memoryStorage` and `application/pdf` file filter. Existing `upload` instance for images is untouched.
- **`resumeRoutes.js`** — Updated `/analyze` route to use `uploadResume.single("resume")` instead of `upload.single("resume")`.

## Why memoryStorage
Since the controller reads req.file.buffer to send the PDF to Gemini, diskStorage won't work here -it saves to disk and never fills buffer, meaning the file would silently fail even after the MIME fix.

### Testing
- Upload a `.pdf` via `/api/resume/analyze` → accepted and analyzed 
- Upload a non-PDF via `/api/resume/analyze` → rejected with error 
- Other routes using `upload` (image uploads) → unaffected 