### PR TITLE
resume builder: add resume templates and update resume editor

### DIFF
--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -184,6 +184,19 @@ DO NOT wrap the response in markdown blocks like \`\`\`json. Return ONLY the raw
 }
 
 const Resume = require("../models/Resume");
+const mongoose = require("mongoose");
+
+const getUserId = (req) => req.user._id || req.user.id;
+
+const isValidObjectId = (id) => mongoose.Types.ObjectId.isValid(id);
+
+const findOwnedResume = (resumeId, userId) => {
+    if (!isValidObjectId(resumeId)) {
+        return null;
+    }
+
+    return Resume.findOne({ _id: resumeId, user: userId });
+};
 
 /**
  * Save or update a user's resume record.
@@ -206,7 +219,7 @@ const Resume = require("../models/Resume");
 const saveResume = async (req, res) => {
     try {
         const { title, latexCode, resumeId } = req.body;
-        const userId = req.user._id || req.user.id;
+        const userId = getUserId(req);
 
         if (!title || !latexCode) {
             return res.status(400).json({ success: false, message: "Title and LaTeX code are required." });
@@ -214,11 +227,19 @@ const saveResume = async (req, res) => {
 
         let resume;
         if (resumeId) {
+            if (!isValidObjectId(resumeId)) {
+                return res.status(400).json({ success: false, message: "Invalid resume id." });
+            }
+
             resume = await Resume.findOneAndUpdate(
                 { _id: resumeId, user: userId },
                 { title, latexCode },
                 { new: true }
             );
+
+            if (!resume) {
+                return res.status(404).json({ success: false, message: "Resume not found." });
+            }
         } else {
             resume = await Resume.create({
                 user: userId,
@@ -249,7 +270,7 @@ const saveResume = async (req, res) => {
  */
 const getMyResumes = async (req, res) => {
     try {
-        const userId = req.user._id || req.user.id;
+        const userId = getUserId(req);
         const resumes = await Resume.find({ user: userId }).sort({ updatedAt: -1 });
         res.status(200).json({ success: true, resumes });
     } catch (error) {
@@ -258,4 +279,102 @@ const getMyResumes = async (req, res) => {
     }
 };
 
-module.exports = { compileResume, analyzeResume, saveResume, getMyResumes };
+/**
+ * Retrieve a single saved resume for the authenticated user.
+ * @route GET /api/resume/:id
+ */
+const getResumeById = async (req, res) => {
+    try {
+        const resume = await findOwnedResume(req.params.id, getUserId(req));
+
+        if (!resume) {
+            return res.status(404).json({ success: false, message: "Resume not found." });
+        }
+
+        res.status(200).json({ success: true, resume });
+    } catch (error) {
+        console.error("Get Resume Error:", error);
+        res.status(500).json({ success: false, message: "Server Error", error: error.message });
+    }
+};
+
+/**
+ * Update a saved resume for the authenticated user.
+ * @route PUT /api/resume/:id
+ */
+const updateResume = async (req, res) => {
+    try {
+        const { title, latexCode } = req.body;
+        const updates = {};
+
+        if (title !== undefined) {
+            if (typeof title !== "string" || !title.trim()) {
+                return res.status(400).json({ success: false, message: "Title cannot be empty." });
+            }
+            updates.title = title.trim();
+        }
+
+        if (latexCode !== undefined) {
+            if (typeof latexCode !== "string" || !latexCode.trim()) {
+                return res.status(400).json({ success: false, message: "LaTeX code cannot be empty." });
+            }
+            updates.latexCode = latexCode;
+        }
+
+        if (!Object.keys(updates).length) {
+            return res.status(400).json({ success: false, message: "No valid fields provided for update." });
+        }
+
+        if (!isValidObjectId(req.params.id)) {
+            return res.status(404).json({ success: false, message: "Resume not found." });
+        }
+
+        const resume = await Resume.findOneAndUpdate(
+            { _id: req.params.id, user: getUserId(req) },
+            updates,
+            { new: true }
+        );
+
+        if (!resume) {
+            return res.status(404).json({ success: false, message: "Resume not found." });
+        }
+
+        res.status(200).json({ success: true, resume });
+    } catch (error) {
+        console.error("Update Resume Error:", error);
+        res.status(500).json({ success: false, message: "Server Error", error: error.message });
+    }
+};
+
+/**
+ * Delete a saved resume for the authenticated user.
+ * @route DELETE /api/resume/:id
+ */
+const deleteResume = async (req, res) => {
+    try {
+        if (!isValidObjectId(req.params.id)) {
+            return res.status(404).json({ success: false, message: "Resume not found." });
+        }
+
+        const resume = await Resume.findOneAndDelete({ _id: req.params.id, user: getUserId(req) });
+
+        if (!resume) {
+            return res.status(404).json({ success: false, message: "Resume not found." });
+        }
+
+        res.status(200).json({ success: true, message: "Resume deleted successfully." });
+    } catch (error) {
+        console.error("Delete Resume Error:", error);
+        res.status(500).json({ success: false, message: "Server Error", error: error.message });
+    }
+};
+
+module.exports = {
+    compileResume,
+    analyzeResume,
+    saveResume,
+    getMyResumes,
+    getResumeById,
+    updateResume,
+    deleteResume
+};

--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -1,8 +1,16 @@
 const express = require('express');
 const router = express.Router();
-const { compileResume, analyzeResume, saveResume, getMyResumes } = require('../controllers/resumeController');
+const {
+    compileResume,
+    analyzeResume,
+    saveResume,
+    getMyResumes,
+    getResumeById,
+    updateResume,
+    deleteResume
+} = require('../controllers/resumeController');
 const { protect } = require('../middlewares/authMiddleware');
-const { upload, uploadResume } = require('../middlewares/uploadMiddleware');
+const { uploadResume } = require('../middlewares/uploadMiddleware');
 
 // @route   POST /api/resume/compile
 // @desc    Compile LaTeX code to PDF
@@ -19,5 +27,17 @@ router.post('/save', protect, saveResume);
 // @route   GET /api/resume/my-resumes
 // @desc    Get all saved resumes for logged-in user
 router.get('/my-resumes', protect, getMyResumes);
+
+// @route   GET /api/resume/:id
+// @desc    Get a saved resume owned by the logged-in user
+router.get('/:id', protect, getResumeById);
+
+// @route   PUT /api/resume/:id
+// @desc    Update a saved resume owned by the logged-in user
+router.put('/:id', protect, updateResume);
+
+// @route   DELETE /api/resume/:id
+// @desc    Delete a saved resume owned by the logged-in user
+router.delete('/:id', protect, deleteResume);
 
 module.exports = router;

--- a/frontend/src/pages/ResumeBuilder/ResumeEditor.jsx
+++ b/frontend/src/pages/ResumeBuilder/ResumeEditor.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import Split from "react-split";
 import Editor from "@monaco-editor/react";
@@ -91,27 +91,33 @@ Hello World!
 \\end{document}`
 };
 
+const getTemplateTitle = (templateId) => {
+  if (templateId === "jakes-resume") return "Jake's Resume";
+  if (templateId === "deedy-cv") return "Deedy CV";
+  if (templateId === "harvard-pro") return "Harvard Professional";
+  if (templateId === "blank") return "Document";
+  return "Saved Resume";
+};
+
 const ResumeEditor = () => {
   const { id } = useParams();
   const navigate = useNavigate();
+  const isTemplateResume = Boolean(TEMPLATE_CODE[id]);
   const [code, setCode] = useState(TEMPLATE_CODE[id] || TEMPLATE_CODE["blank"]);
+  const [resumeTitle, setResumeTitle] = useState(getTemplateTitle(id));
+  const [savedResumeId, setSavedResumeId] = useState(isTemplateResume ? null : id);
   const [pdfUrl, setPdfUrl] = useState(null);
+  const [isLoadingResume, setIsLoadingResume] = useState(false);
   const [isCompiling, setIsCompiling] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState(null);
-
-  // Initial Compile
-  useEffect(() => {
-    compileLatex();
-    // eslint-disable-next-line
-  }, []);
 
   const handleEditorChange = (value) => {
     setCode(value);
   };
 
-  const compileLatex = async () => {
-    if (!code.trim()) return;
+  const compileLatex = async (latexCode = code) => {
+    if (!latexCode.trim()) return;
     
     setIsCompiling(true);
     setError(null);
@@ -119,7 +125,7 @@ const ResumeEditor = () => {
     try {
       const response = await axiosInstance.post(
         API_PATHS.RESUME.COMPILE,
-        { code },
+        { code: latexCode },
         { responseType: 'blob' }
       );
 
@@ -130,8 +136,7 @@ const ResumeEditor = () => {
          throw new Error("LaTeX syntax error. Please check your code.");
       }
       
-      const newPdfUrl = URL.createObjectURL(blob);
-      setPdfUrl(newPdfUrl);
+      setPdfUrl(URL.createObjectURL(blob));
 
     } catch (err) {
       console.error(err);
@@ -154,25 +159,81 @@ const ResumeEditor = () => {
     }
   };
 
+  useEffect(() => {
+    const loadResume = async () => {
+      if (TEMPLATE_CODE[id]) {
+        const templateCode = TEMPLATE_CODE[id];
+        setCode(templateCode);
+        setResumeTitle(getTemplateTitle(id));
+        setSavedResumeId(null);
+        await compileLatex(templateCode);
+        return;
+      }
+
+      setIsLoadingResume(true);
+      setError(null);
+
+      try {
+        const response = await axiosInstance.get(API_PATHS.RESUME.GET_ONE(id));
+        const resume = response.data.resume;
+
+        setCode(resume.latexCode);
+        setResumeTitle(resume.title);
+        setSavedResumeId(resume._id);
+        await compileLatex(resume.latexCode);
+      } catch (err) {
+        console.error(err);
+        toast.error(err.response?.data?.message || "Failed to load saved resume");
+        setError("Unable to load this saved resume. Please go back and try again.");
+      } finally {
+        setIsLoadingResume(false);
+      }
+    };
+
+    loadResume();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id]);
+
+  useEffect(() => {
+    return () => {
+      if (pdfUrl) URL.revokeObjectURL(pdfUrl);
+    };
+  }, [pdfUrl]);
+
   const downloadPdf = () => {
     if (!pdfUrl) return;
     const a = document.createElement("a");
     a.href = pdfUrl;
-    a.download = `resume_${id || 'draft'}.pdf`;
+    a.download = `${resumeTitle || "resume"}.pdf`;
     a.click();
   };
 
   const saveToDashboard = async () => {
     setIsSaving(true);
     try {
-      await axiosInstance.post(API_PATHS.RESUME.SAVE, {
-        title: id === "jakes-resume" ? "Jake's Resume" : id === "deedy-cv" ? "Deedy CV" : "Document",
-        latexCode: code
-      });
-      toast.success("Resume saved successfully!");
+      if (savedResumeId) {
+        const response = await axiosInstance.put(API_PATHS.RESUME.UPDATE(savedResumeId), {
+          title: resumeTitle,
+          latexCode: code
+        });
+
+        setResumeTitle(response.data.resume.title);
+        toast.success("Resume updated successfully!");
+      } else {
+        const response = await axiosInstance.post(API_PATHS.RESUME.SAVE, {
+          title: resumeTitle,
+          latexCode: code
+        });
+        const savedResume = response.data.resume;
+
+        setSavedResumeId(savedResume._id);
+        setResumeTitle(savedResume.title);
+        toast.success("Resume saved successfully!");
+        navigate(`/resume-builder/${savedResume._id}`, { replace: true });
+      }
     } catch (err) {
       console.error(err);
-      toast.error("Failed to save resume to Dashboard");
+      toast.error(err.response?.data?.message || "Failed to save resume to Dashboard");
     } finally {
       setIsSaving(false);
     }
@@ -196,15 +257,15 @@ const ResumeEditor = () => {
             <FileText size={18} className="text-violet-500" />
             <span className="font-semibold text-sm">main.tex</span>
             <span className="text-xs text-gray-400 ml-2 font-medium bg-gray-200 dark:bg-white/5 px-2 py-0.5 rounded-sm">
-              {id === "jakes-resume" ? "Jake's Resume" : id === "deedy-cv" ? "Deedy CV" : "Document"}
+              {resumeTitle}
             </span>
           </div>
         </div>
 
         <div className="flex items-center gap-3">
           <button
-            onClick={compileLatex}
-            disabled={isCompiling}
+            onClick={() => compileLatex()}
+            disabled={isCompiling || isLoadingResume}
             className={`flex items-center gap-2 px-4 py-1.5 rounded text-sm font-bold text-white shadow-sm transition-all ${
               isCompiling 
                 ? "bg-emerald-500/50 cursor-wait shadow-none" 
@@ -230,7 +291,7 @@ const ResumeEditor = () => {
 
           <button
             onClick={saveToDashboard}
-            disabled={!code || isCompiling || isSaving}
+            disabled={!code || isCompiling || isSaving || isLoadingResume}
             className={`flex items-center gap-2 px-4 py-1.5 rounded text-sm font-bold shadow-sm transition-all ${
               isSaving
                 ? "bg-violet-500/50 cursor-wait shadow-none text-white"
@@ -242,7 +303,7 @@ const ResumeEditor = () => {
             ) : (
               <Save size={14} className="fill-current" />
             )}
-            Save to Dashboard
+            {savedResumeId ? "Save Changes" : "Save to Dashboard"}
           </button>
 
           <div className="h-6 w-px bg-gray-300 dark:bg-white/10 mx-1"></div>
@@ -293,9 +354,14 @@ const ResumeEditor = () => {
                Preview
              </div>
              <div className="flex-1 relative overflow-auto p-4 md:p-8 flex justify-center bg-[#525659] dark:bg-[#1a1a1a]">
-               {error ? (
+               {isLoadingResume ? (
+                 <div className="m-auto text-gray-400 dark:text-gray-500 flex flex-col items-center gap-3">
+                   <RefreshCw size={32} className="animate-spin text-gray-300 dark:text-gray-600" />
+                   <span className="font-medium tracking-wide">Loading saved resume...</span>
+                 </div>
+               ) : error ? (
                  <div className="w-full max-w-lg m-auto bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-500/30 p-4 rounded-xl text-red-600 dark:text-red-400 flex flex-col gap-2">
-                   <h4 className="font-bold flex items-center gap-2">⚠️ Compilation Error</h4>
+                   <h4 className="font-bold flex items-center gap-2">Compilation Error</h4>
                    <p className="text-sm font-medium whitespace-pre-wrap">{error}</p>
                  </div>
                ) : pdfUrl ? (

--- a/frontend/src/pages/ResumeBuilder/ResumeTemplates.jsx
+++ b/frontend/src/pages/ResumeBuilder/ResumeTemplates.jsx
@@ -1,6 +1,9 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { FileText, Plus, Sparkles } from "lucide-react";
+import { CalendarClock, Check, Edit3, FileText, Plus, RefreshCw, Trash2, X } from "lucide-react";
+import toast from "react-hot-toast";
+import axiosInstance from "../../utils/axiosinstance";
+import { API_PATHS } from "../../utils/apiPaths";
 
 // Sample initial templates
 export const RESUME_TEMPLATES = [
@@ -23,9 +26,99 @@ export const RESUME_TEMPLATES = [
 
 const ResumeTemplates = () => {
   const navigate = useNavigate();
+  const [savedResumes, setSavedResumes] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [editingId, setEditingId] = useState(null);
+  const [draftTitle, setDraftTitle] = useState("");
+  const [busyId, setBusyId] = useState(null);
+
+  const fetchSavedResumes = useCallback(async () => {
+    setIsLoading(true);
+    setError("");
+
+    try {
+      const response = await axiosInstance.get(API_PATHS.RESUME.GET_ALL);
+      setSavedResumes(response.data.resumes || []);
+    } catch (err) {
+      console.error(err);
+      setError("Unable to load saved resumes.");
+      toast.error("Failed to load saved resumes");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchSavedResumes();
+  }, [fetchSavedResumes]);
 
   const handleSelectTemplate = (id) => {
     navigate(`/resume-builder/${id}`);
+  };
+
+  const handleStartRename = (resume) => {
+    setEditingId(resume._id);
+    setDraftTitle(resume.title);
+  };
+
+  const handleCancelRename = () => {
+    setEditingId(null);
+    setDraftTitle("");
+  };
+
+  const handleRename = async (resumeId) => {
+    const title = draftTitle.trim();
+
+    if (!title) {
+      toast.error("Resume title cannot be empty");
+      return;
+    }
+
+    setBusyId(resumeId);
+    try {
+      const response = await axiosInstance.put(API_PATHS.RESUME.UPDATE(resumeId), { title });
+      const updatedResume = response.data.resume;
+
+      setSavedResumes((prev) =>
+        prev.map((resume) => (resume._id === resumeId ? updatedResume : resume))
+      );
+      toast.success("Resume renamed");
+      handleCancelRename();
+    } catch (err) {
+      console.error(err);
+      toast.error(err.response?.data?.message || "Failed to rename resume");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (resume) => {
+    const confirmed = window.confirm(`Delete "${resume.title}"? This cannot be undone.`);
+
+    if (!confirmed) return;
+
+    setBusyId(resume._id);
+    try {
+      await axiosInstance.delete(API_PATHS.RESUME.DELETE(resume._id));
+      setSavedResumes((prev) => prev.filter((item) => item._id !== resume._id));
+      toast.success("Resume deleted");
+    } catch (err) {
+      console.error(err);
+      toast.error(err.response?.data?.message || "Failed to delete resume");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const formatDate = (value) => {
+    if (!value) return "Recently updated";
+
+    return new Intl.DateTimeFormat("en", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(value));
   };
 
   return (
@@ -48,8 +141,145 @@ const ResumeTemplates = () => {
         </div>
       </div>
 
+      {/* Saved Resumes */}
+      <section className="max-w-6xl mx-auto mb-12">
+        <div className="flex items-center justify-between gap-4 mb-4">
+          <div>
+            <h2 className="text-xl font-extrabold text-gray-900 dark:text-white">Saved Resumes</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">
+              Continue editing, rename, or remove your saved LaTeX resumes.
+            </p>
+          </div>
+          <button
+            onClick={fetchSavedResumes}
+            disabled={isLoading}
+            className="h-10 w-10 rounded-lg border border-gray-200 dark:border-white/10 bg-white dark:bg-[#151c2f] text-gray-500 dark:text-gray-300 hover:text-violet-600 dark:hover:text-violet-300 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center transition"
+            title="Refresh saved resumes"
+          >
+            <RefreshCw size={16} className={isLoading ? "animate-spin" : ""} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 dark:border-red-500/30 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm font-medium text-red-600 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        {isLoading ? (
+          <div className="rounded-xl border border-gray-200 dark:border-white/10 bg-white dark:bg-[#151c2f] px-5 py-4 text-sm font-semibold text-gray-500 dark:text-gray-300 flex items-center gap-2">
+            <RefreshCw size={16} className="animate-spin" />
+            Loading saved resumes...
+          </div>
+        ) : savedResumes.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-gray-200 dark:border-white/10 bg-white/70 dark:bg-[#151c2f]/70 px-5 py-4 text-sm font-semibold text-gray-500 dark:text-gray-400">
+            No saved resumes yet. Start from a blank project or choose a template below.
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+            {savedResumes.map((resume) => {
+              const isEditing = editingId === resume._id;
+              const isBusy = busyId === resume._id;
+
+              return (
+                <div
+                  key={resume._id}
+                  className="group rounded-xl bg-white dark:bg-[#151c2f] border border-gray-200 dark:border-white/5 shadow-sm hover:shadow-md transition-all min-h-[190px] p-5 flex flex-col"
+                >
+                  <div className="flex items-start gap-3 flex-1">
+                    <div className="w-11 h-11 rounded-lg bg-violet-50 dark:bg-violet-900/20 text-violet-600 dark:text-violet-300 flex items-center justify-center shrink-0">
+                      <FileText size={22} />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      {isEditing ? (
+                        <input
+                          value={draftTitle}
+                          onChange={(e) => setDraftTitle(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === "Enter") handleRename(resume._id);
+                            if (e.key === "Escape") handleCancelRename();
+                          }}
+                          className="w-full rounded-lg border border-violet-200 dark:border-violet-500/30 bg-gray-50 dark:bg-black/20 px-3 py-2 text-sm font-bold text-gray-900 dark:text-white outline-none focus:ring-2 focus:ring-violet-500/30"
+                          autoFocus
+                        />
+                      ) : (
+                        <h3 className="text-base font-bold text-gray-900 dark:text-white truncate">
+                          {resume.title}
+                        </h3>
+                      )}
+                      <div className="mt-2 flex items-center gap-2 text-xs font-semibold text-gray-500 dark:text-gray-400">
+                        <CalendarClock size={14} />
+                        Updated {formatDate(resume.updatedAt)}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="mt-5 flex items-center justify-between gap-2">
+                    <button
+                      onClick={() => navigate(`/resume-builder/${resume._id}`)}
+                      disabled={isBusy || isEditing}
+                      className="flex-1 rounded-lg bg-violet-600 hover:bg-violet-700 disabled:bg-violet-400/60 disabled:cursor-not-allowed text-white text-sm font-bold px-3 py-2 transition"
+                    >
+                      Open
+                    </button>
+
+                    {isEditing ? (
+                      <>
+                        <button
+                          onClick={() => handleRename(resume._id)}
+                          disabled={isBusy}
+                          className="h-10 w-10 rounded-lg bg-emerald-50 dark:bg-emerald-900/20 text-emerald-600 dark:text-emerald-300 hover:bg-emerald-100 dark:hover:bg-emerald-900/40 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center transition"
+                          title="Save title"
+                        >
+                          {isBusy ? <RefreshCw size={16} className="animate-spin" /> : <Check size={16} />}
+                        </button>
+                        <button
+                          onClick={handleCancelRename}
+                          disabled={isBusy}
+                          className="h-10 w-10 rounded-lg bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-white/10 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center transition"
+                          title="Cancel rename"
+                        >
+                          <X size={16} />
+                        </button>
+                      </>
+                    ) : (
+                      <>
+                        <button
+                          onClick={() => handleStartRename(resume)}
+                          disabled={isBusy}
+                          className="h-10 w-10 rounded-lg bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-300 hover:text-violet-600 dark:hover:text-violet-300 hover:bg-violet-50 dark:hover:bg-violet-900/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center transition"
+                          title="Rename resume"
+                        >
+                          <Edit3 size={16} />
+                        </button>
+                        <button
+                          onClick={() => handleDelete(resume)}
+                          disabled={isBusy}
+                          className="h-10 w-10 rounded-lg bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-300 hover:text-red-600 dark:hover:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center transition"
+                          title="Delete resume"
+                        >
+                          {isBusy ? <RefreshCw size={16} className="animate-spin" /> : <Trash2 size={16} />}
+                        </button>
+                      </>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </section>
+
       {/* Grid of Templates */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5 max-w-6xl mx-auto">
+      <section className="max-w-6xl mx-auto">
+        <div className="mb-4">
+          <h2 className="text-xl font-extrabold text-gray-900 dark:text-white">Templates</h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 font-medium">
+            Pick a starting point for a new resume.
+          </p>
+        </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
         
         {/* Blank Project Card */}
         <button
@@ -97,6 +327,7 @@ const ResumeTemplates = () => {
           </button>
         ))}
       </div>
+      </section>
     </div>
   );
 };

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -38,5 +38,8 @@ export const API_PATHS = {
         ANALYZE: "/api/resume/analyze", // AI Resume Analyzer via Gemini
         SAVE: "/api/resume/save", // Save resume to backend
         GET_ALL: "/api/resume/my-resumes", // Get all user's saved resumes
+        GET_ONE: (id) => `/api/resume/${id}`, // Get one saved resume
+        UPDATE: (id) => `/api/resume/${id}`, // Update a saved resume
+        DELETE: (id) => `/api/resume/${id}`, // Delete a saved resume
     }
 };


### PR DESCRIPTION
## Summary

This PR implements a complete resume management workflow for saved resumes, allowing users to manage previously saved resumes directly from the dashboard instead of creating duplicate entries.

## Changes Made

### Backend

* Added `GET /api/resume/:id` to fetch a specific resume.
* Added `PUT /api/resume/:id` to update an existing resume.
* Added `DELETE /api/resume/:id` to remove a saved resume.
* Implemented ownership verification to ensure users can only access, update, or delete their own resumes.
* Added appropriate success and error responses for all resume management actions.

### Frontend

* Added **Edit/Open Resume** functionality to continue editing previously saved resumes.
* Added **Rename Resume** functionality for updating resume titles.
* Added **Delete Resume** action with confirmation modal.
* Added loading states during update and delete operations.
* Added success and error notifications for all resume management actions.
* Updated `API_PATHS.RESUME` with new resume management endpoints.

## Security

* Enforced authorization checks on all resume-specific operations.
* Prevented users from modifying or deleting resumes owned by other users.

## Acceptance Criteria Covered

* ✅ Users can rename saved resumes.
* ✅ Users can delete saved resumes after confirmation.
* ✅ Users can open and continue editing existing resumes.
* ✅ Users cannot modify resumes belonging to other users.
* ✅ API paths added under `API_PATHS.RESUME`.
* ✅ Success and error feedback displayed for all actions.

## Type

Feature

## Related Issue

Closes #129