### PR TITLE
ci: add CodeQL GitHub Actions workflow for automated JavaScript security analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+name: 'CodeQL Advanced'
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  schedule:
+    # Runs at 15:34, only on Sunday
+    - cron: '34 15 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above to set the build mode to "manual" for that language. Then modify this step to build your code.
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Related issue 
closes #210 

## Summary

This pull request introduces a dedicated GitHub Actions workflow to enable automated CodeQL security analysis for the JavaScript codebase.

The workflow establishes a baseline for continuous static application security testing (SAST) using GitHub's recommended CodeQL configuration while keeping the existing development workflow unchanged.

## Changes

* Added `.github/workflows/codeql.yml`
* Configured CodeQL initialization and analysis for JavaScript
* Enabled automatic scans for:
  * Pushes to the default branch
  * Pull requests targeting the default branch
  * Weekly scheduled execution
* Configured SARIF upload so scan results are published to GitHub Code Scanning
* Followed GitHub's recommended CodeQL workflow structure

## Why

As the project evolves, automated security analysis helps identify potential issues before they reach production. Integrating CodeQL into CI provides continuous scanning for common JavaScript security risks, including insecure data flows, unsafe API usage, injection-related patterns, and other code quality concerns without affecting contributor workflows.

## Validation

* Workflow syntax has been verified.
* Workflow is configured to execute on supported GitHub Actions events.
* JavaScript CodeQL analysis is successfully initialized and executed.
* SARIF results are uploaded to GitHub Code Scanning when the workflow completes.

## Impact

This change is limited to CI configuration and does not modify application logic, dependencies, or runtime behavior.

### Manual Verification

* [x] Verified workflow YAML syntax and configuration
* [x] Confirmed CodeQL matrix configuration for JavaScript, Typescript
* [x] Verified workflow triggers for push, pull_request, and scheduled execution
* [x] Confirmed SARIF upload step is configured for GitHub Code Scanning


## Checklist
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or console errors.
