### PR TITLE
feat: add autofocus support for auth modals

### DIFF
--- a/frontend/src/components/Inputs/Input.jsx
+++ b/frontend/src/components/Inputs/Input.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { FaRegEye, FaRegEyeSlash } from "react-icons/fa6";
 
-const Input = ({ value, onChange, label, placeholder, type }) => {
+const Input = ({ value, onChange, label, placeholder, type, autoFocus = false, }) => {
   const [showPassword, setShowpassword] = useState(false);
   const toggleShowPassword = () => {
     setShowpassword(!showPassword);
@@ -21,6 +21,7 @@ const Input = ({ value, onChange, label, placeholder, type }) => {
           className="w-full min-w-0 bg-white border border-violet-300 hover:border-violet-400 focus:border-violet-500 rounded-lg py-2.5 px-4 pr-10 text-sm text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500/20 transition-all duration-200"
           value={value}
           onChange={(e) => onChange(e)}
+          autoFocus={autoFocus}
         />
         {type === "password" && (
           <span

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -86,6 +86,7 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
           label="Email Address"
           placeholder="your@email.com"
           type="text"
+          autoFocus
         />
 
         <Input

--- a/frontend/src/pages/Auth/SignUp.jsx
+++ b/frontend/src/pages/Auth/SignUp.jsx
@@ -121,6 +121,7 @@ const SignUp = ({ setCurrentPage }) => {
           label="Full Name"
           placeholder="John Doe"
           type="text"
+          autoFocus
         />
 
         {/* Email Input */}


### PR DESCRIPTION
## Description

This PR improves the authentication modal experience by automatically focusing the first input field when the Login or Sign Up modal is opened.

Previously, users had to manually click an input field before entering their credentials. With this change, users can begin typing immediately after the modal appears.

### Changes Made

* Added support for the `autoFocus` prop in the reusable Input component.
* Automatically focuses the Email field when the Login modal opens.
* Automatically focuses the Full Name field when the Sign Up modal opens.

### Issue

Fixes #90 

### Testing

* Verified the Email field receives focus when the Login modal opens.
* Verified the Full Name field receives focus when the Sign Up modal opens.
* Confirmed users can start typing immediately without clicking an input field.
* Tested existing form functionality to ensure no regressions.

### Benefits

* Improves keyboard accessibility.
* Reduces unnecessary user interactions.
* Provides a smoother authentication experience.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
