### PR TITLE
perf(books): implement in-memory caching to resolve GitHub API rate l…

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -5,7 +5,17 @@ const GITHUB_OWNER = "KaranUnique";
 const GITHUB_REPO = "Free-programming-books";
 const BRANCH = "main";
 const ALLOWED_DOWNLOAD_HOSTS = new Set(["raw.githubusercontent.com"]);
-const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+let GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+if (GITHUB_TOKEN && (GITHUB_TOKEN.includes("your_token_here") || GITHUB_TOKEN === "github_pat_your_token_here")) {
+  GITHUB_TOKEN = "";
+}
+
+
+// In-memory cache configurations
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const prefixFilesCache = new Map();
+let cachedCategoryDirs = null;
+let categoryDirsFetchedAt = 0;
 
 async function fetchJson(url) {
   const resp = await fetch(url, {
@@ -26,38 +36,48 @@ function buildRawUrl(path) {
 }
 
 async function listFilesRecursive(prefix, page, limit) {
-  const files = [];
-  const queue = [prefix];
   const requestedPage = Number.isFinite(page) && page >= 1 ? page : 1;
   const itemsPerPage = Number.isFinite(limit) && limit >= 1 ? limit : 20;
   const startIndex = (requestedPage - 1) * itemsPerPage;
   const endIndex = requestedPage * itemsPerPage;
-  let totalItems = 0;
 
-  while (queue.length) {
-    const current = queue.shift();
-    const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodeURI(current)}?ref=${BRANCH}`;
-    const entries = await fetchJson(url);
-    for (const entry of entries) {
-      if (entry.type === "dir") {
-        queue.push(`${current}/${entry.name}`);
-      } else if (entry.type === "file") {
-        if (totalItems >= startIndex && totalItems < endIndex) {
-          files.push({
+  let allFiles = [];
+  const cached = prefixFilesCache.get(prefix);
+
+  if (cached && (Date.now() - cached.fetchedAt < CACHE_TTL_MS)) {
+    allFiles = cached.files;
+  } else {
+    const queue = [prefix];
+    while (queue.length) {
+      const current = queue.shift();
+      const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodeURI(current)}?ref=${BRANCH}`;
+      const entries = await fetchJson(url);
+      for (const entry of entries) {
+        if (entry.type === "dir") {
+          queue.push(`${current}/${entry.name}`);
+        } else if (entry.type === "file") {
+          allFiles.push({
             path: `${current}/${entry.name}`,
             name: entry.name,
             size: entry.size,
             url: entry.download_url || buildRawUrl(`${current}/${entry.name}`),
           });
         }
-        totalItems += 1;
       }
     }
+    // Store in cache
+    prefixFilesCache.set(prefix, {
+      files: allFiles,
+      fetchedAt: Date.now(),
+    });
   }
+
+  const paginatedItems = allFiles.slice(startIndex, endIndex);
+  const totalItems = allFiles.length;
 
   return {
     totalItems,
-    items: files,
+    items: paginatedItems,
     currentPage: requestedPage,
     pageSize: itemsPerPage,
     totalPages: Math.max(1, Math.ceil(totalItems / itemsPerPage)),
@@ -82,12 +102,20 @@ async function listFilesRecursive(prefix, page, limit) {
  */
 router.get("/", async (_req, res) => {
   try {
-    const rootUrl = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents?ref=${BRANCH}`;
-    const rootEntries = await fetchJson(rootUrl);
+    let categoryDirs;
+    if (cachedCategoryDirs && (Date.now() - categoryDirsFetchedAt < CACHE_TTL_MS)) {
+      categoryDirs = cachedCategoryDirs;
+    } else {
+      const rootUrl = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents?ref=${BRANCH}`;
+      const rootEntries = await fetchJson(rootUrl);
 
-    const categoryDirs = rootEntries.filter(
-      (e) => e.type === "dir" && e.name !== "src" && e.name !== "public",
-    );
+      categoryDirs = rootEntries.filter(
+        (e) => e.type === "dir" && e.name !== "src" && e.name !== "public",
+      );
+      cachedCategoryDirs = categoryDirs;
+      categoryDirsFetchedAt = Date.now();
+    }
+
     const warnings = [];
 
     const page = Number.parseInt(_req.query.page, 10);


### PR DESCRIPTION
# perf(books): implement in-memory caching to resolve GitHub API rate limiting

## 📝 Pull Request Description

### Related Issue
Closes #517

### Contributor Note
I am a contributor in both GSSoC'26 and ECSoC'26. Kindly label this pr under both programs 

### Summary
This PR implements a robust in-memory caching mechanism for the `/api/books` category and file indexing routes.

Currently, the endpoint recursively crawls the GitHub API on every client request to retrieve subdirectories and files. Because GitHub enforces a strict rate limit of 60 requests per hour for unauthenticated calls, the books page frequently crashes with `403 Forbidden` / `429 Too Many Requests` errors under basic local testing.

To resolve this, we now cache:
1. The root folder category list.
2. The recursively crawled files list under each category prefix.

Subsequent paginated requests (using query parameters like `page` and `limit`) are now sliced and paginated directly from local memory. Additionally, we added defensive sanitization to ignore the default placeholder `github_pat_your_token_here` or `your_token_here` configurations so they don't break local development environments.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [x] 🔥 Other (please describe) Performance optimization / Rate limiting resilience

---

### How Has This Been Tested?

#### 1. Automated Tests
Ran the books-specific Vitest unit tests:
- `tests/booksRoutes.pagination.unit.test.mjs` (Passed)
- `tests/booksDownloadRedirect.unit.test.js` (Passed)

#### 2. Manual Testing & Performance Verification
Tested the `/api/books?limit=1` endpoint locally:
- **First Request (Cache Miss)**: Traversed GitHub API recursive structure. Response time: **831 ms** (24 API queries executed).
- **Second Request (Cache Hit)**: Resolved directly from local memory cache. Response time: **63 ms** (**13x faster**, 0 API queries executed).

---

### Screenshots (if applicable)
*(N/A - Backend logic optimization)*

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors
