### PR TITLE
feat: add unsaved changes warning for settings page

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -82,7 +82,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1677,7 +1676,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1697,7 +1695,8 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -1738,7 +1737,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1861,7 +1859,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2070,8 +2067,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2165,6 +2161,7 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -2334,7 +2331,6 @@
       "integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3572,6 +3568,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4840,7 +4837,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4940,7 +4936,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4953,7 +4948,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5735,7 +5729,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
       "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/frontend/src/hooks/useUnsavedChangesWarning.js
+++ b/frontend/src/hooks/useUnsavedChangesWarning.js
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+
+export default function useUnsavedChangesWarning(hasUnsavedChanges) {
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      if (!hasUnsavedChanges) return;
+
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+    };
+  }, [hasUnsavedChanges]);
+}

--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useContext, useRef } from "react";
+import useUnsavedChangesWarning from "../../hooks/useUnsavedChangesWarning";
 import { useNavigate } from "react-router-dom";
 import { UserContext } from "../../context/userContext";
 import { useTheme } from "../../context/themeContext";
@@ -62,6 +63,7 @@ const Settings = () => {
   const [degree, setDegree] = useState("");
   const [branch, setBranch] = useState("");
   const [graduationYear, setGraduationYear] = useState("");
+  const [initialFormData, setInitialFormData] = useState(null);
   // Form Fields State - Profile Details
   const [profileDetailsActiveTab, setProfileDetailsActiveTab] =
     useState("about-me");
@@ -109,6 +111,18 @@ const Settings = () => {
       setDegree(user.educationDetails?.degree || "");
       setBranch(user.educationDetails?.branch || "");
       setGraduationYear(user.educationDetails?.graduationYear || "");
+
+      setInitialFormData({
+  firstName: user.firstName || "",
+  lastName: user.lastName || "",
+  bio: user.bio || "",
+  country: user.country || "",
+  school: user.educationDetails?.school || "",
+  degree: user.educationDetails?.degree || "",
+  branch: user.educationDetails?.branch || "",
+  graduationYear: user.educationDetails?.graduationYear || "",
+});
+
       setAboutMeText(user.profileDetails?.aboutMe || "");
       setEducationText(user.profileDetails?.education || "");
       setAchievementsText(user.profileDetails?.achievements || "");
@@ -124,6 +138,24 @@ const Settings = () => {
       );
     }
   }, [user]);
+
+  const currentFormData = {
+  firstName,
+  lastName,
+  bio,
+  country,
+  school,
+  degree,
+  branch,
+  graduationYear,
+};
+
+const hasUnsavedChanges =
+  initialFormData &&
+  JSON.stringify(currentFormData) !== JSON.stringify(initialFormData);
+
+  useUnsavedChangesWarning(hasUnsavedChanges);
+
   // Handle Profile Picture Upload
   const handlePhotoClick = () => {
     fileInputRef.current.click();
@@ -173,11 +205,24 @@ const Settings = () => {
         },
       };
       const response = await axiosInstance.put(
-        API_PATHS.AUTH.UPDATE_PROFILE,
-        payload,
-      );
-      updateUser(response.data);
-      toast.success("Basic info updated successfully!", { id: saveToast });
+  API_PATHS.AUTH.UPDATE_PROFILE,
+  payload,
+);
+
+updateUser(response.data);
+
+setInitialFormData({
+  firstName,
+  lastName,
+  bio,
+  country,
+  school,
+  degree,
+  branch,
+  graduationYear,
+});
+
+toast.success("Basic info updated successfully!", { id: saveToast });
     } catch (err) {
       toast.error(err.response?.data?.message || "Failed to update profile", {
         id: saveToast,


### PR DESCRIPTION
## Summary

Implemented unsaved changes protection for the Settings page.

### Changes Made

* Added unsaved changes detection for the Basic Info section in Settings.
* Added browser refresh warning when unsaved changes exist.
* Added browser/tab close warning when unsaved changes exist.
* Added logic to clear the warning after a successful save.
* Created a reusable `useUnsavedChangesWarning` hook.

### Scope

Implementation is limited to the Settings page as discussed in the issue.

### Testing

* Warning appears when form data is modified and the page is refreshed.
* Warning appears when form data is modified and the browser tab is closed.
* No warning appears when no changes have been made.
* Warning is cleared after a successful save.

### Note

I also asked for clarification regarding in-app route navigation warnings. I can extend the implementation further if route-transition blocking is expected for this PR.
