### PR TITLE
fix: unify password validation to single OWASP policy, fix narrow special-char rejection 

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -3,6 +3,7 @@ const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const crypto = require("crypto");
 const { sendVerificationEmail } = require("../utils/sendEmail");
+const { validatePassword } = require('../utils/passwordPolicy');
 
 /**
  * Generate a JWT token for the authenticated user.
@@ -20,40 +21,10 @@ const generateToken = (userId) => {
 const registerUser = async (req, res) => {
     try {
         const { name, email, password, profileImageUrl } = req.body;
-
-        if (!password || password.length < 8) {
-            return res.status(400).json({
-                success: false,
-                message: "Password must be at least 8 characters long."
-            });
-        }
-
-        if (!/[A-Z]/.test(password)) {
-            return res.status(400).json({
-                success: false,
-                message: "Password must contain at least one uppercase letter."
-            });
-        }
-
-        if (!/[a-z]/.test(password)) {
-            return res.status(400).json({
-                success: false,
-                message: "Password must contain at least one lowercase letter."
-            });
-        }
-
-        if (!/[0-9]/.test(password)) {
-            return res.status(400).json({
-                success: false,
-                message: "Password must contain at least one number."
-            });
-        }
-
-        if (!/[@$!%*?&]/.test(password)) {
-            return res.status(400).json({
-                success: false,
-                message: "Password must contain at least one special character (@$!%*?&)."
-            });
+        
+        const { valid, errors } = validatePassword(password);
+        if (!valid) {
+            return res.status(400).json({ success: false, message: errors[0] });
         }
 
         const userExists = await User.findOne({ email });

--- a/backend/tests/passwordPolicy.unit.test.js
+++ b/backend/tests/passwordPolicy.unit.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { validatePassword } from '../utils/passwordPolicy.js';
+
+// ---------------------------------------------------------------------------
+// Helper: build a password with exactly one special char
+// ---------------------------------------------------------------------------
+function withSpecial(char) {
+    return `ValidPass1${char}`;
+}
+
+// ---------------------------------------------------------------------------
+// Core rule enforcement
+// ---------------------------------------------------------------------------
+
+describe('validatePassword — core rules', () => {
+    it('accepts a fully compliant password', () => {
+        const { valid } = validatePassword('ValidPass1!');
+        expect(valid).toBe(true);
+    });
+
+    it('rejects a password shorter than 8 characters', () => {
+        const { valid, errors } = validatePassword('V1!a');
+        expect(valid).toBe(false);
+        expect(errors[0]).toMatch(/8 characters/);
+    });
+
+    it('rejects a password with no uppercase letter', () => {
+        const { valid, errors } = validatePassword('validpass1!');
+        expect(valid).toBe(false);
+        expect(errors[0]).toMatch(/uppercase/);
+    });
+
+    it('rejects a password with no lowercase letter', () => {
+        const { valid, errors } = validatePassword('VALIDPASS1!');
+        expect(valid).toBe(false);
+        expect(errors[0]).toMatch(/lowercase/);
+    });
+
+    it('rejects a password with no digit', () => {
+        const { valid, errors } = validatePassword('ValidPass!');
+        expect(valid).toBe(false);
+        expect(errors[0]).toMatch(/number/);
+    });
+
+    it('rejects a password with no special character', () => {
+        const { valid, errors } = validatePassword('ValidPass1');
+        expect(valid).toBe(false);
+        expect(errors[0]).toMatch(/special character/);
+    });
+
+    it('rejects null / undefined gracefully', () => {
+        expect(validatePassword(null).valid).toBe(false);
+        expect(validatePassword(undefined).valid).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Special-character allowlist — previously rejected characters must now pass
+// ---------------------------------------------------------------------------
+
+const previouslyRejectedChars = ['#', '^', '(', ')', '{', '}', '[', ']', '<', '>', ',', '.', '"', '|', '`', '~', '_', '+', '-', '=', "'", ':', ';', '\\', '/'];
+
+describe('validatePassword — previously rejected special characters now accepted', () => {
+    for (const char of previouslyRejectedChars) {
+        it(`accepts "${char}" as a valid special character`, () => {
+            const { valid } = validatePassword(withSpecial(char));
+            expect(valid).toBe(true);
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Special-character allowlist — characters from the old narrow set still pass
+// ---------------------------------------------------------------------------
+
+const originalAllowedChars = ['@', '$', '!', '%', '*', '?', '&'];
+
+describe('validatePassword — original special characters still accepted (no regression)', () => {
+    for (const char of originalAllowedChars) {
+        it(`still accepts "${char}" as a valid special character`, () => {
+            const { valid } = validatePassword(withSpecial(char));
+            expect(valid).toBe(true);
+        });
+    }
+});
+
+// ---------------------------------------------------------------------------
+// Response shape: errors array is always present
+// ---------------------------------------------------------------------------
+
+describe('validatePassword — return shape', () => {
+    it('always returns { valid, errors } shape', () => {
+        const result = validatePassword('weak');
+        expect(result).toHaveProperty('valid');
+        expect(result).toHaveProperty('errors');
+        expect(Array.isArray(result.errors)).toBe(true);
+    });
+
+    it('errors array is empty when password is valid', () => {
+        const { errors } = validatePassword('ValidPass1!');
+        expect(errors).toHaveLength(0);
+    });
+
+    it('errors array contains one entry per failing rule', () => {
+        // Fails: lowercase, digit, special — but passes length and uppercase (length >=8, has upper)
+        const { errors } = validatePassword('VALIDPAS');
+        expect(errors.length).toBeGreaterThan(0);
+    });
+});

--- a/backend/utils/passwordPolicy.js
+++ b/backend/utils/passwordPolicy.js
@@ -1,0 +1,42 @@
+/**
+ * OWASP-recommended special-character set.
+ * Covers all printable non-alphanumeric ASCII characters that are
+ * unambiguous in most encoding contexts.
+ */
+const SPECIAL_CHAR_REGEX = /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~]/;
+
+const PASSWORD_RULES = [
+    {
+        test: (pw) => typeof pw === 'string' && pw.length >= 8,
+        message: 'Password must be at least 8 characters long.',
+    },
+    {
+        test: (pw) => /[A-Z]/.test(pw),
+        message: 'Password must contain at least one uppercase letter.',
+    },
+    {
+        test: (pw) => /[a-z]/.test(pw),
+        message: 'Password must contain at least one lowercase letter.',
+    },
+    {
+        test: (pw) => /[0-9]/.test(pw),
+        message: 'Password must contain at least one number.',
+    },
+    {
+        test: (pw) => SPECIAL_CHAR_REGEX.test(pw),
+        message:
+            'Password must contain at least one special character (e.g. !@#$%^&*()_+-=[]{};\':"|,.<>/?`~).',
+    },
+];
+
+/**
+ * Validate a password against all rules.
+ * @param {string} password
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+function validatePassword(password) {
+    const errors = PASSWORD_RULES.filter((r) => !r.test(password)).map((r) => r.message);
+    return { valid: errors.length === 0, errors };
+}
+
+module.exports = { validatePassword, SPECIAL_CHAR_REGEX, PASSWORD_RULES };

--- a/frontend/src/pages/Auth/SignUp.jsx
+++ b/frontend/src/pages/Auth/SignUp.jsx
@@ -31,7 +31,7 @@ const SignUp = ({ setCurrentPage }) => {
     uppercase: /[A-Z]/.test(password),
     lowercase: /[a-z]/.test(password),
     number: /[0-9]/.test(password),
-    special: /[@$!%*?&]/.test(password),
+    special: /[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~]/.test(password),
   };
 
   const strengthScore = Object.values(passwordChecks).filter(Boolean).length;
@@ -48,7 +48,7 @@ const SignUp = ({ setCurrentPage }) => {
     if (!/[A-Z]/.test(password)) { setError("Password must contain at least one uppercase letter."); return; }
     if (!/[a-z]/.test(password)) { setError("Password must contain at least one lowercase letter."); return; }
     if (!/[0-9]/.test(password)) { setError("Password must contain at least one number."); return; }
-    if (!/[@$!%*?&]/.test(password)) { setError("Password must contain at least one special character (@$!%*?&)."); return; }
+    if (!/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~]/.test(password)) { setError("Password must contain at least one special character (e.g. !@#$%^&*)."); return; }
 
     setError("");
     setLoading(true);


### PR DESCRIPTION
## Summary

Fixes #132.

`registerUser` enforced a narrow special-character allowlist (`[@$!%*?&]`) that silently rejected valid strong passwords containing characters like `#`, `^`, `(`, `)`, `{`, `}`, `,`, `.`, `"`, and others. The same narrow regex lived independently in the frontend, making both wrong together — but any future change to one would silently diverge from the other.

---

## Root cause

Password rules were duplicated inline in `authController.js` and `SignUp.jsx` with no shared source of truth. The backend used a narrow special-character set from an early implementation; the issue described a "second block" with a broader set that was either removed before this commit or never fully landed — either way the narrow set remained the sole enforcer.

---

## Changes

### `backend/utils/passwordPolicy.js` *(new)*
Canonical definition of all password rules. Exports `validatePassword(pw)` returning `{ valid: boolean, errors: string[] }`. All rule text and regex live here and nowhere else. Special-character regex updated to the OWASP-recommended full printable ASCII set.

### `backend/controllers/authController.js`
- Imports `validatePassword` from the new utility.
- Replaces the five sequential early-return validation blocks in `registerUser` with a single `validatePassword()` call — identical observable behaviour but with one authoritative code path.
- All `400` responses from `registerUser` already included `success: false`; the refactor preserves that shape consistently.

### `frontend/src/pages/Auth/SignUp.jsx`
- Updates the real-time `passwordChecks.special` regex to match the broadened backend set, so the strength indicator no longer marks `#` or `^` as a failed requirement.
- Updates the pre-submit guard regex and error message to match, so the frontend and backend are in sync.

### `backend/tests/passwordPolicy.unit.test.js` *(new)*
- Parameterised tests for all 25 previously-rejected characters — each must now pass.
- Parameterised regression tests for the original 7 characters — must still pass.
- Rule enforcement tests (length, upper, lower, digit, special, null). 
- Return-shape tests (`{ valid, errors }` contract).

---

## Testing

```bash
cd backend
npx vitest run tests/passwordPolicy.unit.test.js
```

No live DB or environment variables required.

---

## What is not changed

`changePassword` in `authController.js` does not validate the new password against the policy — that is a separate concern and out of scope for this issue. A follow-up issue can add `validatePassword` there too using the same utility.