### PR TITLE
fix: expand blocked prompt injection patterns in aiPromptSchema

### DIFF
--- a/backend/validation/aiPromptSchema.js
+++ b/backend/validation/aiPromptSchema.js
@@ -1,6 +1,5 @@
 const Joi = require("joi");
 
-// Patterns used in prompt injection / jailbreak attempts
 const blockedPatterns = [
   /ignore previous instructions/i,
   /system prompt/i,
@@ -10,7 +9,18 @@ const blockedPatterns = [
   /pretend to be/i,
   /you are now/i,
   /<script.*?>.*?<\/script>/i,
+  /\bdan\b/i,
+  /developer mode/i,
+  /disregard all/i,
+  /ignore all instructions/i,
+  /forget previous/i,
+  /override instructions/i,
+  /you have no restrictions/i,
+  /act as if/i,
+  /simulate being/i,
+  /do anything now/i,
 ];
+
 
 // custom validator
 const safePrompt = (value, helpers) => {


### PR DESCRIPTION
Closes #205

## Summary
The `blockedPatterns` array in `backend/validation/aiPromptSchema.js` only covered 8 basic prompt injection patterns. Many widely-known jailbreak techniques like DAN, developer mode, and disregard all instructions were passing validation undetected and reaching the Gemini AI API.

## Before vs After

**Before — only 8 patterns:**
```js
const blockedPatterns = [
  /ignore previous instructions/i,
  /system prompt/i,
  /act as root/i,
  /jailbreak/i,
  /bypass restrictions/i,
  /pretend to be/i,
  /you are now/i,
  /<script.*?>.*?<\/script>/i,
];
```

**After — 18 patterns covering all major jailbreak techniques:**
Added 10 missing critical patterns:
- `/\bdan\b/i` — blocks DAN jailbreak
- `/developer mode/i` — blocks developer mode exploit
- `/disregard all/i` — blocks disregard instructions
- `/ignore all instructions/i`
- `/forget previous/i`
- `/override instructions/i`
- `/you have no restrictions/i`
- `/act as if/i`
- `/simulate being/i`
- `/do anything now/i`

## Screenshots

 before

<img width="1600" height="899" alt="image" src="https://github.com/user-attachments/assets/d01ff0b0-f9dc-4c4e-ad11-150d62791734" />

after

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/7ce99af0-f551-4628-b477-3a95ff237d10" />


## Type of Change
- [x] Bug fix

## How Has This Been Tested
- Tested all 10 new patterns — all correctly blocked 
- Existing 8 patterns still working correctly 
- Valid requests pass through normally 

## Checklist
- [x] Code follows project guidelines
- [x] Changes tested locally
- [x] Related issue linked
- [x] No new warnings or errors introduced
- [x] I understand every line submitted