### PR TITLE
fix(auth): redirect expired sessions to the login page

### DIFF
--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -39,7 +39,7 @@ axiosInstance.interceptors.response.use(
                 localStorage.removeItem("token");
                 sessionStorage.removeItem("token");
                 //redirect to login page
-                window.location.href="/";
+                window.location.href="/login";
             }
             else if(error.response.status === 500){
                 console.error("Server error . please try again later");


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #345

### Summary
This PR fixes the authentication redirect behavior when a user's session expires.

Previously, the global Axios response interceptor redirected users to the landing page (`/`) after receiving a `401 Unauthorized` response. This required users to manually navigate back to the login page to authenticate again.

This change updates the redirect target to `/login` while preserving the existing token cleanup logic. No other authentication or logout behavior has been modified.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?

- Verified that a `401 Unauthorized` response now redirects users to `/login` instead of `/`.
- Confirmed that existing token cleanup (`localStorage` and `sessionStorage`) remains unchanged.
- Verified that the manual logout flow is unaffected.
- Ran `npm run build` successfully.
- Confirmed that the modified file introduces no new lint issues.

---

### Screenshots (if applicable)

N/A 

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors