### PR TITLE
feat: preserve last selected auth view

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -926,7 +926,6 @@ const LandingPage = () => {
         isOpen={openAuthModal}
         onClose={() => {
           setOpenAuthModal(false);
-          setCurrentPage("login");
           setPendingRoute(null);
         }}
         hideHeader


### PR DESCRIPTION
## Description

This PR preserves the user's last selected authentication view when reopening the authentication modal.

### Current Behavior

* Open the authentication modal.
* Switch from Login to Sign Up (or vice versa).
* Close the modal.
* Reopen the modal.
* The modal always resets to the Login view.

### Updated Behavior

* Open the authentication modal.
* Switch from Login to Sign Up (or vice versa).
* Close the modal.
* Reopen the modal.
* The previously selected authentication view remains active.

### Changes Made

* Removed the forced reset of the authentication view to Login when the modal is closed.
* Preserved the existing authentication view state between modal open/close actions during the session.

### Benefits

* Improves user experience.
* Reduces unnecessary navigation.
* Allows users to continue from the authentication view they were previously using.

### Testing

* Verified that Login remains active after reopening when Login was the last selected view.
* Verified that Sign Up remains active after reopening when Sign Up was the last selected view.
* Verified that switching between Login and Sign Up continues to work correctly.

### Issue

Fixes #119

### GSSoC 2026

This contribution is submitted as part of GSSoC 2026.
