### PR TITLE
docs: fix incorrect clone URL in README Quick Start guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Before getting started, ensure you have the following installed:
 #### 1️⃣ Clone the Repository
 
 ```bash
-git clone https://github.com/yourusername/PrepPilot.git
+git clone https://github.com/Canopus-Labs/PrepPilot.git
 cd PrepPilot
 ```
 


### PR DESCRIPTION
## Summary
Fix the wrong repository clone URL in the Quick Start section of README.md.
## Problem
Line 137 of README.md uses `yourusername` as a placeholder:
  git clone https://github.com/yourusername/PrepPilot.git
This causes a 404 for anyone who copies the command directly, 
which is the first step new contributors take.
## Solution
Replace with the actual repository URL:
  git clone https://github.com/Canopus-Labs/PrepPilot.git
## Type of Change
- [x] 📝 Documentation fix
## Testing
- [x] URL verified to be correct 