### PR TITLE
fix: replace undefined hashToken() calls with bcrypt.hash()

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -82,7 +82,7 @@ const registerUser = async (req, res) => {
         const accessToken = generateAccessToken(user._id);
         const refreshToken = generateRefreshToken(user._id);
 
-        user.refreshTokenHash = hashToken(refreshToken);
+        user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
 
@@ -133,7 +133,7 @@ const loginUser = async (req, res) => {
         const accessToken = generateAccessToken(user._id);
         const refreshToken = generateRefreshToken(user._id);
 
-        user.refreshTokenHash = hashToken(refreshToken);
+        user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
 


### PR DESCRIPTION
## Summary
- `registerUser` (line 85) and `loginUser` (line 136) in `backend/controllers/authController.js` both call `hashToken(refreshToken)` — a function that is never defined, declared, or imported anywhere in the repo
- Every call to `POST /api/auth/register` and `POST /api/auth/login` throws a `ReferenceError` and returns 500; registration even leaves an orphaned, unusable user document in MongoDB since `User.create()` succeeds before the crash
- Replaces both call sites with `await bcrypt.hash(token, REFRESH_TOKEN_SALT_ROUNDS)`, the exact pattern already used by the working refresh-token rotation handler (line 197), so the resulting hash is correctly verifiable by the existing `bcrypt.compare` check in `/api/auth/refresh`

Fixes #291

## Test plan
- [x] Reproduced before the fix: `node -e "hashToken('abc')"` → `ReferenceError: hashToken is not defined`
- [x] Spun up the backend locally against a real MongoDB instance and exercised the full flow after the fix:
  - `POST /api/auth/register` → 201, account created
  - `POST /api/auth/login` → 200, returns access/refresh tokens
  - `POST /api/auth/refresh` with the login's refresh token → 200, token rotated successfully (confirms the new hash format is compatible with the existing verification logic)