### PR TITLE
fix: add upper limit validation for years of experience

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -4,7 +4,7 @@ const mongoose = require("mongoose");
 
 
 const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;;
-
+const MAX_EXPERIENCE = 50;
 
 /**
  * Create a new practice session and associated questions.
@@ -33,7 +33,21 @@ exports.createSession = async (req, res) => {
     try {
         await mongoSession.withTransaction(async () => {
             const userId = req.user._id;
+            const experience = Number(req.body.experience);
+ 
+            if (isNaN(experience)) {
+              return res.status(400).json({
+                    success: false,
+                    message: "Years of experience must be a valid number.",
+           });
+         }
 
+          if (experience < 0 || experience > MAX_EXPERIENCE) {
+             return res.status(400).json({
+                   success: false,
+                   message: `Years of experience must be between 0 and ${MAX_EXPERIENCE}.`,
+             });
+            }
             const sessionCount = await Session.countDocuments({
                 user: userId,
             }).session(mongoSession);

--- a/frontend/src/pages/Home/CreateSessionForm.jsx
+++ b/frontend/src/pages/Home/CreateSessionForm.jsx
@@ -5,6 +5,8 @@ import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
 import { Target, Briefcase, Code2, FileText, Sparkles } from "lucide-react";
 
+const MAX_EXPERIENCE = 50;
+
 const CreateSessionForm = () => {
   const [formData, setFormData] = useState({
     role: "",
@@ -19,11 +21,15 @@ const CreateSessionForm = () => {
   const navigate = useNavigate();
 
   const handleChange = (key, value) => {
-    setFormData((prevData) => ({
-      ...prevData,
-      [key]: value,
-    }));
-  };
+  setFormData((prevData) => ({
+    ...prevData,
+    [key]: value,
+  }));
+
+  if (error) {
+    setError("");
+  }
+   };
 
   const handleCreateSession = async (e) => {
     e.preventDefault();
@@ -33,9 +39,16 @@ const CreateSessionForm = () => {
       setError("Please fill all the required fields.");
       return;
     }
-    if (Number(experience) < 0) {
-  setError("Years of experience cannot be negative.");
-  return;
+   const experienceValue = Number(experience);
+
+if (experienceValue < 0) {
+    setError("Years of experience cannot be negative.");
+    return;
+}
+
+if (experienceValue > MAX_EXPERIENCE) {
+    setError(`Years of experience cannot exceed ${MAX_EXPERIENCE}.`);
+    return;
 }
     
     const topicsArray = topicsToFocus.split(",")
@@ -147,6 +160,7 @@ const CreateSessionForm = () => {
                     <input
                       type={field.type}
                       min={field.type === "number" ? 0 : undefined}
+                      max={field.type === "number" ? MAX_EXPERIENCE : undefined}
                       value={formData[field.id]}
                       onChange={({ target }) => handleChange(field.id, target.value)}
                       placeholder={field.placeholder}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #449 

### Summary
This PR fixes the validation for the **Years of Experience** field while creating a new interview session.

### Changes Made
- Added frontend validation to restrict the experience value between **0 and 50**.
- Added backend validation to prevent invalid values from being submitted through API requests.
- Displayed clear validation messages for invalid experience values.
- Added `max={50}` to the experience input field for better user guidance.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?
- Tested with valid experience values (0–50) and verified session creation works successfully.
- Tested values greater than 50 and confirmed that an appropriate validation error is displayed.
- Tested negative values and confirmed they are rejected.
- Verified backend validation by ensuring invalid requests are also blocked.

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors