### PR TITLE
fix: avoid repeating previously seen questions in AI generation (closes #113)

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -3,9 +3,11 @@ const {
   conceptExplainPrompt,
   questionAnswerPrompt,
 } = require("../utils/prompts");
+const Session = require("../models/Session");
+const Question = require("../models/Question");
 
-// Initialize Gemini with API key from .env
 const ai = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
 
 /**
  * Generate interview questions and answers using the Gemini AI service.
@@ -40,24 +42,41 @@ const generateInterviewQuestions = async (req, res) => {
       return res.status(400).json({ message: "Missing required fields" });
     }
 
-    // Build prompt
+    // Fetch questions the user has already seen for this role + topic
+    const pastSessions = await Session.find({
+      user: req.user._id,
+      role,
+      topicsToFocus,
+    }).select("questions");
+
+    const pastQuestionIds = pastSessions.flatMap((s) => s.questions);
+
+    const pastQuestions = await Question.find({
+      _id: { $in: pastQuestionIds },
+    }).select("question");
+
+    const seenQuestions = pastQuestions.map((q) => q.question);
+
+    // Build prompt with seen questions so Gemini avoids repeating them
     const prompt = questionAnswerPrompt({
       role,
       experience,
       topicsToFocus,
       numberOfQuestions,
+      seenQuestions,
     });
 
-    // Use stable Gemini model
     const candidateModels = [
       process.env.GEMINI_MODEL,
       "models/gemini-2.5-flash",
       "models/gemini-flash-latest",
       "models/gemini-2.0-flash",
     ].filter(Boolean);
+
     let lastErr = null;
     let result = null;
     let usedModel = null;
+
     for (const m of candidateModels) {
       try {
         console.log(`Trying model: ${m}`);
@@ -72,32 +91,31 @@ const generateInterviewQuestions = async (req, res) => {
         continue;
       }
     }
+
     if (!result) throw lastErr || new Error("All Gemini models failed");
 
     const rawText = await result.response.text();
-    // Robustly clean: remove all leading/trailing code block markers (```json, ```), even if repeated, and trim
     let cleanedText = rawText
-      .replace(/^(\s*```json\s*|\s*```\s*)+/i, "") // remove all leading ```json or ```
-      .replace(/(\s*```\s*)+$/i, "") // remove all trailing ```
+      .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
+      .replace(/(\s*```\s*)+$/i, "")
       .trim();
 
     try {
       const data = JSON.parse(cleanedText);
-      // Handle array response (questions) vs object response
       if (Array.isArray(data)) {
         res.status(200).json({ model: usedModel, question: data });
       } else {
         res.status(200).json({ model: usedModel, ...data });
       }
     } catch (err) {
-      console.error("Gemini returned invalid JSON:", cleanedText); // Log the cleaned text
+      console.error("Gemini returned invalid JSON:", cleanedText);
       res.status(500).json({
         message: "Gemini returned invalid JSON",
         raw: rawText,
       });
     }
   } catch (error) {
-    console.error("Gemini API Error:", error); // Log the error
+    console.error("Gemini API Error:", error);
     res.status(500).json({
       message: "Failed to generate questions",
       error: error.message,

--- a/backend/utils/prompts.js
+++ b/backend/utils/prompts.js
@@ -1,5 +1,10 @@
 
-const questionAnswerPrompt = ({ role, experience, topicsToFocus, numberOfQuestions }) => `
+const questionAnswerPrompt = ({ role, experience, topicsToFocus, numberOfQuestions, seenQuestions = [] }) => {
+  const avoidSection = seenQuestions.length > 0
+    ? `\nAvoid generating questions similar to these, which the user has already seen:\n${seenQuestions.map((q, i) => `${i + 1}. ${q}`).join("\n")}\n`
+    : "";
+
+  return `
 You are an AI trained to generate technical interview questions and answers.
 
 Task:
@@ -12,6 +17,7 @@ Task:
     - If the answer naturally requires a code example, include exactly ONE short, simple code block.
     - Use basic markdown formatting (bold, italics, bullet points).
     - DO NOT generate excessively long explanations; the user will request more details separately if needed.
+${avoidSection}
 - Return a pure JSON array like:
 [
   {
@@ -23,6 +29,7 @@ Task:
 
 Important: Do NOT add any extra text. Only return valid JSON.
 `;
+};
 
 const conceptExplainPrompt = (question) => (`
 You are an AI trained to generate explanations for a given interview question.


### PR DESCRIPTION
## Solves issue #113 

**What was the problem?**

When a user generated interview questions for the same role and topic multiple times, the AI would return the same questions repeatedly. The prompt sent to Gemini had no knowledge of the user's question history, so each session started from scratch.

**What was changed?**

`backend/controllers/aiController.js`
- Imported `Session` and `Question` models
- Before building the prompt, fetch all past sessions for the authenticated user matching the same `role` and `topicsToFocus`
- Extract the question texts from those sessions and pass them into the prompt as `seenQuestions`

`backend/utils/prompts.js`
- Added `seenQuestions` parameter to `questionAnswerPrompt`
- If the array is non-empty, an avoid-section is injected into the prompt telling Gemini not to repeat those questions
- If the user has no history (first session), `seenQuestions` defaults to `[]` and the prompt is unchanged

**How it works end to end**

1. User hits `/api/ai/generate-questions`
2. Controller queries MongoDB for all their past sessions with the same role + topic
3. Question texts from those sessions are collected
4. They're injected into the Gemini prompt as a list to avoid
5. Gemini generates fresh questions the user hasn't seen before

**What stays the same**
- `generateConceptExplanation` is untouched
- New users with no history see zero change in behaviour
- No changes to any frontend files, models, or routes.