### PR TITLE
Move refresh token to httpOnly cookie instead of localStorage/session…

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,6 +9,13 @@ const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "7d";
 const REFRESH_TOKEN_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_SALT_ROUNDS = 10;
+const getRefreshCookieOptions = () => ({
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
+    maxAge: REFRESH_TOKEN_MAX_AGE_MS,
+    path: "/api/auth",
+});
 
 /**
  * Generate an access token for the authenticated user.
@@ -81,12 +88,12 @@ const registerUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-
+        res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         return res.status(201).json({
             success: true,
             message: "Account created successfully. You can now log in.",
             accessToken,
-            refreshToken,
+            
             _id: user._id,
             name: user.name,
             email: user.email,
@@ -131,7 +138,7 @@ const loginUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-
+        res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         res.json({
             success: true,
             _id: user._id,
@@ -139,7 +146,7 @@ const loginUser = async (req, res) => {
             email: user.email,
             profileImageUrl: user.profileImageUrl,
             accessToken,
-            refreshToken,
+
         });
     } catch (error) {
         console.log(error)
@@ -149,10 +156,10 @@ const loginUser = async (req, res) => {
 
 const refreshToken = async (req, res) => {
     try {
-        const { refreshToken: incomingRefreshToken } = req.body;
+        const incomingRefreshToken = req.cookies?.refreshToken;
 
         if (!incomingRefreshToken) {
-            return res.status(400).json({ success: false, message: "Refresh token is required." });
+            return res.status(401).json({ success: false, message: "Refresh token is missing." });
         }
 
         let decoded;
@@ -193,11 +200,12 @@ const refreshToken = async (req, res) => {
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
 
+        res.cookie("refreshToken", rotatedRefreshToken, getRefreshCookieOptions());
         res.json({
             success: true,
             message: "Token refreshed successfully.",
             accessToken,
-            refreshToken: rotatedRefreshToken,
+        
         });
     } catch (error) {
         res.status(500).json({ success: false, message: "Internal server error occurred", error: error.message });
@@ -206,7 +214,7 @@ const refreshToken = async (req, res) => {
 
 const logoutUser = async (req, res) => {
     try {
-        const { refreshToken: incomingRefreshToken } = req.body;
+        const incomingRefreshToken = req.cookies?.refreshToken;
 
         if (!incomingRefreshToken) {
             return res.status(400).json({ success: false, message: "Refresh token is required." });
@@ -238,6 +246,7 @@ const logoutUser = async (req, res) => {
         user.refreshTokenExpiresAt = null;
         await user.save();
 
+        res.clearCookie("refreshToken", { path: "/api/auth" });
         res.json({ success: true, message: "User logged out successfully." });
     } catch (error) {
         res.status(500).json({ success: false, message: "Internal server error occurred", error: error.message });

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -13,6 +13,7 @@
         "@google/generative-ai": "^0.21.0",
         "axios": "^1.13.6",
         "bcryptjs": "^3.0.2",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
@@ -1217,6 +1218,25 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,6 +16,7 @@
     "@google/generative-ai": "^0.21.0",
     "axios": "^1.13.6",
     "bcryptjs": "^3.0.2",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/backend/server.js
+++ b/backend/server.js
@@ -5,6 +5,7 @@ const express = require("express");
 const cors = require("cors");
 const path = require("path");
 const connectDB = require("./config/db");
+const cookieParser = require("cookie-parser");
 const {
   generateInterviewQuestions,
   generateConceptExplanation,
@@ -90,6 +91,7 @@ connectDB()
 
 // middleware
 app.use(express.json());
+app.use(cookieParser());
 
 //Routes
 app.use("/api/auth", sensitiveRouteHeaders,authRoutes);

--- a/frontend/src/components/Cards/ProfileinfoCard.jsx
+++ b/frontend/src/components/Cards/ProfileinfoCard.jsx
@@ -1,17 +1,24 @@
 import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 import { UserContext } from "../../context/userContext";
+import axiosInstance from "../../utils/axiosinstance";
+import { API_PATHS } from "../../utils/apiPaths";
 
 const ProfileinfoCard = () => {
   const { user, clearUser } = useContext(UserContext);
   const navigate = useNavigate();
-
-  const handleLogout = () => {
-    localStorage.clear();
-    clearUser();
-    navigate("/");
+  const handleLogout = async () => {
+    try {
+      await axiosInstance.post(API_PATHS.AUTH.LOGOUT);
+    } catch (error) {
+      console.error("Logout request failed:", error);
+    } finally {
+      localStorage.clear();
+      sessionStorage.clear();
+      clearUser();
+      navigate("/");
+    }
   };
-
   if (!user) return null;
 
   return (

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -13,6 +13,7 @@ export const API_PATHS = {
     UPDATE_PROFILE: "/api/auth/profile",
     CHANGE_PASSWORD: "/api/auth/change-password",
     DELETE_ACCOUNT: "/api/auth/delete-account",
+    LOGOUT: "/api/auth/logout",
 },
     IMAGE: {
         UPLOAD_IMAGE: "/api/auth/upload-image", // Upload profile picture

--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -4,6 +4,7 @@ import { BASE_URL } from "./apiPaths";
 const axiosInstance = axios.create({
     baseURL: BASE_URL,
     timeout: 80000,
+    withCredentials: true,
     headers: {
         "Content-Type": "application/json",
         Accept: "application/json",


### PR DESCRIPTION
##  Pull Request Description

### Related Issue
Closes #312

### Summary
Moves the refresh token out of localStorage/sessionStorage and into an httpOnly, Secure cookie so it can no longer be read by page JavaScript (and therefore not by an XSS payload). The backend now sets the refresh token via `res.cookie(...)` on register/login/refresh instead of returning it in the JSON body, and reads it from `req.cookies` on the refresh and logout routes instead of `req.body`. Added `cookie-parser` middleware and a `getRefreshCookieOptions()` helper that uses `SameSite=Lax` in dev and `SameSite=None; Secure` in production, since the frontend and backend run on different origins. On the frontend, `axiosInstance` now sends `withCredentials: true` so the cookie is included automatically, and logout now calls the new `/api/auth/logout` endpoint before clearing local state, so the server-side refresh token hash and cookie are actually invalidated instead of just being abandoned client-side.

Note: the short-lived access token still lives in localStorage/sessionStorage for now. Moving it to in-memory-only storage would need a broader frontend refactor (auth context + 401 retry handling), so I've scoped that as a possible follow-up rather than bundling it here — this PR focuses on removing the 7-day refresh token from client-side exposure, which is the higher-severity part of the issue.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### How Has This Been Tested?
- Verified via code review and manual tracing of all call sites that the refresh token is no longer present in any JSON response body (register, login, refresh) and is only ever set via `res.cookie(...)`.
- Confirmed `req.cookies` is used (not `req.body`) in both the refresh and logout controllers.
- Confirmed `axiosInstance` now sends `withCredentials: true`.
- **Not yet verified**: a full local end-to-end run (login → inspect cookie in DevTools → refresh → logout) — my local `.env` wasn't fully set up (missing `MONGO_URI`/`JWT_SECRET`) at the time of this PR. Flagging this so a maintainer/reviewer can do a full local run before merging, since this touches the auth flow directly.

---

### Screenshots (if applicable)
N/A - backend/auth logic change, no UI change.

---

### Checklist
- [x] My code follows the project's guidelines
- [ ] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors