### PR TITLE
fix: correct invalid react-router-dom import in LandingPage

### DIFF
--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -1,8 +1,7 @@
 import ProfileInfoCard from "./components/Cards/ProfileinfoCard";
 import React, { useContext, useState, useEffect } from "react";
 import { APP_FEATURES, STATS, HOW_IT_WORKS_STEPS } from "./utils/data";
-import { useNavigate } from "react-router-dom";
-import { Link, something } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import {
   LuSparkles,
   LuChevronRight,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #402 

### Summary
This PR fixes a runtime error on the landing page caused by an invalid import from `react-router-dom`.

---

### Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)

---