### PR TITLE
fix: validate download URLs to prevent open redirect vulnerabilities

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -4,6 +4,7 @@ const router = express.Router();
 const GITHUB_OWNER = "KaranUnique";
 const GITHUB_REPO = "Free-programming-books";
 const BRANCH = "main";
+const ALLOWED_DOWNLOAD_HOSTS = new Set(["raw.githubusercontent.com"]);
 const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
 
 async function fetchJson(url) {
@@ -122,8 +123,26 @@ router.get("/", async (_req, res) => {
  */
 router.get("/download", (req, res) => {
   const { url } = req.query;
-  if (!url) return res.status(400).json({ message: "url query is required" });
-  return res.redirect(url);
+  if (typeof url !== "string" || !url.trim()) {
+    return res.status(400).json({ message: "url query is required" });
+  }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return res.status(400).json({ message: "url query must be a valid URL" });
+  }
+
+  if (parsedUrl.protocol !== "https:") {
+    return res.status(403).json({ message: "download URL must use https" });
+  }
+
+  if (!ALLOWED_DOWNLOAD_HOSTS.has(parsedUrl.hostname)) {
+    return res.status(403).json({ message: "download URL host is not allowed" });
+  }
+
+  return res.redirect(parsedUrl.toString());
 });
 
 module.exports = router;

--- a/backend/tests/booksDownloadRedirect.unit.test.js
+++ b/backend/tests/booksDownloadRedirect.unit.test.js
@@ -1,0 +1,92 @@
+import express from "express";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import booksRoutes from "../routes/booksRoutes.js";
+
+function buildApp() {
+  const app = express();
+  app.use("/api/books", booksRoutes);
+  return app;
+}
+
+function buildPath(rawUrl) {
+  return `/api/books/download?${new URLSearchParams({ url: rawUrl }).toString()}`;
+}
+
+let server;
+let baseUrl;
+
+beforeAll(async () => {
+  const app = buildApp();
+  server = app.listen(0);
+
+  await new Promise((resolve) => {
+    server.once("listening", resolve);
+  });
+
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  if (!server) {
+    return;
+  }
+
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+});
+
+describe("books download redirect validation", () => {
+  it("redirects allowed raw GitHub download URLs", async () => {
+    const allowedUrl = "https://raw.githubusercontent.com/owner/repo/main/file.pdf";
+
+    const response = await fetch(`${baseUrl}${buildPath(allowedUrl)}`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(302);
+    expect(response.headers.get("location")).toBe(allowedUrl);
+  });
+
+  it("blocks non-allowlisted hosts", async () => {
+    const response = await fetch(`${baseUrl}${buildPath("https://evil.com/file.pdf")}`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(403);
+  });
+
+  it("blocks non-https raw GitHub URLs", async () => {
+    const response = await fetch(
+      `${baseUrl}${buildPath("http://raw.githubusercontent.com/file.pdf")}`,
+      {
+        redirect: "manual",
+      }
+    );
+
+    expect(response.status).toBe(403);
+  });
+
+  it("rejects malformed URLs", async () => {
+    const response = await fetch(`${baseUrl}${buildPath("not-a-url")}`, {
+      redirect: "manual",
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects javascript URLs", async () => {
+    const response = await fetch(`${baseUrl}${buildPath("javascript:alert(1)")}`, {
+      redirect: "manual",
+    });
+
+    expect([400, 403]).toContain(response.status);
+  });
+});


### PR DESCRIPTION
## Description

This PR fixes an open redirect vulnerability in the `/api/books/download` endpoint.

### Changes Made
- Added URL parsing and validation before redirects.
- Restricted redirects to HTTPS URLs only.
- Added an allowlist for approved download hosts.
- Allowed redirects only to `raw.githubusercontent.com`.
- Added regression tests covering valid and invalid redirect targets.

### Security Improvements
- Prevents redirects to arbitrary external domains.
- Blocks malicious schemes such as `javascript:`.
- Prevents insecure HTTP redirects.

### Test Coverage
Added tests for:
- Valid GitHub raw download URLs (`302`)
- External domains (`403`)
- Non-HTTPS URLs (`403`)
- Malformed URLs (`400`)
- `javascript:` URLs (`400`/`403`)

Fixes #171