### PR TITLE
fix: sanitize uploaded filenames to prevent path traversal

### DIFF
--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -1,7 +1,20 @@
 const multer = require("multer");
 const fs = require("fs");
+const path = require("path");
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+const sanitizeFilename = (filename) => {
+  const ext = path.extname(filename);
+  const basename = path.basename(filename, ext);
+
+  const sanitizedBase = basename
+    .replace(/[^a-zA-Z0-9_-]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+  return `${sanitizedBase || "file"}${ext.toLowerCase()}`;
+};
 
 // Create uploads directory if it doesn't exist
 if (!fs.existsSync("uploads")) {
@@ -14,7 +27,8 @@ const diskStorage = multer.diskStorage({
     cb(null, "uploads/");
   },
   filename: (req, file, cb) => {
-    cb(null, `${Date.now()}-${file.originalname}`);
+    const safeFilename = sanitizeFilename(file.originalname);
+    cb(null, `${Date.now()}-${safeFilename}`);
   },
 });
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #208

### Summary

This PR enhances upload security by sanitizing uploaded filenames before storing them on disk.

Changes made:

* Added `path` module for safe filename handling.
* Introduced a reusable `sanitizeFilename()` helper function.
* Removed unsafe and special characters from uploaded filenames.
* Prevented path traversal attempts through crafted filenames.
* Preserved file extensions while normalizing them to lowercase.
* Added a fallback filename when the sanitized name becomes empty.

---

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature
* [ ] ♻️ Refactoring
* [ ] 📝 Documentation update
* [ ] 🎨 UI/UX improvement
* [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?

* Verified that normal filenames (e.g., `resume.pdf`) are stored correctly.
* Verified that filenames containing special characters are sanitized safely.
* Verified that path traversal filenames such as `../../../evil.js` are sanitized before storage.
* Confirmed that file extensions are preserved and converted to lowercase.

---

### Screenshots (if applicable)

N/A – Backend security enhancement with no UI changes.

---

### Checklist

* [x] My code follows the project's guidelines
* [x] I have tested my changes
* [ ] I have updated documentation where necessary
* [x] I have linked the related issue
* [x] My changes do not introduce new warnings or errors
