### PR TITLE
fix: add accessible label to authentication modal close button

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -52,6 +52,8 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
 
             <button
               type="button"
+              aria-label="Close authentication modal"
+              title="Close"
               className="text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 rounded-full p-1.5 flex items-center justify-center absolute top-4 right-4 transition-all duration-200 z-10"
               onClick={onClose}
             >


### PR DESCRIPTION
## Description

This PR improves accessibility for the authentication modal close button.

### Changes Made

* Added `aria-label="Close authentication modal"` to provide a descriptive accessible name for screen reader users.
* Added `title="Close"` to provide a tooltip for mouse users.

### Benefits

* Improves screen reader accessibility.
* Makes the close button purpose clearer.
* Aligns with accessibility best practices for icon-only buttons.

### Issue

Fixes #108 

### Screenshot

<img width="554" height="588" alt="Screenshot 2026-06-06 at 4 16 12 PM" src="https://github.com/user-attachments/assets/44af7919-3f3c-4934-aac4-f312a85cf013" />


### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
