### PR TITLE
fix: validate topic before generating cache key

### DIFF
--- a/backend/routes/AptitudeQuestions.js
+++ b/backend/routes/AptitudeQuestions.js
@@ -58,11 +58,15 @@ async function generateWithRetry(model, prompt) {
 // GET /api/questions?topic=Probability
 router.get("/", validateAiPrompt, sanitizeAiPrompt, async (req, res) => {
   const { topic } = req.query;
-  if (!topic) 
-    return res.status(400).json({ 
-      error: "Topic is required" 
+
+if (typeof topic !== "string" || topic.trim() === "") {
+    return res.status(400).json({
+        error: "Topic is required"
     });
-  const cacheKey = `questions:${topic.toLowerCase()}`;
+}
+
+const normalizedTopic = topic.trim().toLowerCase();
+const cacheKey = `questions:${normalizedTopic}`;
 
 const cachedQuestions =
   questionCache.get(cacheKey);

--- a/backend/routes/AptitudeQuestions.js
+++ b/backend/routes/AptitudeQuestions.js
@@ -58,6 +58,10 @@ async function generateWithRetry(model, prompt) {
 // GET /api/questions?topic=Probability
 router.get("/", validateAiPrompt, sanitizeAiPrompt, async (req, res) => {
   const { topic } = req.query;
+  if (!topic) 
+    return res.status(400).json({ 
+      error: "Topic is required" 
+    });
   const cacheKey = `questions:${topic.toLowerCase()}`;
 
 const cachedQuestions =
@@ -74,7 +78,7 @@ if (cachedQuestions) {
 console.log(
   `[Cache MISS] Topic: ${topic}`
 );
-  if (!topic) return res.status(400).json({ error: "Topic is required" });
+  
 
   const prompt = `
     Generate 5 multiple-choice aptitude questions on the topic: ${topic}.


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #299

### Summary
This PR fixes the `/api/questions` endpoint crash when the `topic` query parameter is missing.

### Changes
- Added validation for the `topic` query parameter before generating the cache key.
- Prevented calling `topic.toLowerCase()` on an undefined value.
- Removed the duplicate validation later in the route.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe)

---

### How Has This Been Tested?
- Reviewed the route logic to verify that the `topic` parameter is now validated before calling `topic.toLowerCase()`.
- Could not run the application locally because the required environment variables (`MONGO_URI`, `JWT_SECRET`, `GEMINI_API_KEY`) are not included in the repository.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [ ] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors