### PR TITLE
fix: return 403 and suppress CORS headers for disallowed-origin preflights

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -60,14 +60,16 @@ app.use((req, res, next) => {
       global.__rejectedCors.add(origin);
       console.warn("[CORS] Rejected origin:", origin);
     }
+    if (req.method === "OPTIONS") {
+      return res.sendStatus(403);
+    }
   }
-  res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
-  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
   if (req.method === "OPTIONS") {
+    res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+    res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
     return res.sendStatus(200);
   }
   next();
-});
 
 connectDB()
   .then((success) => {

--- a/backend/tests/cors.preflight.unit.test.js
+++ b/backend/tests/cors.preflight.unit.test.js
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// Integration-style unit tests for the CORS middleware in server.js
+//
+// We extract just the CORS middleware logic under test by replicating the same
+// block in an isolated Express app — this lets us test the middleware behaviour
+// without starting a real server or connecting to MongoDB.
+// ---------------------------------------------------------------------------
+
+function buildApp(allowedOrigins = new Set(["https://allowed.example.com"])) {
+  const app = express();
+
+  app.use((req, res, next) => {
+    const origin = req.headers.origin;
+    const renderPattern =
+      /^https:\/\/(?:interview-prep(?:aration)?-ai|preppilot-backend)-[a-z0-9-]+\.onrender\.com$/;
+    const localhostPattern =
+      /^http:\/\/(localhost|127\.0\.0\.1):(5\d{3}|3\d{3})$/;
+
+    if (
+      origin &&
+      (allowedOrigins.has(origin) ||
+        renderPattern.test(origin) ||
+        localhostPattern.test(origin))
+    ) {
+      res.header("Access-Control-Allow-Origin", origin);
+      res.header("Vary", "Origin");
+      res.header("Access-Control-Allow-Credentials", "true");
+    } else if (origin) {
+      if (req.method === "OPTIONS") {
+        return res.sendStatus(403);
+      }
+    }
+
+    if (req.method === "OPTIONS") {
+      res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
+      res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+      return res.sendStatus(200);
+    }
+    next();
+  });
+
+  // Sentinel route to confirm non-OPTIONS requests reach handlers
+  app.get("/api/test", (_req, res) => res.json({ ok: true }));
+  app.post("/api/test", (_req, res) => res.json({ ok: true }));
+
+  return app;
+}
+
+let app;
+beforeAll(() => { app = buildApp(); });
+
+// ---------------------------------------------------------------------------
+// Approved origin — OPTIONS preflight
+// ---------------------------------------------------------------------------
+describe("CORS preflight — approved origin", () => {
+  it("returns 200 for an OPTIONS from an approved origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://allowed.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("sets Access-Control-Allow-Origin for an approved origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://allowed.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-origin"]).toBe("https://allowed.example.com");
+  });
+
+  it("sets Access-Control-Allow-Methods for an approved origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://allowed.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-methods"]).toBeTruthy();
+  });
+
+  it("sets Access-Control-Allow-Headers for an approved origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://allowed.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-headers"]).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approved origin — Render dynamic subdomain pattern
+// ---------------------------------------------------------------------------
+describe("CORS preflight — approved Render subdomain", () => {
+  it("returns 200 for a Render preview subdomain", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://preppilot-backend-abc123.onrender.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe(
+      "https://preppilot-backend-abc123.onrender.com"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Approved origin — localhost dev pattern
+// ---------------------------------------------------------------------------
+describe("CORS preflight — localhost dev origins", () => {
+  it("returns 200 for localhost:5173", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "http://localhost:5173")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:5173");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Disallowed origin — OPTIONS preflight (the bug fix regression guard)
+// ---------------------------------------------------------------------------
+describe("CORS preflight — disallowed origin", () => {
+  it("returns 403 for an OPTIONS from a disallowed origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://attacker.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.status).toBe(403);
+  });
+
+  it("does NOT set Access-Control-Allow-Origin for a disallowed origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://attacker.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("does NOT set Access-Control-Allow-Methods for a disallowed origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://attacker.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-methods"]).toBeUndefined();
+  });
+
+  it("does NOT set Access-Control-Allow-Headers for a disallowed origin", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://attacker.example.com")
+      .set("Access-Control-Request-Method", "POST");
+
+    expect(res.headers["access-control-allow-headers"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-OPTIONS requests from disallowed origins reach route handlers
+// (CORS is browser-enforcement-only; server must not block simple requests)
+// ---------------------------------------------------------------------------
+describe("Non-OPTIONS from disallowed origin — reaches handler", () => {
+  it("GET from a disallowed origin still returns 200 from the route", async () => {
+    const res = await request(app)
+      .get("/api/test")
+      .set("Origin", "https://attacker.example.com");
+
+    // Route handler is reached; browser would block the response, not the server
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("POST from a disallowed origin still reaches the route handler", async () => {
+    const res = await request(app)
+      .post("/api/test")
+      .set("Origin", "https://attacker.example.com");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// No Origin header (same-origin / server-to-server) — passes through
+// ---------------------------------------------------------------------------
+describe("Requests with no Origin header", () => {
+  it("OPTIONS with no Origin returns 200 (same-origin preflight)", async () => {
+    const res = await request(app).options("/api/test");
+    expect(res.status).toBe(200);
+  });
+
+  it("GET with no Origin reaches the handler", async () => {
+    const res = await request(app).get("/api/test");
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #215

The custom CORS middleware unconditionally emitted `Access-Control-Allow-Methods` and `Access-Control-Allow-Headers` for every request, including OPTIONS preflights from rejected origins. This produced a `200` response advertising the full API method/header surface to any client — even ones whose `Origin` was explicitly not approved. Browsers enforce the missing `Access-Control-Allow-Origin` header, but non-browser clients (curl, scanners, server-to-server calls) are not bound by preflight enforcement and could use that `200` + method list to map the API surface or craft direct cross-origin requests.

## Root Cause

```js
// Before — emitted unconditionally, outside the approved-origin branch:
res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
if (req.method === "OPTIONS") {
  return res.sendStatus(200);   // ← disallowed origin got 200 + headers
}
```

## Fix

```js
// After — disallowed origin exits with 403 and no advertising headers:
} else if (origin) {
  if (req.method === "OPTIONS") {
    return res.sendStatus(403);   // ← 403, no Allow-Methods/Allow-Headers
  }
}

// Allow-Methods/Allow-Headers only set when origin was approved (above):
if (req.method === "OPTIONS") {
  res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
  res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
  return res.sendStatus(200);
}
```

Non-OPTIONS requests from disallowed origins still call `next()` — CORS remains browser-enforcement-only for simple requests and no existing API behaviour changes.

## Tests Added

`backend/tests/cors.preflight.unit.test.js` — isolated Express app replicating the middleware under test (no DB, no real server):

| Scenario | Expected |
|---|---|
| OPTIONS, approved origin | `200`, all three CORS headers present |
| OPTIONS, Render preview subdomain | `200`, `Allow-Origin` set |
| OPTIONS, localhost:5173 | `200`, `Allow-Origin` set |
| OPTIONS, disallowed origin | `403`, **no** `Allow-Origin/Methods/Headers` |
| GET from disallowed origin | `200` from route handler, no `Allow-Origin` |
| POST from disallowed origin | `200` from route handler, no `Allow-Origin` |
| OPTIONS, no Origin header | `200` (same-origin / server-to-server) |
| GET, no Origin header | `200` from route handler |

## Files Changed

- `backend/server.js` — CORS middleware restructured (~8 lines changed)
- `backend/tests/cors.preflight.unit.test.js` — new test file