### PR TITLE
Fix/prevent unexpected logout

### DIFF
--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState, useEffect } from "react";
 import axiosInstance from "../utils/axiosinstance";
-import { API_PATHS, BASE_URL } from "../utils/apiPaths";
+import { API_PATHS } from "../utils/apiPaths";
 import toast from "react-hot-toast";
 
 

--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -20,19 +20,24 @@ export const UserProvider = ({ children }) => {
             return;
         }
 
-        const fetchUser = async () => {
-            try {
-                const response = await axiosInstance.get(API_PATHS.AUTH.GET_PROFILE);
-                setUser(response.data);
-                // Fetch all sheet progress for user
-                const progressRes = await axiosInstance.get("/api/user/sheet-progress");
-                setSheetProgress(progressRes.data.progressList || []);
-            } catch (error) {
-                clearUser();
-            } finally {
-                setLoading(false);
-            }
-        };
+ const fetchUser = async () => {
+    try {
+        const response = await axiosInstance.get(API_PATHS.AUTH.GET_PROFILE);
+        setUser(response.data);
+    } catch (error) {
+        clearUser(); // only logs out if AUTH fails 
+        return;
+    } finally {
+        setLoading(false);
+    }
+    try {
+        const progressRes = await axiosInstance.get("/api/user/sheet-progress");
+        setSheetProgress(progressRes.data.progressList || []);
+    } catch (error) {
+        console.error("Failed to load progress:", error);
+        toast.error("Failed to load progress. Please try again.");
+    }
+};
         fetchUser();
     }, []);
 


### PR DESCRIPTION
## Description

This PR fixes an issue where users were being logged out when the `/api/user/sheet-progress` API request failed.

### Before

* `GET_PROFILE` and `sheet-progress` requests were wrapped in the same `try-catch` block.
* Failure of the sheet progress API triggered `clearUser()`.
* Users were logged out unexpectedly despite successful authentication.

### After

* Authentication and progress fetching are handled separately.
* Sheet progress failures no longer affect the authenticated session.
* Users remain logged in and receive a toast notification if progress data cannot be loaded.

### Suggested Labels

* `type:bug`
* `quality:clean`
* `level:intermediate`
* `gssoc:approved`



Closes #83
