### PR TITLE
fix: prevent negative experience values in session creation

### DIFF
--- a/frontend/src/pages/Home/CreateSessionForm.jsx
+++ b/frontend/src/pages/Home/CreateSessionForm.jsx
@@ -33,6 +33,10 @@ const CreateSessionForm = () => {
       setError("Please fill all the required fields.");
       return;
     }
+    if (Number(experience) < 0) {
+  setError("Years of experience cannot be negative.");
+  return;
+}
     
     const topicsArray = topicsToFocus.split(",")
     .map((t) => t.trim())
@@ -142,6 +146,7 @@ const CreateSessionForm = () => {
                   ) : (
                     <input
                       type={field.type}
+                      min={field.type === "number" ? 0 : undefined}
                       value={formData[field.id]}
                       onChange={({ target }) => handleChange(field.id, target.value)}
                       placeholder={field.placeholder}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #411

### Summary
This PR addresses the remaining issue from #411 by preventing users from entering negative values for **Years of Experience** while creating a new interview session.

> **Note:** The `topicsToFocus` validation issue (string → array) has already been resolved in the latest `main` branch. This PR focuses only on the remaining negative input validation.

### Changes made:
- Added client-side validation to prevent negative values for **Years of Experience**.
- Displayed a validation error message when a negative value is entered.
- Added `min={0}` to the experience input field to prevent negative values through the UI.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?
- Tested with valid values such as **0**, **1**, and **5** to ensure session creation works correctly.
- Tested with **-1** and other negative values to verify that an error message is displayed and form submission is prevented.

---

### Screenshots (if applicable)

**Before:** Negative values such as `-1` were accepted.

**After:** Negative values display the error **"Years of experience cannot be negative."** and prevent form submission.
<img width="642" height="805" alt="Screenshot 2026-07-09 230018" src="https://github.com/user-attachments/assets/70480638-07b4-4be1-91a3-55c261ec8774" />


---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors