### PR TITLE
fix: remove duplicate token field from auth responses

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -54,7 +54,7 @@ Response `201`:
   "firstName": "Jane",
   "lastName": "Doe",
   "prepPilotId": "jane1234",
-  "token": "eyJhb..."
+  "accessToken": "eyJhb..."
 }
 ```
 Errors:
@@ -82,7 +82,7 @@ Response `200`:
   "name": "Jane Doe",
   "email": "jane@example.com",
   "profileImageUrl": "https://example.com/avatar.png",
-  "token": "eyJhb..."
+  "accessToken": "eyJhb..."
 }
 ```
 Errors:

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -89,7 +89,6 @@ const registerUser = async (req, res) => {
         return res.status(201).json({
             success: true,
             message: "Account created successfully. You can now log in.",
-            token: accessToken,
             accessToken,
             refreshToken,
             _id: user._id,
@@ -143,7 +142,6 @@ const loginUser = async (req, res) => {
             name: user.name,
             email: user.email,
             profileImageUrl: user.profileImageUrl,
-            token: accessToken,
             accessToken,
             refreshToken,
         });
@@ -201,7 +199,6 @@ const refreshToken = async (req, res) => {
         res.json({
             success: true,
             message: "Token refreshed successfully.",
-            token: accessToken,
             accessToken,
             refreshToken: rotatedRefreshToken,
         });

--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -45,8 +45,8 @@ export const UserProvider = ({ children }) => {
 
     const updateUser = (userData) => {
     setUser(userData);
-    if (userData.token) {
-        localStorage.setItem("token", userData.token);
+    if (userData.accessToken) {
+        localStorage.setItem("token", userData.accessToken);
     }
     setLoading(false);
 };

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -37,13 +37,13 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
         email,
         password,
       });
-      const { token } = response.data;
+      const { accessToken } = response.data;
 
-      if (token) {
+      if (accessToken) {
         if (rememberMe) {
-          localStorage.setItem("token", token);
+          localStorage.setItem("token", accessToken);
         } else {
-          sessionStorage.setItem("token", token);
+          sessionStorage.setItem("token", accessToken);
         }
         updateUser(response.data);
         if (onLoginSuccess) {

--- a/frontend/src/pages/Auth/SignUp.jsx
+++ b/frontend/src/pages/Auth/SignUp.jsx
@@ -65,11 +65,11 @@ const SignUp = ({ setCurrentPage }) => {
         password,
         profileImageUrl: profileImageUrl || "",
       });
-
+      
       if (response.data.success) {
-        const { token } = response.data;
-        if (token) {
-          sessionStorage.setItem("token", token);
+        const { accessToken } = response.data;
+        if (accessToken) {
+          sessionStorage.setItem("token", accessToken);
           updateUser(response.data);
           navigate("/dashboard");
         }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #296 

### Summary

This PR removes the redundant `token` field from authentication API responses and standardizes the authentication flow to use `accessToken` consistently across the application.

## Authentication Token Flow

### Before Changes

```mermaid
flowchart LR
    subgraph Backend
        A["Auth Handlers<br/>registerUser()<br/>loginUser()<br/>refreshToken()"]
    end

    A --> B["API Response<br/>{ accessToken, token: accessToken }"]

    B --> C["Frontend<br/>Reads token or accessToken"]

    C --> D["Storage<br/>localStorage/sessionStorage<br/>Key: 'token'"]

    D --> E["Axios Instance<br/>Authorization: Bearer &lt;token&gt;"]
```

### After Changes

```mermaid
flowchart LR
    subgraph Backend
        A["Auth Handlers<br/>registerUser()<br/>loginUser()<br/>refreshToken()"]
    end

    A --> B["API Response<br/>{ accessToken (Removed token from response)}"]

    B --> C["Frontend<br/>Reads accessToken"]

    C --> D["Storage<br/>localStorage/sessionStorage<br/>Key: 'token' (unchanged)"]

    D --> E["Axios Instance<br/>Authorization: Bearer &lt;token&gt;"]

    F["✅ API Contract Simplified"] -.-> B
    G["✅ Existing User Sessions Preserved"] -.-> D
```

#### Backend
- Removed the duplicate `token` field from the response payloads of:
  - `registerUser`
  - `loginUser`
  - `refreshToken`

#### Frontend
- Updated `Login.jsx` to consume `response.data.accessToken` instead of `response.data.token`.
- Updated `SignUp.jsx` to consume `response.data.accessToken` instead of `response.data.token`.
- Updated `userContext.jsx` to check for `userData.accessToken` when updating the authenticated user state.

#### API_Documentation
- Updated `Login api response` i.e `POST /api/auth/login` to send `accessToken` instead of `token`.
- Updated `SignUp api response` i.e `POST /api/auth/register` to send `accessToken` instead of `token`.

#### Notes
- The `localStorage`/`sessionStorage` key (`"token"`) remains unchanged intentionally to preserve existing user sessions and avoid introducing a breaking change.
- No changes were required in `frontend/src/utils/axiosinstance.js`, as it already reads from the storage key rather than the API response field.

---

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [x] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe)

---

### How Has This Been Tested?

- Verified that the backend returns only `accessToken` for the Register, Login, and Refresh Token endpoints.
- Tested the authentication flow to ensure users can successfully register, log in, and remain authenticated after the response field update.
- Confirmed that the existing `localStorage`/`sessionStorage` key (`"token"`) continues to work without requiring any changes.

---

### Screenshots (if applicable)

N/A – This change only affects the authentication API response and frontend token handling.

---

### Checklist

- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors