### PR TITLE
fix: validate unlockedAchievements request payload

### DIFF
--- a/backend/controllers/achievementController.js
+++ b/backend/controllers/achievementController.js
@@ -14,8 +14,16 @@ exports.getAchievements = async (req, res) => {
 exports.saveAchievements = async (req, res) => {
     const { unlockedAchievements } = req.body;
 
+        if (!unlockedAchievements || !Array.isArray(unlockedAchievements)) {
+        return res.status(400).json({
+            success: false,
+            error: "unlockedAchievements must be a valid array"
+        });
+    }
+
     // Reject any ID not in the server-side allowlist
     const unknown = unlockedAchievements.filter((id) => !VALID_ACHIEVEMENTS.has(id));
+
     if (unknown.length > 0) {
         return res.status(400).json({
             success: false,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #413 
### Summary
Added request payload validation to the ```saveAchievements``` controller in 
```achievementController.js```

Previously, if``` unlockedAchievements``` was missing from the request body or was not an array, calling ```unlockedAchievements.filter(...)```  would throw an unhandled TypeError (e.g., ```Cannot read properties of undefined (reading 'filter'))```. This caused the backend server to return a 500 Internal Server Error or crash the process.

This PR introduces a validation guard at the top of the saveAchievements handler to ensure unlockedAchievements is present and is a valid array, returning a ```400 Bad Request``` with a clear error message instead.



---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

## How Has This Been Tested?

**Unit Testing**: Ran local vitest tests verifying that:
Missing unlockedAchievements field returns 400 Bad Request and success: false.
Passing a non-array value (e.g., a string or null) to unlockedAchievements returns 400 Bad Request and success: false.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors