### PR TITLE
docs: update README to match question API routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,11 +537,9 @@ POST   /api/ai/evaluate         - Evaluate user answer
 ### Question Endpoints
 
 ```
-GET    /api/questions           - Get all questions
-GET    /api/questions/:id       - Get single question
-POST   /api/questions           - Create question (admin)
-PUT    /api/questions/:id       - Update question (admin)
-DELETE /api/questions/:id       - Delete question (admin)
+POST   /api/question/add        - Add questions to a session
+POST   /api/question/:id/pin    - Pin or unpin a question
+POST   /api/question/:id/note   - Update note for a question
 ```
 
 ### Resume Endpoints


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #359

### Summary
This PR updates the README to accurately reflect the implemented question API endpoints.
- Removed the outdated question endpoints:
  - `GET /api/questions`
  - `POST /api/questions`
  - `PUT /api/questions/:id`
  - `DELETE /api/questions/:id`

- Updated the documentation to match the current backend implementation:
  - `POST /api/question/add`
  - `POST /api/question/:id/pin`
  - `POST /api/question/:id/note`

---

### Type of Change
- 📝 Documentation update
