### PR TITLE
feat: Add Live PDF Preview Before Resume Analysis

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,6 +82,7 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1676,6 +1677,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1695,8 +1697,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -1737,6 +1738,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1859,6 +1861,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2067,7 +2070,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2161,7 +2165,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2331,6 +2334,7 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3568,7 +3572,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4837,6 +4840,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4936,6 +4940,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4948,6 +4953,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5729,6 +5735,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/frontend/src/pages/ResumeBuilder/ResumeAnalyzer.jsx
+++ b/frontend/src/pages/ResumeBuilder/ResumeAnalyzer.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Upload, FileText, Briefcase, Zap, CheckCircle2, AlertTriangle, AlertCircle, X, ChevronRight, RefreshCw, Target } from "lucide-react";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
@@ -9,7 +9,16 @@ const ResumeAnalyzer = () => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
+  const [previewUrl, setPreviewUrl] = useState('');
 
+  useEffect(() => {
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => {
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
   const handleFileDrop = (e) => {
     e.preventDefault();
     const droppedFile = e.dataTransfer.files[0];
@@ -154,13 +163,13 @@ const ResumeAnalyzer = () => {
                 {file ? (
                 <div className="flex flex-col items-center text-center px-6 w-full h-full">
                   <iframe
-                    src={URL.createObjectURL(file)}
+                    src={previewUrl}
                     className="w-full h-48 rounded-xl border border-gray-200 dark:border-white/10 shadow-sm mb-3"
-                    title="Resume Preview"
+                    title="File Preview"
                   />
                   <h3 className="text-sm font-bold text-gray-900 dark:text-white line-clamp-1">{file.name}</h3>
                   <p className="text-xs text-gray-500 dark:text-gray-400 font-medium mt-1">
-                    {(file.size / 1024 / 1024).toFixed(2)} MB • PDF Document
+                    {(file.size / 1024 / 1024).toFixed(2)} MB • {file.type.includes('pdf') ? 'PDF Document' : 'Image'}
                   </p>
                   <button 
                     onClick={(e) => { e.preventDefault(); setFile(null); }}

--- a/frontend/src/pages/ResumeBuilder/ResumeAnalyzer.jsx
+++ b/frontend/src/pages/ResumeBuilder/ResumeAnalyzer.jsx
@@ -152,21 +152,24 @@ const ResumeAnalyzer = () => {
                 />
                 
                 {file ? (
-                  <div className="flex flex-col items-center text-center px-6">
-                    <div className="w-20 h-20 rounded-full bg-emerald-50 dark:bg-emerald-900/30 text-emerald-500 flex items-center justify-center mb-4 shadow-sm">
-                      <FileText size={40} />
-                    </div>
-                    <h3 className="text-lg font-bold text-gray-900 dark:text-white line-clamp-1">{file.name}</h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 font-medium mt-1">
-                      {(file.size / 1024 / 1024).toFixed(2)} MB • PDF Document
-                    </p>
-                    <button 
-                      onClick={(e) => { e.preventDefault(); setFile(null); }}
-                      className="mt-6 text-xs font-bold uppercase tracking-wider text-red-500 hover:text-red-700 transition"
-                    >
-                      Remove File
-                    </button>
-                  </div>
+                <div className="flex flex-col items-center text-center px-6 w-full h-full">
+                  <iframe
+                    src={URL.createObjectURL(file)}
+                    className="w-full h-48 rounded-xl border border-gray-200 dark:border-white/10 shadow-sm mb-3"
+                    title="Resume Preview"
+                  />
+                  <h3 className="text-sm font-bold text-gray-900 dark:text-white line-clamp-1">{file.name}</h3>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 font-medium mt-1">
+                    {(file.size / 1024 / 1024).toFixed(2)} MB • PDF Document
+                  </p>
+                  <button 
+                    onClick={(e) => { e.preventDefault(); setFile(null); }}
+                    className="mt-3 text-xs font-bold uppercase tracking-wider text-red-500 hover:text-red-700 transition"
+
+                  >
+                    Remove File
+                  </button>
+                </div>
                 ) : (
                   <div className="flex flex-col items-center text-center px-6 pointer-events-none">
                     <div className="w-20 h-20 rounded-full bg-indigo-50 dark:bg-indigo-900/20 text-indigo-500 group-hover:scale-110 transition-transform duration-300 flex items-center justify-center mb-4">


### PR DESCRIPTION
Closes #29

## Changes Made
- Added live PDF preview iframe inside the upload box
- When user uploads a PDF, they can see the actual PDF pages before analyzing
- Preview renders using URL.createObjectURL() — no backend required
- File name and size still displayed below the preview
- Remove File button still works as before

## Screenshots

### Before
<img width="1917" height="873" alt="image" src="https://github.com/user-attachments/assets/090f5526-0a09-46c0-a7ca-7f785fb5799c" />
The upload box only showed a drag & drop icon with no visual feedback 
after uploading a PDF — users had no way to verify their file before analyzing.


### After
The upload box now renders an inline PDF preview via iframe when a 
file is uploaded. Users can scroll through their PDF pages directly 
inside the upload box before clicking Analyze Resume, instead of 
just seeing a file icon.