### PR TITLE
feat: Add PDF export for interview feedback (#315)

### DIFF
--- a/frontend/src/pages/InterviewPrep/InterviewPrep.jsx
+++ b/frontend/src/pages/InterviewPrep/InterviewPrep.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import moment from "moment";
 import { AnimatePresence, motion } from "framer-motion";
-import { LuCircleAlert, LuListCollapse } from "react-icons/lu";
+import { LuCircleAlert, LuListCollapse, LuDownload } from "react-icons/lu";
+import html2pdf from "html2pdf.js";
 import SpinnerLoader from "../../components/Loader/SpinnerLoader";
 import { toast } from "react-hot-toast";
 import DashboardLayout from "../../components/Layouts/DashboardLayout";
@@ -24,6 +25,19 @@ const InterviewPrep = () => {
 
   const [isLoading, setIsLoading] = useState(false);
   const [isUpdateLoader, setIsUpdateLoader] = useState(false);
+
+  const handleDownloadPdf = () => {
+    const element = document.getElementById("pdf-report");
+    if (!element) return;
+    const opt = {
+      margin:       10,
+      filename:     'Interview_Feedback_Report.pdf',
+      image:        { type: 'jpeg', quality: 0.98 },
+      html2canvas:  { scale: 2, useCORS: true },
+      jsPDF:        { unit: 'mm', format: 'a4', orientation: 'portrait' }
+    };
+    html2pdf().set(opt).from(element).save();
+  };
 
   // fetch session data
   const fetchSessionDetailsById = async () => {
@@ -130,9 +144,20 @@ const InterviewPrep = () => {
       />
 
       <div className="container mx-auto pt-6 pb-10 px-4 sm:px-6 md:px-10">
-        <h2 className="text-lg sm:text-xl md:text-2xl font-semibold text-gray-900">
-          Interview Q & A
-        </h2>
+        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center">
+          <h2 className="text-lg sm:text-xl md:text-2xl font-semibold text-gray-900 dark:text-white">
+            Interview Q & A
+          </h2>
+          {sessionData?.questions?.length > 0 && (
+            <button
+              onClick={handleDownloadPdf}
+              className="mt-3 sm:mt-0 flex items-center gap-2 bg-indigo-50 dark:bg-indigo-500/10 hover:bg-indigo-100 dark:hover:bg-indigo-500/20 text-indigo-600 dark:text-indigo-400 border border-indigo-100 dark:border-indigo-500/20 px-4 py-2 rounded-xl text-sm font-semibold transition-all shadow-sm"
+            >
+              <LuDownload size={16} />
+              Download PDF
+            </button>
+          )}
+        </div>
 
         <div className="grid grid-cols-1 md:grid-cols-12 gap-6 mt-6">
           {/* Q&A Section */}
@@ -198,6 +223,35 @@ const InterviewPrep = () => {
             <AIResponsePreview content={explanation?.explanation} />
           )}
         </Drawer>
+
+        {/* Hidden PDF Report Area */}
+        <div className="absolute left-[-9999px] top-0 w-[800px] bg-white text-black p-10 font-sans" id="pdf-report">
+          <div className="border-b border-gray-200 pb-4 mb-6">
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">Interview Feedback Report</h1>
+            <p className="text-gray-600 text-sm mb-1"><strong>Role:</strong> {sessionData?.role || ""}</p>
+            <p className="text-gray-600 text-sm mb-1"><strong>Experience:</strong> {sessionData?.experience || "-"} {sessionData?.experience === 1 ? "Year" : "Years"}</p>
+            <p className="text-gray-600 text-sm mb-1"><strong>Date:</strong> {sessionData?.updatedAt ? moment(sessionData.updatedAt).format("MMMM Do YYYY, h:mm a") : ""}</p>
+          </div>
+          
+          <div className="space-y-8">
+            {sessionData?.questions?.map((q, idx) => (
+              <div key={idx} className="border border-gray-200 rounded-xl p-5 break-inside-avoid shadow-sm bg-white">
+                <div className="flex gap-3 mb-4 border-b border-gray-100 pb-3">
+                  <div className="w-8 h-8 rounded-lg bg-violet-100 text-violet-700 font-bold flex items-center justify-center shrink-0">
+                    Q{idx + 1}
+                  </div>
+                  <h3 className="text-lg font-bold text-gray-900 mt-1">{q.question}</h3>
+                </div>
+                <div>
+                  <h4 className="text-sm font-bold text-gray-700 mb-2 uppercase tracking-wide">Answer</h4>
+                  <div className="prose prose-sm max-w-none text-gray-800">
+                    <AIResponsePreview content={q.answer} />
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     </DashboardLayout>
   );


### PR DESCRIPTION
Closes #315 

## Description
This PR introduces a feature allowing users to download their AI-generated interview feedback as a nicely formatted PDF report. 

### Implementation Details:
- Added `html2pdf.js` for client-side HTML to PDF generation without requiring a backend endpoint.
- Updated the `InterviewPrep` page to include a "Download PDF" button next to the "Interview Q & A" section.
- Designed an off-screen, print-friendly hidden section (`#pdf-report`) in the UI that cleanly formats the user's role, experience, date, and expands all questions and AI-generated answers sequentially. This layout ensures the PDF report displays all information seamlessly, bypassing the accordion style used in the browser interface.

### ECSoC26 Label Request
**Analysis:** This PR introduces a substantial new front-end feature to the application, implementing client-side PDF generation, structuring a custom printable UI layout, and integrating it with the existing AI interview session data. 
**Request:** Could you please add the `ECSoC26` label, along with the `Level 2` label (and potentially `good-ui` or `good-pr` if applicable), as this represents a solid feature implementation? Thank you!
