### PR TITLE
fix: restrict numeric input in First Name and Last Name fields

### DIFF
--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -179,7 +179,15 @@ const Settings = () => {
       );
     }
   };
+  
+  const NAME_REGEX = /^[A-Za-z\s]*$/;
+   const handleNameChange = (setter) => (e) => {
+    const value = e.target.value;
 
+    if (NAME_REGEX.test(value)) {
+      setter(value);
+    }
+  };
   // Handle Save Basic Info
   const handleSaveBasicInfo = async (e) => {
     e.preventDefault();
@@ -644,7 +652,7 @@ const Settings = () => {
                       type="text"
                       className="w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 focus:border-blue-500 rounded-lg py-2.5 px-4 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-blue-500/30 transition-all"
                       value={firstName}
-                      onChange={(e) => setFirstName(e.target.value)}
+                      onChange={handleNameChange(setFirstName)}
                       required
                     />
                   </div>
@@ -656,7 +664,7 @@ const Settings = () => {
                       type="text"
                       className="w-full bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 focus:border-blue-500 rounded-lg py-2.5 px-4 text-sm text-slate-900 dark:text-white focus:outline-none focus:ring-1 focus:ring-blue-500/30 transition-all"
                       value={lastName}
-                      onChange={(e) => setLastName(e.target.value)}
+                      onChange={handleNameChange(setLastName)}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #378

### Summary
This PR fixes the bug where the **First Name** and **Last Name** fields in the Basic Info section accepted numeric characters as valid input.

The validation has been updated to allow only alphabetic characters and spaces in both fields.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?

- Added validation to the First Name and Last Name input fields.
- Verified the logic to ensure only alphabetic characters and spaces are accepted while numeric and special characters are restricted.

---

### Screenshots (if applicable)

N/A

---

### Checklist

- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors