### PR TITLE
fix(security): prevent reverse tabnabbing on external article links

### DIFF
--- a/frontend/src/pages/OpenSource/OSSBlog.jsx
+++ b/frontend/src/pages/OpenSource/OSSBlog.jsx
@@ -217,7 +217,7 @@ const scrollToTop = () => {
                 key={article.id}
                 href={article.url}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3, delay: index * 0.05 }}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #455

### Summary
Fixed a potential Reverse Tabnabbing security vulnerability in the `OSSBlog.jsx` component. Added the missing `rel="noopener noreferrer"` attributes to external article links that use `target="_blank"`. This ensures proper cross-origin isolation and protects the application from potential tab hijacking.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🔥 Other(please describe): Security Vulnerability Fix

---

### How Has This Been Tested?
- Inspected the DOM to confirm that the `rel="noopener noreferrer"` attributes are correctly applied to the targeted `<a>` tags.
- Clicked on the external article links to verify they still open successfully in a new tab.
- Confirmed that the `window.opener` object is nullified in the newly opened tabs, ensuring cross-origin safety.

---

### Screenshots (if applicable)
N/A (This is a background security attribute addition; there are no visual changes to the UI).

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors