### PR TITLE
fix: update username regex to allow alphanumeric characters

### DIFF
--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -180,7 +180,7 @@ const Settings = () => {
     }
   };
   
-  const NAME_REGEX = /^[A-Za-z\s]*$/;
+  const NAME_REGEX = /^[A-Za-z0-9\s]*$/;
    const handleNameChange = (setter) => (e) => {
     const value = e.target.value;
 


### PR DESCRIPTION
### Description
This PR fixes an issue where the username validation regex was too strict, preventing users from adding numbers to their names/usernames (e.g., `johndoe123`) during profile creation or settings updates. 

### Changes
- Updated `NAME_REGEX` in `Settings.jsx` from `/^[A-Za-z\s]*$/` to `/^[A-Za-z0-9\s]*$/`.

### Related Issue
Closes #493 
### Testing Done
- Verified that usernames containing both characters and numbers are now properly accepted and saved on the Settings page.
