### PR TITLE
refactor(backend): extract Gemini model fallback into reusable utility (DRY)

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -1,4 +1,3 @@
-const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { z } = require("zod");
 const {
   conceptExplainPrompt,
@@ -7,8 +6,7 @@ const {
 } = require("../utils/prompts");
 const Session = require("../models/Session");
 const Question = require("../models/Question");
-
-const ai = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+const { generateWithFallback } = require("../utils/geminiHelper");
 
 /**
  * Generate interview questions and answers using the Gemini AI service.
@@ -63,33 +61,10 @@ const generateInterviewQuestions = async (req, res) => {
       seenQuestions,
     });
 
-    const candidateModels = [
-      process.env.GEMINI_MODEL,
-      "models/gemini-2.5-flash",
-      "models/gemini-flash-latest",
-      "models/gemini-2.0-flash",
-    ].filter(Boolean);
-
-    let lastErr = null;
-    let result = null;
-    let usedModel = null;
-
-    for (const m of candidateModels) {
-      try {
-        console.log(`Trying model: ${m}`);
-        const model = ai.getGenerativeModel({ model: m });
-        result = await model.generateContent([prompt]);
-        usedModel = m;
-        console.log(`Successfully used model: ${m}`);
-        break;
-      } catch (e) {
-        console.error(`Model ${m} failed:`, e.message);
-        lastErr = e;
-        continue;
-      }
-    }
-
-    if (!result) throw lastErr || new Error("All Gemini models failed");
+    const { result, usedModel } = await generateWithFallback(
+      process.env.GEMINI_API_KEY,
+      [prompt]
+    );
 
     const rawText = await result.response.text();
     let cleanedText = rawText
@@ -158,30 +133,10 @@ const generateConceptExplanation = async (req, res) => {
 
     const prompt = conceptExplainPrompt(question);
 
-    const candidateModels = [
-      process.env.GEMINI_MODEL,
-      "models/gemini-2.5-flash",
-      "models/gemini-flash-latest",
-      "models/gemini-2.0-flash",
-    ].filter(Boolean);
-    let lastErr = null;
-    let result = null;
-    let usedModel = null;
-    for (const m of candidateModels) {
-      try {
-        console.log(`Trying model: ${m}`);
-        const model = ai.getGenerativeModel({ model: m });
-        result = await model.generateContent([prompt]);
-        usedModel = m;
-        console.log(`Successfully used model: ${m}`);
-        break;
-      } catch (e) {
-        console.error(`Model ${m} failed:`, e.message);
-        lastErr = e;
-        continue;
-      }
-    }
-    if (!result) throw lastErr || new Error("All Gemini models failed");
+    const { result, usedModel } = await generateWithFallback(
+      process.env.GEMINI_API_KEY,
+      [prompt]
+    );
 
     const rawText = await result.response.text();
     // Clean: remove all leading/trailing code block markers (```json, ```), even if repeated, and trim
@@ -246,33 +201,10 @@ const generateInterviewTips = async (req, res) => {
 
     const prompt = interviewTipsPrompt({ role, experience });
 
-    const candidateModels = [
-      process.env.GEMINI_MODEL,
-      "models/gemini-2.5-flash",
-      "models/gemini-flash-latest",
-      "models/gemini-2.0-flash",
-    ].filter(Boolean);
-
-    let lastErr = null;
-    let result = null;
-    let usedModel = null;
-
-    for (const m of candidateModels) {
-      try {
-        console.log(`Trying model: ${m}`);
-        const model = ai.getGenerativeModel({ model: m });
-        result = await model.generateContent([prompt]);
-        usedModel = m;
-        console.log(`Successfully used model: ${m}`);
-        break;
-      } catch (e) {
-        console.error(`Model ${m} failed:`, e.message);
-        lastErr = e;
-        continue;
-      }
-    }
-
-    if (!result) throw lastErr || new Error("All Gemini models failed");
+    const { result, usedModel } = await generateWithFallback(
+      process.env.GEMINI_API_KEY,
+      [prompt]
+    );
 
     const rawText = await result.response.text();
     let cleanedText = rawText

--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const FormData = require('form-data');
-const { GoogleGenerativeAI } = require('@google/generative-ai');
+const { generateWithFallback } = require('../utils/geminiHelper');
 
 /**
  * Compile LaTeX resume code to a PDF document.
@@ -101,9 +101,6 @@ const analyzeResume = async (req, res) => {
 
         const targetRole = req.body.targetRole || "General Professional";
 
-        // 1. Setup Gemini
-        const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY.trim());
-
         // 2. Prompt Engineering
         const prompt = `You are an expert ATS (Applicant Tracking System) and Senior Technical Recruiter.
 Analyze the attached PDF resume against the target role: "${targetRole}".
@@ -124,37 +121,18 @@ Return the analysis STRICTLY as a JSON object with the following exact keys and 
 DO NOT wrap the response in markdown blocks like \`\`\`json. Return ONLY the raw JSON object.`;
 
         // 3. Fallback Engine (Mirroring aiController robustness)
-        const candidateModels = [
-            process.env.GEMINI_MODEL,
-            "models/gemini-2.5-flash",
-            "models/gemini-flash-latest",
-            "models/gemini-2.0-flash",
-            "gemini-1.5-flash"
-        ].filter(Boolean);
-
-        let lastErr = null;
-        let result = null;
-
-        for (const m of candidateModels) {
-            try {
-                const model = genAI.getGenerativeModel({ model: m });
-                result = await model.generateContent([
-                    prompt,
-                    {
-                        inlineData: {
-                            data: req.file.buffer.toString("base64"),
-                            mimeType: "application/pdf"
-                        }
+        const { result } = await generateWithFallback(
+            process.env.GEMINI_API_KEY.trim(),
+            [
+                prompt,
+                {
+                    inlineData: {
+                        data: req.file.buffer.toString("base64"),
+                        mimeType: "application/pdf"
                     }
-                ]);
-                break; // Stop on first success
-            } catch (e) {
-                lastErr = e;
-                continue;
-            }
-        }
-
-        if (!result) throw lastErr || new Error("All Gemini models failed to process PDF");
+                }
+            ]
+        );
         
         let aiResponse = result.response.text();
         

--- a/backend/routes/AptitudeQuestions.js
+++ b/backend/routes/AptitudeQuestions.js
@@ -1,5 +1,5 @@
 const express = require("express");
-const { GoogleGenerativeAI } = require("@google/generative-ai");
+const { generateWithFallback } = require("../utils/geminiHelper");
 const NodeCache = require("node-cache");
 
 const questionCache = new NodeCache({
@@ -7,50 +7,9 @@ const questionCache = new NodeCache({
 });
 
 const router = express.Router();
-const ai = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
 const MAX_RETRIES = 3;
 const INITIAL_DELAY = 1000;
 
-function isRetryableError(error) {
-  const status = error?.status || error?.code;
-
-  return (
-    status === 429 ||
-    status === 503 ||
-    error?.message?.toLowerCase().includes("timeout") ||
-    error?.message?.toLowerCase().includes("network")
-  );
-}
-
-async function generateWithRetry(model, prompt) {
-  let lastError;
-
-  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-    try {
-      return await model.generateContent([prompt]);
-    } catch (error) {
-      lastError = error;
-
-      if (!isRetryableError(error)) {
-        throw error;
-      }
-
-      if (attempt === MAX_RETRIES - 1) {
-        throw error;
-      }
-
-      const delay = INITIAL_DELAY * Math.pow(2, attempt);
-
-      console.warn(
-        `[Gemini Retry] Attempt ${attempt + 1}/${MAX_RETRIES} failed. Retrying in ${delay}ms`
-      );
-
-      await new Promise((resolve) => setTimeout(resolve, delay));
-    }
-  }
-
-  throw lastError;
-}
 
 // GET /api/questions?topic=Probability
 router.get("/", async (req, res) => {
@@ -91,46 +50,16 @@ console.log(
   `;
 
   try {
-    // Use working Gemini models with fallback
-    const candidateModels = [
-      process.env.GEMINI_MODEL,
-      "models/gemini-2.5-flash",
-      "models/gemini-flash-latest",
-      "models/gemini-2.0-flash",
-    ].filter(Boolean);
+    // Use centralised helper with per-model retry (exponential backoff)
+    const { result, usedModel } = await generateWithFallback(
+      process.env.GEMINI_API_KEY,
+      [prompt],
+      {},
+      MAX_RETRIES,
+      INITIAL_DELAY
+    );
 
-    let lastErr = null;
-    let result = null;
-    let usedModel = null;
-
-    for (const m of candidateModels) {
-      try {
-        console.log(`[Aptitude] Trying model: ${m}`);
-        const model = ai.getGenerativeModel({ model: m });
-
-        result = await generateWithRetry(
-          model,
-          prompt
-        );
-        usedModel = m;
-        console.log(`[Aptitude] Successfully used model: ${m}`);
-        break;
-      } catch (e) {
-        console.error(
-          `[Aptitude] Model ${m} exhausted retries:`,
-          e.message
-        );
-        lastErr = e;
-        continue;
-      }
-    }
-
-    if (!result) {
-      return res.status(500).json({
-        error: "Failed to generate questions. Gemini API Key is missing or invalid.",
-        details: lastErr ? lastErr.message : "All Gemini models failed"
-      });
-    }
+    console.log(`[Aptitude] Successfully used model: ${usedModel}`);
 
     const rawText = await result.response.text();
     let cleanedText = rawText

--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const router = express.Router();
-const { GoogleGenerativeAI } = require('@google/generative-ai');
+const { generateChatWithFallback } = require('../utils/geminiHelper');
 const { aiLimiter } = require('../middlewares/rateLimiter');
 const { validateAiPrompt } = require('../middlewares/validateAiPrompt');
 const sanitizeAiPrompt = require('../middlewares/sanitizeAiPrompt');
@@ -58,52 +58,29 @@ async function generateHandler(req, res) {
   }
   try {
     const start = Date.now();
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const candidateModels = [
-      process.env.GEMINI_MODEL,
-      "models/gemini-2.5-flash",
-      "models/gemini-flash-latest",
-      "models/gemini-2.0-flash",
-    ].filter(Boolean);
-
-    let lastErr = null;
-    let result = null;
-    let usedModel = null;
-    for (const m of candidateModels) {
-      try {
-        const model = genAI.getGenerativeModel({ 
-          model: m,
-          systemInstruction: systemInstruction || `You are PrepPilot AI Mentor.
+    const systemInstructionText = systemInstruction || `You are PrepPilot AI Mentor.
 1. Allow friendly greetings and casual onboarding conversation.
 2. Focus primarily on PrepPilot-related domains: interview preparation, coding interviews, aptitude, resumes, career guidance, mock interviews, and platform usage.
 3. Politely redirect unrelated conversations.
-4. End your responses with a helpful, contextual follow-up question whenever appropriate (e.g., asking if they want an example, feedback on a resume section, or practice questions).`
-        });
-        
-        // Format history for Gemini API
-        let formattedHistory = history.map(msg => ({
-          role: msg.role === "model" ? "model" : "user",
-          parts: [{ text: msg.text }]
-        }));
+4. End your responses with a helpful, contextual follow-up question whenever appropriate (e.g., asking if they want an example, feedback on a resume section, or practice questions).`;
 
-        // Gemini requires the first message in history to be from the user
-        if (formattedHistory.length > 0 && formattedHistory[0].role !== "user") {
-          formattedHistory.unshift({ role: "user", parts: [{ text: "Hi" }] });
-        }
+    // Format history for Gemini API
+    let formattedHistory = history.map(msg => ({
+      role: msg.role === "model" ? "model" : "user",
+      parts: [{ text: msg.text }]
+    }));
 
-        const chat = model.startChat({
-          history: formattedHistory
-        });
-
-        result = await chat.sendMessage(prompt);
-        usedModel = m;
-        break;
-      } catch (e) {
-        lastErr = e;
-        continue;
-      }
+    // Gemini requires the first message in history to be from the user
+    if (formattedHistory.length > 0 && formattedHistory[0].role !== "user") {
+      formattedHistory.unshift({ role: "user", parts: [{ text: "Hi" }] });
     }
-    if (!result) throw lastErr || new Error("All Gemini models failed");
+
+    const { result, usedModel } = await generateChatWithFallback(
+      process.env.GEMINI_API_KEY,
+      prompt,
+      formattedHistory,
+      { systemInstruction: systemInstructionText }
+    );
 
     const rawText = await result.response.text();
     console.log("Incoming Prompt:", prompt);

--- a/backend/utils/geminiHelper.js
+++ b/backend/utils/geminiHelper.js
@@ -1,0 +1,151 @@
+const { GoogleGenerativeAI } = require("@google/generative-ai");
+
+/**
+ * Ordered list of fallback Gemini models tried when the primary model
+ * (process.env.GEMINI_MODEL) is unavailable or returns an error.
+ * The env var is prepended at runtime so it is always attempted first.
+ */
+const DEFAULT_CANDIDATE_MODELS = [
+  "models/gemini-2.5-flash",
+  "models/gemini-flash-latest",
+  "models/gemini-2.0-flash",
+];
+
+/**
+ * Determines whether an error is transient and worth retrying (e.g. rate
+ * limits, temporary service unavailability, or network timeouts).
+ *
+ * @param {Error} error
+ * @returns {boolean}
+ */
+function isRetryableError(error) {
+  const status = error?.status || error?.code;
+  return (
+    status === 429 ||
+    status === 503 ||
+    error?.message?.toLowerCase().includes("timeout") ||
+    error?.message?.toLowerCase().includes("network")
+  );
+}
+
+/**
+ * Calls model.generateContent(parts) with exponential-backoff retries for
+ * transient errors.
+ *
+ * @param {object} model          - A Gemini GenerativeModel instance.
+ * @param {Array}  parts          - Content parts array passed to generateContent.
+ * @param {number} [maxRetries=1] - Total attempts before giving up (default: 1 = no retry).
+ * @param {number} [initialDelay=1000] - Base delay in ms for the first retry.
+ * @returns {Promise<object>} The raw Gemini result object.
+ * @throws {Error} Re-throws the last error when all retries are exhausted.
+ */
+async function generateWithRetry(model, parts, maxRetries = 1, initialDelay = 1000) {
+  let lastError;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      return await model.generateContent(parts);
+    } catch (error) {
+      lastError = error;
+
+      // Do not retry non-transient errors (e.g. bad request, auth failures)
+      if (!isRetryableError(error) || attempt === maxRetries - 1) {
+        throw error;
+      }
+
+      const delay = initialDelay * Math.pow(2, attempt);
+      console.warn(
+        `[Gemini Retry] Attempt ${attempt + 1}/${maxRetries} failed. Retrying in ${delay}ms…`
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Tries each candidate Gemini model in order and returns the result from the
+ * first one that succeeds.  The model specified by process.env.GEMINI_MODEL
+ * is always attempted first (if set).
+ *
+ * @param {string} apiKey              - Gemini API key.
+ * @param {Array}  parts               - Content parts array to pass to generateContent.
+ * @param {object} [options={}]        - Optional extra config forwarded to getGenerativeModel
+ *                                       (e.g. { generationConfig, systemInstruction }).
+ * @param {number} [retries=1]         - Attempts per model (1 = no retry, >1 = exponential backoff).
+ * @param {number} [initialDelay=1000] - Base delay in ms used for retry back-off.
+ * @returns {Promise<{ result: object, usedModel: string }>}
+ * @throws {Error} If every candidate model fails.
+ *
+ * @example
+ * const { result, usedModel } = await generateWithFallback(
+ *   process.env.GEMINI_API_KEY,
+ *   [prompt]
+ * );
+ * const text = await result.response.text();
+ */
+async function generateWithFallback(apiKey, parts, options = {}, retries = 1, initialDelay = 1000) {
+  const genAI = new GoogleGenerativeAI(apiKey);
+
+  const candidates = [
+    process.env.GEMINI_MODEL,
+    ...DEFAULT_CANDIDATE_MODELS,
+  ].filter(Boolean);
+
+  let lastErr = null;
+
+  for (const m of candidates) {
+    try {
+      const model = genAI.getGenerativeModel({ model: m, ...options });
+      const result = await generateWithRetry(model, parts, retries, initialDelay);
+      return { result, usedModel: m };
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+
+  throw lastErr || new Error("All Gemini models failed");
+}
+
+/**
+ * Variant of generateWithFallback for chat sessions.  Initialises a chat
+ * with optional history, sends a single message, and returns the raw result.
+ *
+ * @param {string} apiKey               - Gemini API key.
+ * @param {string} prompt               - The user message to send.
+ * @param {Array}  [formattedHistory=[]] - Pre-formatted chat history expected
+ *                                        by the Gemini chat API.
+ * @param {object} [options={}]         - Extra config forwarded to getGenerativeModel.
+ * @returns {Promise<{ result: object, usedModel: string }>}
+ * @throws {Error} If every candidate model fails.
+ */
+async function generateChatWithFallback(apiKey, prompt, formattedHistory = [], options = {}) {
+  const genAI = new GoogleGenerativeAI(apiKey);
+
+  const candidates = [
+    process.env.GEMINI_MODEL,
+    ...DEFAULT_CANDIDATE_MODELS,
+  ].filter(Boolean);
+
+  let lastErr = null;
+
+  for (const m of candidates) {
+    try {
+      const model = genAI.getGenerativeModel({ model: m, ...options });
+      const chat = model.startChat({ history: formattedHistory });
+      const result = await chat.sendMessage(prompt);
+      return { result, usedModel: m };
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+
+  throw lastErr || new Error("All Gemini models failed");
+}
+
+module.exports = {
+  generateWithFallback,
+  generateChatWithFallback,
+  DEFAULT_CANDIDATE_MODELS,
+};


### PR DESCRIPTION
## Summary

The Gemini model fallback loop was duplicated across **6 locations in 5 files**.
This PR extracts it into a single reusable utility at `utils/geminiHelper.js`.

## Changes

### New: `utils/geminiHelper.js`
- `generateWithFallback(apiKey, parts, options?, retries?, initialDelay?)` — tries
  candidate models in order (env var first), with optional exponential-backoff
  retries for transient errors (429, 503, timeout, network)
- `generateChatWithFallback(apiKey, prompt, history?, options?)` — same fallback
  strategy for chat-session endpoints using `startChat` + `sendMessage`

### Updated files
| File | Loops removed |
|------|--------------|
| `controllers/aiController.js` | 3 |
| `controllers/resumeController.js` | 1 |
| `routes/aiRoutes.js` | 1 (chat) |
| `routes/AptitudeQuestions.js` | 1 + local retry helpers |

## Benefits
- ✅ Single source of truth for model list and fallback order
- ✅ Retry logic (previously only in AptitudeQuestions) now available everywhere
- ✅ ~90 lines of boilerplate removed
- ✅ Fallback helper is independently unit-testable

## Testing
All existing behaviour is preserved. No API surface changed.

Closes #435 