### PR TITLE
Fix/sanitize middleware and prompt injection

### DIFF
--- a/backend/middlewares/sanitizeAiPrompt.js
+++ b/backend/middlewares/sanitizeAiPrompt.js
@@ -1,21 +1,18 @@
+const sanitizeField = (value) => {
+  if (typeof value !== "string") return value;
+  return value
+    .replace(/<[^>]*>?/gm, "")
+    .replace(/[^\x20-\x7E\n]/g, "")
+    .trim();
+};
 
 const sanitizeAiPrompt = (req, res, next) => {
-  if (req.body && typeof req.body.prompt === "string") {
-    req.body.prompt = req.body.prompt
-      .replace(/<[^>]*>?/gm, "")        // remove HTML tags
-      .replace(/[^\x20-\x7E\n]/g, "")   // remove hidden control chars
-      .trim();
-      req.body.role = req.body.role
-      .replace(/<[^>]*>?/gm, "")        // remove HTML tags
-      .replace(/[^\x20-\x7E\n]/g, "")   // remove hidden control chars
-      .trim();
-      req.body.topic = req.body.topic
-      .replace(/<[^>]*>?/gm, "")        // remove HTML tags
-      .replace(/[^\x20-\x7E\n]/g, "")   // remove hidden control chars
-      .trim();
+  if (req.body) {
+    req.body.prompt = sanitizeField(req.body.prompt);
+    req.body.role = sanitizeField(req.body.role);
+    req.body.topic = sanitizeField(req.body.topic);
   }
-
   next();
 };
 
-module.exports = {sanitizeAiPrompt};
+module.exports = sanitizeAiPrompt;

--- a/backend/validation/aiPromptSchema.js
+++ b/backend/validation/aiPromptSchema.js
@@ -1,6 +1,5 @@
 const Joi = require("joi");
 
-// Patterns used in prompt injection / jailbreak attempts
 const blockedPatterns = [
   /ignore previous instructions/i,
   /system prompt/i,
@@ -10,7 +9,19 @@ const blockedPatterns = [
   /pretend to be/i,
   /you are now/i,
   /<script.*?>.*?<\/script>/i,
+  /\bdan\b/i,
+  /developer mode/i,
+  /disregard all/i,
+  /ignore all instructions/i,
+  /forget previous/i,
+  /override instructions/i,
+  /you have no restrictions/i,
+  /act as if/i,
+  /simulate being/i,
+  /do anything now/i,
 ];
+
+
 
 // custom validator
 const safePrompt = (value, helpers) => {

--- a/backend/validation/aiPromptSchema.js
+++ b/backend/validation/aiPromptSchema.js
@@ -1,5 +1,6 @@
 const Joi = require("joi");
 
+// Patterns used in prompt injection / jailbreak attempts
 const blockedPatterns = [
   /ignore previous instructions/i,
   /system prompt/i,
@@ -9,19 +10,7 @@ const blockedPatterns = [
   /pretend to be/i,
   /you are now/i,
   /<script.*?>.*?<\/script>/i,
-  /\bdan\b/i,
-  /developer mode/i,
-  /disregard all/i,
-  /ignore all instructions/i,
-  /forget previous/i,
-  /override instructions/i,
-  /you have no restrictions/i,
-  /act as if/i,
-  /simulate being/i,
-  /do anything now/i,
 ];
-
-
 
 // custom validator
 const safePrompt = (value, helpers) => {


### PR DESCRIPTION
Closes #204

## Summary
The sanitizeAiPrompt middleware was calling `.replace()` on `req.body.role` and `req.body.topic` without checking if they exist. This caused a `TypeError` crash when either field was missing from the request body.

## Before vs After

**Before — crashes if role or topic is missing:**
```js
req.body.role = req.body.role.replace(/<[^>]*>?/gm, "").trim();
```

**After — null-safe helper function:**
```js
const sanitizeField = (value) => {
  if (typeof value !== "string") return value;
  return value.replace(/<[^>]*>?/gm, "").replace(/[^\x20-\x7E\n]/g, "").trim();
};
```

screenshot

<img width="1600" height="899" alt="image" src="https://github.com/user-attachments/assets/4e88ca94-1ebf-47ca-a932-6d8312b5c5de" />


## Type of Change
- [x] Bug fix

## How Has This Been Tested
- Sent POST request with only prompt in body — no crash 
- Valid requests still pass through correctly 

## Checklist
- [x] Code follows project guidelines
- [x] Changes tested locally
- [x] Related issue linked
- [x] No new warnings or errors introduced
- [x] I understand every line submitted