### PR TITLE
fix: protect sheet upload endpoint

### DIFF
--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -1,10 +1,11 @@
 const express = require('express');
 const router = express.Router();
 const Sheet = require('../models/Sheet');
+const { protect } = require('../middlewares/authMiddleware');
 
 // POST /api/sheets/upload
 // Body: { filename: "file.json", data: {...sheet data...} }
-router.post('/upload', async (req, res) => {
+router.post('/upload', protect, async (req, res) => {
   console.log('Received upload:', req.body.filename);
   const { filename, data } = req.body;
 


### PR DESCRIPTION
## Summary

This PR secures the sheet upload endpoint by requiring authentication before processing upload requests.

## Changes Made

- Added the `protect` middleware to the `POST /api/sheets/upload` route.
- Prevented unauthenticated users from uploading sheet data.
- Preserved the existing upload functionality for authenticated users.

## Problem

The `POST /api/sheets/upload` endpoint was publicly accessible without authentication, allowing anyone to upload arbitrary sheet data. This posed a security risk by permitting unauthorized data modifications.

## Solution

Applied the existing authentication middleware (`protect`) to the upload route so that only authenticated users can access the endpoint.

## Testing

- Verified authenticated users can successfully upload sheet data.
- Verified unauthenticated requests are denied with an authorization error.
- Confirmed existing upload functionality remains unchanged for authorized users.

## Related Issue

Closes #418 