### PR TITLE
remove unused BASE_URL from userContext.jsx

### DIFF
--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useEffect } from "react";
 import axiosInstance from "../utils/axiosinstance";
-import { API_PATHS, BASE_URL } from "../utils/apiPaths";
+import { API_PATHS } from "../utils/apiPaths";
 import toast from "react-hot-toast";
 
 


### PR DESCRIPTION
## Description

In `userContext.jsx`, `BASE_URL` is imported from `../utils/apiPaths` but is never used anywhere in the file. This is dead code that clutters the import statement and may confuse new contributors.

## File Affected
`frontend/src/context/userContext.jsx`

## Changes Made
- Removed unused `BASE_URL` import

## Before
```js
import { API_PATHS, BASE_URL } from "../utils/apiPaths";
```

## After
```js
import { API_PATHS } from "../utils/apiPaths";
```

## Impact
- Reduces unnecessary imports
- Cleaner and more readable code
- Avoids confusion for new contributors

## Suggested Labels

| Label | 
|---|
| `gssoc:approved` |
| `level:beginner` | 
| `type:refactor` | 
| `quality:clean` | 
| `good first issue` |



### Reason
- `level:beginner` — Single line change, remove one unused import
- `type:refactor` — Improves code cleanliness without changing functionality
- `quality:clean` — Minimal, focused, no unnecessary changes

Closes #82