### PR TITLE
fix: validate topic query before generating cache key

### DIFF
--- a/backend/routes/AptitudeQuestions.js
+++ b/backend/routes/AptitudeQuestions.js
@@ -58,7 +58,11 @@ async function generateWithRetry(model, prompt) {
 // GET /api/questions?topic=Probability
 router.get("/", validateAiPrompt, sanitizeAiPrompt, async (req, res) => {
   const { topic } = req.query;
-  const cacheKey = `questions:${topic.toLowerCase()}`;
+  if (typeof topic !== "string" || topic.trim() === "") {
+    return res.status(400).json({ error: "Topic is required" });
+  }
+  const normalizedTopic = topic.trim().toLowerCase();
+  const cacheKey = `questions:${normalizedTopic}`;
 
 const cachedQuestions =
   questionCache.get(cacheKey);
@@ -74,7 +78,6 @@ if (cachedQuestions) {
 console.log(
   `[Cache MISS] Topic: ${topic}`
 );
-  if (!topic) return res.status(400).json({ error: "Topic is required" });
 
   const prompt = `
     Generate 5 multiple-choice aptitude questions on the topic: ${topic}.


### PR DESCRIPTION
## Description

This PR fixes a runtime exception in the `GET /api/questions` endpoint by validating the `topic` query parameter before it is used to generate the cache key.

### Changes Made

- Added validation to ensure the `topic` query parameter is present before calling `toLowerCase()`.
- Prevented a runtime `TypeError` when the `topic` query parameter is missing.
- Moved the validation before generating the cache key.

### Testing

Tested the following scenarios locally:

- ✅ `GET /api/questions` returns **400 Bad Request** when `topic` is missing.
- ✅ `GET /api/questions?topic=` returns **400 Bad Request**
- ✅ `GET /api/questions?topic=   ` returns **400 Bad Request**
- ✅ `GET /api/questions?topic=Probability` works as expected.

Fixes #299
