### PR TITLE
feat: add Need Revision marker using existing pin functionality

### DIFF
--- a/frontend/src/components/Cards/QuestionCard.jsx
+++ b/frontend/src/components/Cards/QuestionCard.jsx
@@ -47,17 +47,20 @@ const QuestionCard = ({
         <div className="flex items-center justify-start sm:ml-auto gap-3 shrink-0">
           {onTogglePin && (
             <button
-              className={`p-2 rounded-xl transition-colors duration-200 flex items-center justify-center ${
-                isPinned 
-                  ? "bg-violet-100 dark:bg-violet-500/20 text-violet-600 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 shadow-sm" 
-                  : "bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-400 hover:bg-violet-50 hover:text-violet-600 dark:hover:bg-white/10 dark:hover:text-violet-300 border border-transparent"
-              }`}
-              onClick={onTogglePin}
-              title={isPinned ? "Unpin Question" : "Pin Question"}
+            className={`px-3 py-2 rounded-xl transition-colors duration-200 flex items-center gap-2 ${
+              isPinned
+              ? "bg-violet-100 dark:bg-violet-500/20 text-violet-600 dark:text-violet-400 border border-violet-200 dark:border-violet-500/30 shadow-sm"
+              : "bg-gray-100 dark:bg-white/5 text-gray-500 dark:text-gray-400 hover:bg-violet-50 hover:text-violet-600 dark:hover:bg-white/10 dark:hover:text-violet-300 border border-transparent"
+            }`}
+            onClick={onTogglePin}
+            title={isPinned ? "Remove from Revision" : "Mark for Revision"}
             >
               {isPinned ? <LuPinOff size={18} /> : <LuPin size={18} />}
-            </button>
-          )}
+              <span className="text-sm font-medium">
+                {isPinned ? "Revision" : "Need Revision"}
+                </span>
+                </button>
+              )}
 
             <button
               className="p-2 rounded-xl bg-gray-100 dark:bg-white/5 text-gray-500             dark:text-gray-400 hover:bg-violet-50 hover:text-violet-600 dark:hover:bg-white/10             dark:hover:text-violet-300 transition-all"


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #322

### Summary
This PR updates the existing question marking functionality to better support the "Need Revision" workflow by reusing the existing pin feature. The UI now presents the action as "Mark for Revision" / "Remove from Revision", allowing users to easily identify and revisit important interview questions without introducing duplicate backend functionality.

---

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [x] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Verified that users can mark and unmark interview questions for revision.
- Confirmed that the existing functionality continues to work without any backend changes.

---

### Screenshots (if applicable)
Add before and after screenshots of the updated "Need Revision" button.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors