### PR TITLE
fix : added null guard in getInitials to prevent crash on empty title parts

### DIFF
--- a/frontend/src/utils/helper.js
+++ b/frontend/src/utils/helper.js
@@ -9,6 +9,7 @@ export const getInitials=(title)=>{
     const words = title.split(" ");
     let initials="";
     for(let i=0; i<Math.min(words.length,2);i++){
+        if (!words[i]) continue;
         initials += words[i][0];
     }
 


### PR DESCRIPTION
Closes #529.

Summary of What Has Been Done:
The getInitials utility function was crashing with a TypeError when a title contained empty string parts (e.g., double spaces in 'Hello  World' caused words[i][0] to be called on an empty string). Added a guard to skip empty words.

Changes Made:
- frontend/src/utils/helper.js: Added if (!words[i]) continue; before accessing words[i][0].

Impact it Made:
- Prevents runtime crash on malformed title input
- Build verified: npm run build passes

Note: Please assign this PR to the `tmdeveloper007` account.