### PR TITLE
feat(auth): improve accessibility of password visibility toggle (#126)

### DIFF
--- a/frontend/src/components/Inputs/Input.jsx
+++ b/frontend/src/components/Inputs/Input.jsx
@@ -23,16 +23,19 @@ const Input = ({ value, onChange, label, placeholder, type }) => {
           onChange={(e) => onChange(e)}
         />
         {type === "password" && (
-          <span
-            className="absolute right-3 cursor-pointer select-none text-gray-400 hover:text-gray-300 transition-colors"
-            onClick={toggleShowPassword}
-          >
-            {showPassword ? (
-              <FaRegEye size={18} />
-            ) : (
-              <FaRegEyeSlash size={18} />
-            )}
-          </span>
+          <button
+  type="button"
+  onClick={toggleShowPassword}
+  aria-label={showPassword ? "Hide password" : "Show password"}
+  aria-pressed={showPassword}
+  className="absolute right-3 text-gray-400 hover:text-gray-300 transition-colors focus:outline-none focus:ring-2 focus:ring-violet-500 rounded"
+>
+  {showPassword ? (
+    <FaRegEye size={18} />
+  ) : (
+    <FaRegEyeSlash size={18} />
+  )}
+</button>
         )}
       </div>
     </div>


### PR DESCRIPTION
Closes #126

## Description

Enhanced the existing password visibility toggle to improve accessibility and usability across authentication forms.

## Changes Made

* Replaced the clickable `span` element with a semantic `button`
* Added dynamic `aria-label` values:

  * "Show password"
  * "Hide password"
* Added `aria-pressed` to communicate toggle state
* Improved keyboard accessibility (Tab, Enter, Space support)
* Added visible focus styles for keyboard users

## Benefits

* Improves accessibility for screen reader users
* Enables keyboard navigation and interaction
* Reduces login and signup errors by allowing users to verify passwords
* Improves compliance with accessibility best practices

## Testing

* Verified password visibility toggles correctly
* Verified keyboard navigation support
* Verified screen readers announce the toggle action appropriately
* Confirmed login and signup forms continue to function as expected

## Type of Change

* [x] Enhancement
* [x] Accessibility Improvement
* [ ] Bug Fix
* [ ] Documentation Update
