### PR TITLE
fix: clear invalid JWT tokens on 401 unauthorized responses

### DIFF
--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -35,6 +35,9 @@ axiosInstance.interceptors.response.use(
         // handle common error globally
         if(error.response){
             if(error.response.status === 401){
+                // Clear the invalid token from storage
+                localStorage.removeItem("token");
+                sessionStorage.removeItem("token");
                 //redirect to login page
                 window.location.href="/";
             }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #220

### Summary

This PR fixes the authentication flow when a `401 Unauthorized` response is received.

Previously, expired or invalid JWT tokens remained stored in `localStorage` and `sessionStorage` even after the user was redirected to the login page. This could result in repeated authentication failures, redirect loops, and inconsistent application state.

The Axios response interceptor has been updated to clear invalid tokens before redirecting users, ensuring a clean re-authentication flow.

---

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature
* [ ] ♻️ Refactoring
* [ ] 📝 Documentation update
* [ ] 🎨 UI/UX improvement
* [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?

* Verified that a `401 Unauthorized` response removes the stored token from `localStorage` and `sessionStorage`.
* Confirmed that users are redirected to the login page after token removal.
* Validated that subsequent requests no longer use stale authentication tokens.
* Ran the application locally and manually tested the authentication flow with an expired token.

> Note: `npm run lint` could not be executed successfully because ESLint is not currently available in the local environment.

---

### Screenshots (if applicable)

N/A – This change affects authentication logic and does not introduce UI modifications.

---

### Checklist

* [x] My code follows the project's guidelines
* [x] I have tested my changes
* [ ] I have updated documentation where necessary
* [x] I have linked the related issue
* [x] My changes do not introduce new warnings or errors
