### PR TITLE
security: add missing HTTP security headers middleware

### DIFF
--- a/backend/middlewares/securityHeaders.js
+++ b/backend/middlewares/securityHeaders.js
@@ -1,0 +1,23 @@
+const generalHeaders = (req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('X-XSS-Protection', '1; mode=block');
+    res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self'; object-src 'none'; frame-src 'none'"); // add this
+    next();
+};
+
+const sensitiveRouteHeaders = (req, res, next) => {
+    res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
+    res.setHeader('Pragma', 'no-cache');
+    res.setHeader('Surrogate-Control', 'no-store');
+    next();
+};
+
+module.exports = {
+    generalHeaders,
+    sensitiveRouteHeaders,
+};

--- a/backend/server.js
+++ b/backend/server.js
@@ -18,10 +18,12 @@ const aiRoutes = require("./routes/aiRoutes");
 const resumeRoutes = require("./routes/resumeRoutes");
 const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
+const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
 // Remove ES Module import for cors. Use CommonJS require below.
 const app = express();
 
 app.set("trust proxy", 1);
+app.use(generalHeaders); 
 // CORS settings: derive from env
 // FRONTEND_ORIGIN=primary production frontend
 // EXTRA_ORIGINS=comma separated additional origins (staging, preview, etc.)
@@ -85,7 +87,7 @@ connectDB()
 app.use(express.json());
 
 //Routes
-app.use("/api/auth", authRoutes);
+app.use("/api/auth", sensitiveRouteHeaders,authRoutes);
 app.use("/api/sessions", generalLimiter, sessionRoutes);
 app.use("/api/question", generalLimiter, questionRoutes);
 app.use("/api", aiRoutes);
@@ -101,12 +103,14 @@ const { required } = require("joi");
 app.use("/api/resume", generalLimiter, resumeRoutes);
 app.use(
   "/api/ai/generate-questions",
+  sensitiveRouteHeaders,
   aiLimiter,
   protect,
   generateInterviewQuestions,
 );
 app.use(
   "/api/ai/generate-explanation",
+  sensitiveRouteHeaders,
   aiLimiter,
   protect,
   generateConceptExplanation,


### PR DESCRIPTION
Added missing HTTP security headers middleware to fix security scan failures.

## Problem
Security test flagged 4 missing headers:
- Content-Security-Policy
- X-Frame-Options
- Referrer-Policy
- Permissions-Policy

## Solution
Created `backend/middlewares/securityHeaders.js` with two middlewares:
- `generalHeaders` — applies all security headers to every response
- `sensitiveRouteHeaders` — adds cache-control headers to AI/auth routes to prevent response caching

Registered both in `server.js` before all routes.

## Headers Added
| Header | Purpose |
|---|---|
| Content-Security-Policy | Prevents XSS attacks |
| X-Frame-Options | Prevents clickjacking |
| Referrer-Policy | Controls referrer information leakage |
| Permissions-Policy | Restricts browser feature access |
| X-Content-Type-Options | Prevents MIME sniffing |
| Strict-Transport-Security | Enforces HTTPS |
| X-XSS-Protection | Legacy XSS browser protection |
| Cache-Control (sensitive routes) | Prevents AI/auth responses from being cached |


## Related Issue
Closes #150 