### PR TITLE
feat: add escape key support for auth modals

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -1,8 +1,24 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { modalVariants, backdropVariants } from "../../utils/animations";
 
 const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
+  useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    };
+  
+    if (isOpen) {
+      document.addEventListener("keydown", handleEsc);
+    }
+  
+    return () => {
+      document.removeEventListener("keydown", handleEsc);
+    };
+  }, [isOpen, onClose]);
+
   return (
     <AnimatePresence>
       {isOpen && (


### PR DESCRIPTION
## Description

This PR adds keyboard accessibility support for authentication modals by allowing users to close Login and Sign Up modals using the Escape (Esc) key.

### Changes Made

* Added Escape key event listener when a modal is open.
* Closes the active authentication modal when Esc is pressed.
* Properly cleans up event listeners when the modal closes or unmounts.

### Issue

Fixes #79 

### Testing

* Verified Login modal closes on Esc.
* Verified Sign Up modal closes on Esc.
* Confirmed existing close button and backdrop click behavior remain unchanged.
* Checked for console errors and proper event listener cleanup.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
