### PR TITLE
security: fix broken access control in question endpoints

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -68,6 +68,21 @@ const togglePinQuestion = async (req, res) => {
         .status(404)
         .json({ success: false, message: "Question not found" });
     }
+
+    const session = await Session.findById(question.session);
+    if (!session) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Session not found" });
+    }
+
+    if (session.user.toString() !== req.user.id) {
+      return res.status(403).json({
+        success: false,
+        message: "Unauthorized access",
+      });
+    }
+
     question.isPinned = !question.isPinned;
     await question.save();
 
@@ -104,6 +119,21 @@ const updateQuestionNote = async (req, res) => {
         .status(404)
         .json({ success: false, message: "Question not found" });
     }
+
+    const session = await Session.findById(question.session);
+    if (!session) {
+      return res
+        .status(404)
+        .json({ success: false, message: "Session not found" });
+    }
+
+    if (session.user.toString() !== req.user.id) {
+      return res.status(403).json({
+        success: false,
+        message: "Unauthorized access",
+      });
+    }
+
     question.note = note || "";
     await question.save();
 


### PR DESCRIPTION
## Summary
This pull request fixes a broken access control (IDOR) vulnerability in the question controller. Specifically, in `togglePinQuestion` and `updateQuestionNote`, any authenticated user could modify pins or notes for questions belonging to other users if they knew the question ID.

## Changes
- Added checks in `togglePinQuestion` and `updateQuestionNote` to load the question's session and verify that the session user ID matches the authenticated user ID (`req.user.id`).
- If they do not match, a `403 Forbidden` response with `Unauthorized access` is returned.
- Added an automated verification script at `backend/scripts/verify_vulnerability.js` to reproduce and confirm the fix.

Documentation about the fix->
[questionAuth fix.pdf](https://github.com/user-attachments/files/28471337/questionAuth.fix.pdf)
