### PR TITLE
fix: preserve auth form state when switching forms

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -932,11 +932,12 @@ const LandingPage = () => {
         hideHeader
       >
         <div>
-          {currentPage === "login" && (
+          <div className={currentPage === "login" ? "block" : "hidden"}>
             <Login
               setCurrentPage={setCurrentPage}
               onLoginSuccess={() => {
                 setOpenAuthModal(false);
+          
                 if (pendingRoute) {
                   navigate(pendingRoute);
                   setPendingRoute(null);
@@ -945,10 +946,11 @@ const LandingPage = () => {
                 }
               }}
             />
-          )}
-          {currentPage === "signup" && (
+          </div>
+          
+          <div className={currentPage === "signup" ? "block" : "hidden"}>
             <SignUp setCurrentPage={setCurrentPage} />
-          )}
+          </div>
         </div>
       </Modal>
     </>


### PR DESCRIPTION
## Description

This PR fixes an issue where user-entered form data was lost when switching between the Login and Sign Up forms in the authentication modal.

### Changes Made

* Kept Login and Sign Up components mounted while toggling visibility.
* Preserved user-entered form data when switching between authentication forms.
* Prevented unnecessary loss of information during form navigation.

### Issue

Fixes #106 

### Testing

* Verified Login form data remains intact after switching to Sign Up and back.
* Verified Sign Up form data remains intact after switching to Login and back.
* Confirmed authentication flow continues to function correctly.

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
