### PR TITLE
fix: resolve unresponsive close button on auth modal in responsive views

### DIFF
--- a/frontend/src/components/Loader/Modal.jsx
+++ b/frontend/src/components/Loader/Modal.jsx
@@ -50,7 +50,7 @@ const Modal = ({ children, isOpen, onClose, title, hideHeader }) => {
               type="button"
               aria-label="Close authentication modal"
               title="Close"
-              className="text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 rounded-full p-1.5 flex items-center justify-center absolute top-4 right-4 transition-all duration-200 z-10"
+              className="text-gray-400 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 rounded-full w-11 h-11 flex items-center justify-center absolute top-4 right-4 transition-all duration-200 z-50"
               onClick={onClose}
             >
               ✕


### PR DESCRIPTION
### Description
This PR resolves the issue where the close (✕) button on the authentication modal is unresponsive on mobile, tablet, and other responsive views.

### Cause
On responsive screens (mobile/tablet widths), the modal form container (`Login` / `SignUp` components) sits inside a relative div styled with `z-10`. Since it is rendered later in the DOM and stretches to occupy the full width, it intercepts all click/tap events in the top-right corner of the modal, blocking the absolute close button which was also styled with `z-10`.

### Solution
1. **Z-Index Fix**: Increased the close button's z-index from `z-10` to `z-50` in `Modal.jsx` to ensure it always stacks above the inner form container's contents.
2. **Accessible Touch Target**: Replaced `p-1.5` with `w-11 h-11` (setting width and height to `44px`) to guarantee a reliable, touchable target on mobile and tablet viewports, meeting WCAG and Apple HIG standards.

Closes #307
