### PR TITLE
feat: add custom 404 not found page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ import OSSBlog from "./pages/OpenSource/OSSBlog";
 import OpenSourceEvents from "./pages/OpenSource/OpenSourceEvents";
 import NotesBooks from "./pages/NotesBooks/NotesBooks";
 import Settings from "./pages/Settings/Settings";
-
+import NotFound from "./pages/NotFound";
 const ProtectedRoute = ({ children }) => {
   const { user, loading } = useContext(UserContext);
   if (loading) return null;
@@ -290,6 +290,14 @@ const App = () => {
                     }
                   />
                 </Route>
+                <Route
+                 path="*"
+                 element={
+                    <PageTransition>
+                      <NotFound />
+                      </PageTransition>
+                    }
+                 />
               </Routes>
             </AnimatePresence>
           </Router>

--- a/frontend/src/pages/NotFound.jsx
+++ b/frontend/src/pages/NotFound.jsx
@@ -1,0 +1,34 @@
+import { Link } from "react-router-dom";
+import { motion } from "framer-motion";
+
+const NotFound = () => {
+  return (
+    <div className="min-h-screen bg-[var(--color-background)] text-[var(--color-text-dark)] flex items-center justify-center px-6 transition-colors duration-300">
+      <motion.div
+        initial={{ opacity: 0, y: 15 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.3 }}
+        className="text-center"
+      >
+        <h1 className="text-7xl font-bold mb-4">404</h1>
+
+        <h2 className="text-2xl font-semibold mb-3">
+          Page Not Found
+        </h2>
+
+        <p className="text-gray-600 dark:text-gray-400 mb-8">
+          The page you are looking for doesn't exist or has been moved.
+        </p>
+
+        <Link
+          to="/"
+          className="inline-block px-6 py-3 rounded-lg bg-[var(--color-primary)] hover:opacity-90 text-white transition-all duration-300"
+        >
+          Go Back Home
+        </Link>
+      </motion.div>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Description

This PR adds a custom 404 Not Found page for invalid or non-existent routes.

### Changes Made

- Added a new `NotFound.jsx` page component
- Added a catch-all route using `path="*"`
- Added a "Go Back Home" button for navigation
- Added Framer Motion animations for a smoother user experience
- Applied existing theme variables to support both dark and light themes
- Kept styling consistent with PrepPilot's design system

### Acceptance Criteria

- [x] Invalid routes display a custom 404 page
- [x] Users can navigate back to the homepage
- [x] Page supports both dark and light themes
- [x] UI remains consistent with existing design language
- [x] Existing routes continue to work as expected

### Testing

- Tested invalid routes (e.g. `/random-page`)
- Verified navigation back to homepage
- Verified existing routes continue to function correctly

### Screenshots

<img width="1466" height="909" alt="Screenshot 2026-06-09 at 2 05 13 PM" src="https://github.com/user-attachments/assets/45294331-08a9-4b24-a7b3-987c231bd0d1" />


### Related Issue

Closes #176