### PR TITLE
feat: trap keyboard focus within auth modals

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -1,8 +1,49 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { modalVariants, backdropVariants } from "../../utils/animations";
 
 const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
+  const modalRef = useRef(null);
+  useEffect(() => {
+    if (!isOpen) return;
+  
+    const modal = modalRef.current;
+  
+    const focusableElements = modal.querySelectorAll(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    
+
+    const firstElement = focusableElements[0];
+    const lastElement = focusableElements[focusableElements.length - 1];
+
+    if (firstElement) {
+      firstElement.focus();
+   }
+  
+    const handleTabKey = (e) => {
+      if (e.key !== "Tab") return;
+  
+      if (e.shiftKey) {
+        if (document.activeElement === firstElement) {
+          e.preventDefault();
+          lastElement.focus();
+        }
+      } else {
+        if (document.activeElement === lastElement) {
+          e.preventDefault();
+          firstElement.focus();
+        }
+      }
+    };
+  
+    document.addEventListener("keydown", handleTabKey);
+  
+    return () => {
+      document.removeEventListener("keydown", handleTabKey);
+    };
+  }, [isOpen, children]);
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -15,6 +56,7 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
           onClick={onClose}
         >
           <motion.div
+            ref={modalRef}
             className="relative flex flex-col bg-white dark:bg-[#151c2f] border border-gray-100 dark:border-white/10 shadow-2xl rounded-2xl lg:w-[35vw] w-[90vw] max-w-lg p-6 md:p-8 max-h-[90vh]
             overflow-y-auto"
             variants={modalVariants}


### PR DESCRIPTION
## Description

This PR improves accessibility for authentication modals by implementing keyboard focus trapping.
<br>
Previously, users could navigate outside the Login and Sign Up modals using the Tab key, allowing focus to move to background page elements while the modal was still open.

### Changes Made

* Added keyboard focus trapping within authentication modals.
* Supports both forward (Tab) and backward (Shift + Tab) navigation.
* Recalculates focusable elements when modal content changes (Login ↔ Sign Up).
* Prevents focus from escaping to background page elements while the modal is active.

### Issue

Fixes #91 

### Testing

* Verified Tab navigation remains within Login modal.
* Verified Tab navigation remains within Sign Up modal.
* Verified Shift + Tab navigation works correctly.
* Verified focus remains trapped after switching between Login and Sign Up views.
* Confirmed background elements cannot receive focus while the modal is open.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
