### PR TITLE
feat(ai): add Zod validation for generateInterviewTips response

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -220,6 +220,26 @@ const generateConceptExplanation = async (req, res) => {
   }
 };
 
+/**
+ * Generate interview preparation tips using the Gemini AI service.
+ * @route POST /api/ai/generate-tips
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ * @throws {Error} When required request fields are missing or Gemini fails.
+ * @example
+ * POST /api/ai/generate-tips
+ * Authorization: Bearer eyJhb...
+ * {
+ *   "role": "Frontend Engineer",
+ *   "experience": "2 years"
+ * }
+ * @example
+ * 200 {
+ *   "model": "models/gemini-2.5-flash",
+ *   "tips": ["Focus on React hooks.", "Practice system design basics.", ...]
+ * }
+ */
 const generateInterviewTips = async (req, res) => {
   try {
     const { role, experience } = req.body;
@@ -262,6 +282,16 @@ const generateInterviewTips = async (req, res) => {
 
     try {
       const data = JSON.parse(cleanedText);
+
+      // Validate Gemini response structure
+      const tipsSchema = z.object({
+        tips: z.array(z.string()),
+      });
+      const parsed = tipsSchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: "Invalid AI response format", details: parsed.error.issues[0]?.message });
+      }
+
       res.status(200).json({ model: usedModel, ...data });
     } catch (err) {
       console.error("Gemini returned invalid JSON:", cleanedText);


### PR DESCRIPTION
## Summary

The `generateInterviewTips` endpoint was parsing the Gemini AI response
using `JSON.parse` without validating its structure. The other two AI
endpoints — `generateInterviewQuestions` and `generateConceptExplanation`
— already use Zod schema validation after parsing, making this endpoint
inconsistent and vulnerable to malformed AI responses silently reaching
the client.

## Changes

- **Added Zod schema** (`tipsSchema`) for the expected AI response
  structure: `{ tips: z.array(z.string()) }`, matching the contract
  defined in `interviewTipsPrompt`
- **Validate parsed JSON** with `safeParse` before sending the response
- **Return a structured error** (`500` with `"Invalid AI response format"`
  and a `details` field) if validation fails
- **Added JSDoc comment** to `generateInterviewTips` consistent with the
  documentation style of the other two AI handlers

## Why

- Prevents malformed AI responses from reaching clients silently
- Makes validation consistent across all three AI controller endpoints
- Improves debuggability via the `details` field in the error response
- No behaviour change for valid responses — purely additive

## Testing

- Verified against `ValidateAi.js` — the request input validator is
  unaffected (separate concern, separate middleware)
- Verified against `server.js` — route registration and pipeline
  unchanged
- Verified against all existing tests — no test covers this function,
  so nothing is broken
- The module export is unchanged: `{ generateInterviewQuestions,
  generateConceptExplanation, generateInterviewTips }`

## Related Issue

Closes #424 
