### PR TITLE
fix: enforce session ownership authorization check in getSessionById

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -124,6 +124,11 @@ exports.getSessionById = async (req, res) => {
         .status(404)
         .json({success:false , message:"Session not found"});
     }
+    if (session.user.toString() !== req.user._id.toString()) {
+        return res
+        .status(403)
+        .json({ success: false, message: "Unauthorized access to this session" });
+    }
     res.status(200).json({ success:true , session })
   } catch (error) {
     res.status(500).json({ success: false, message: "Server Error" });


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #421 

### Summary
This PR fixes a broken access control vulnerability in the `getSessionById` controller by ensuring that only the owner of a practice session can access it.
Previously, the endpoint returned the requested session without verifying that the authenticated user owned the session, allowing any authenticated user with a valid session ID to access another user's interview session.


### Type of Change
- Bug fix (non-breaking change which fixes an issue)
