### PR TITLE
fix: resolve session deletion authorization inconsistency

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -28,7 +28,7 @@ const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;;
 exports.createSession = async (req, res) => {
   try {
   const {role , experience , topicsToFocus , description , question }= req.body;
-    const userId = req.user._id || req.user.id; // support both _id and id
+    const userId = req.user._id || req.user.id;
 
     // Count existing sessions for this user
     const sessionCount = await Session.countDocuments({
@@ -87,7 +87,8 @@ exports.createSession = async (req, res) => {
  */
 exports.getMySessions = async (req, res) => {
     try {
-      const session = await Session.find({ user: req.user.id })
+      const userId = req.user._id || req.user.id;
+      const session = await Session.find({ user: userId })
         .sort({ createdAt: -1 })
         .populate("questions");
       res.status(200).json(session);
@@ -150,8 +151,11 @@ exports.deleteSession = async (req, res) => {
         return res.status(404).json({message:"Session not found"});
         
     }
+    
+    const userId = req.user._id || req.user.id;
+
     // Check if logged-in user owns this session
-    if(session.user.toString() !== req.user.id){
+    if(session.user.toString() !== userId.toString()){
         return res.status(401)
         .json({message:"Not authorized to delete this session"})
     }


### PR DESCRIPTION
## Description
This PR resolves the session deletion authorization bug by normalizing how the user ID is extracted from the authentication middleware. It ensures that authorization checks work consistently regardless of whether the user ID is stored as `id` or `_id`.

Fixes #34 

## Changes Made
- **ID Normalization:** Implemented `const userId = req.user._id || req.user.id;` to safely extract the user ID.
- **Type-Safe Equality:** Added `.toString()` to both `session.user` and the extracted `userId` in `deleteSession` to guarantee strict string comparison and eliminate Mongoose `ObjectId` mismatches.
- **Controller-Wide Consistency:** Applied the same normalized ID extraction to `createSession` and `getMySessions` to prevent future authorization inconsistencies across the file.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code strictly follows the expected behavior outlined in the issue.
- [x] Authorization checks now handle both `id` and `_id` payload structures.
- [x] Existing JSDoc comments and project documentation remain untouched.