### PR TITLE
fix: prevent background scrolling when modal is open

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -1,8 +1,20 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { modalVariants, backdropVariants } from "../../utils/animations";
 
 const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
   return (
     <AnimatePresence>
       {isOpen && (


### PR DESCRIPTION
## Description

This PR fixes a UX issue where the landing page remained scrollable while authentication modals were open.

When the Login or Sign Up modal was displayed, users could still scroll the background content, which could lead to unintended page movement and a less focused modal experience.

### Changes Made

* Disabled background page scrolling when a modal is open.
* Restored normal scrolling behavior when the modal is closed.
* Added proper cleanup to prevent scroll-lock persistence.

### Issue

Fixes #78 

### Testing

* Verified background scrolling is disabled when Login modal is open.
* Verified background scrolling is disabled when Sign Up modal is open.
* Confirmed scrolling is restored after closing the modal.
* Tested close button and backdrop click functionality.
* Verified no console errors were introduced.

### Before

* Background page could still be scrolled while a modal was open.

### After

* Background page remains locked while the modal is active.
* Scrolling is restored immediately after the modal closes.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
