### PR TITLE
fix: persist generated interview questions with session

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -67,6 +67,19 @@ exports.createSession = async (req, res) => {
                     session: mongoSession,
                 }
             );
+            const createdQuestions = await Question.insertMany(
+  (req.body.question || []).map((q) => ({
+    session: createdSession[0]._id,
+    question: q.question,
+    answer: q.answer,
+  })),
+  { session: mongoSession }
+);
+createdSession[0].questions = createdQuestions.map((q) => q._id);
+
+await createdSession[0].save({
+  session: mongoSession,
+});
 
             res.status(201).json({
                 success: true,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #425 

### Summary
This PR fixes an issue where newly created interview sessions did not save the AI-generated interview questions to the database.

Previously, the createSession controller only created the Session document. Although questions were generated successfully, corresponding Question documents were never created or linked to the session. As a result, the interview page displayed no questions because the session's questions array remained empty.

This fixes :

Creates Question documents from the generated AI questions.
Associates each question with the newly created session.
Stores the generated question IDs in the session's questions array.
Saves the updated session so that populate("questions") returns the complete interview questions.
---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
-Created a new interview session and verified that AI-generated questions are stored in the Question collection.
-Opened the created session and confirmed that all interview questions are displayed correctly on the interview page.


---

### Screenshots (if applicable)

Before : 
<img width="1917" height="551" alt="Screenshot 2026-07-11 220456" src="https://github.com/user-attachments/assets/951303f7-ef6a-40b0-ad6a-07e2bd9415c8" />

After : 

<img width="1792" height="762" alt="Screenshot 2026-07-15 135350" src="https://github.com/user-attachments/assets/42447f79-998c-4ba5-8394-b902047cdb6e" />

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors