### PR TITLE
fix: resolve signup modal overflow on smaller screens

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -7,7 +7,7 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
     <AnimatePresence>
       {isOpen && (
         <motion.div
-          className="fixed inset-0 z-50 flex justify-center items-center bg-black/40"
+          className="fixed inset-0 z-50 flex justify-center items-center bg-black/40 overflow-y-auto p-4 pt-8"
           variants={backdropVariants}
           initial="initial"
           animate="animate"
@@ -15,7 +15,8 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
           onClick={onClose}
         >
           <motion.div
-            className="relative flex flex-col bg-white dark:bg-[#151c2f] border border-gray-100 dark:border-white/10 shadow-2xl rounded-2xl lg:w-[35vw] w-[90vw] max-w-lg p-6 md:p-8 overflow-hidden"
+            className="relative flex flex-col bg-white dark:bg-[#151c2f] border border-gray-100 dark:border-white/10 shadow-2xl rounded-2xl lg:w-[35vw] w-[90vw] max-w-lg p-6 md:p-8 max-h-[90vh]
+            overflow-y-auto"
             variants={modalVariants}
             initial="initial"
             animate="animate"
@@ -38,7 +39,9 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
             </button>
 
             {/* modal content */}
-            <div className="w-full">{children}</div>
+            <div className="w-full overflow-y-auto max-h-[90vh] pr-1">
+              {children}
+            </div>
           </motion.div>
         </motion.div>
       )}


### PR DESCRIPTION
## Description

This PR fixes a responsiveness issue where the Sign Up modal could overflow beyond the viewport on smaller screen heights, making parts of the form inaccessible.

### Changes Made

* Added vertical scrolling support to the modal backdrop.
* Applied viewport-friendly spacing for smaller screens.
* Improved modal responsiveness and accessibility when content exceeds available height.

<img width="511" height="708" alt="Screenshot 2026-06-04 at 5 37 53 PM" src="https://github.com/user-attachments/assets/4691243a-d0bf-4371-a8b6-a2864f51c0b9" />

### Issue

Fixes #75 

### Testing

* Tested locally using the Vite development server.
* Verified modal accessibility on smaller viewport heights.
* Confirmed all form fields and actions remain reachable.
* Checked that existing modal functionality remains unaffected.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
