### PR TITLE
fix: render markdown in AI Assistant chat messages

### DIFF
--- a/frontend/src/components/AIHepler.jsx
+++ b/frontend/src/components/AIHepler.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useContext } from "react";
 import { UserContext } from "../context/userContext";
 import { Bot, User as UserIcon, Send, Sparkles, Trash2 } from "lucide-react";
 import { BASE_URL } from "../utils/apiPaths";
+import AIResponsePreview from "../pages/InterviewPrep/components/AIResponsePreview";
 
 export default function AIHelper() {
   const { user } = useContext(UserContext);
@@ -210,10 +211,12 @@ export default function AIHelper() {
                           <span className="w-1.5 h-1.5 rounded-full bg-violet-400 animate-bounce" style={{ animationDelay: "150ms" }}></span>
                           <span className="w-1.5 h-1.5 rounded-full bg-violet-400 animate-bounce" style={{ animationDelay: "300ms" }}></span>
                         </div>
-                      ) : (
-                        <div className={`text-[15px] leading-relaxed whitespace-pre-wrap ${isUser ? "font-medium" : "prose prose-sm dark:prose-invert max-w-none break-words"}`}>
+                      ) : isUser ? (
+                        <div className="text-[15px] leading-relaxed whitespace-pre-wrap font-medium">
                           {m.text}
                         </div>
+                      ) : (
+                        <AIResponsePreview content={m.text} />
                       )}
                     </div>
                   </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #399 

### Summary
The AI Assistant chat rendered assistant replies as raw text, so markdown showed
literal syntax (`**bold**`, `*italic*`, `~~strike~~`, `` `code` ``, `*`/`1.` list
markers, code fences). This routes assistant messages through the existing
`AIResponsePreview` component (react-markdown + remark-gfm), so they now render as
formatted markdown — bold, italic, strikethrough, inline code, bulleted / numbered /
nested lists, and code blocks. User messages and the typing indicator are unchanged.
No new dependencies (both libs were already installed).

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
---

### How Has This Been Tested?
- Ran `npm run lint`; no new errors from this change.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors