### PR TITLE
fix: prevent Host Header Injection in image upload route

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,10 @@
 # Server Configuration
 PORT=8000
 
+# Base URL for constructing absolute URLs (e.g. for image uploads)
+# In production, set this to your actual domain like https://preppilot-backend.onrender.com
+# BASE_URL=https://preppilot-backend.onrender.com
+
 # Database Configuration
 # MongoDB connection string (local or cloud)
 MONGO_URI=mongodb://localhost:27017/interview_prep_ai

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -21,7 +21,8 @@ router.post("/upload-image", upload.single("image"), (req, res) => {
   if (!req.file) {
     return res.status(400).json({ message: "No file uploaded" });
   }
-  const imageUrl = `${req.protocol}://${req.get("host")}/uploads/${req.file.filename}`;
+  const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get("host")}`;
+  const imageUrl = `${baseUrl}/uploads/${req.file.filename}`;
   res.status(200).json({ imageUrl });
 });
 


### PR DESCRIPTION
## Fixes #93

### Bug
In `backend/routes/authRoutes.js:24`, the image URL was constructed using `req.get("host")` directly from the incoming request header, allowing Host Header Injection.

### Fix
- Replaced unsafe `req.get("host")` with a configurable `BASE_URL` environment variable
- Added `BASE_URL` documentation to `.env.example`
- Falls back to request-derived URL when `BASE_URL` is not set
