### PR TITLE
fix : removed double semicolon in MAX_SESSIONS constant declaration

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -3,7 +3,7 @@ const Question = require("../models/Question");
 const mongoose = require("mongoose");
 
 
-const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;;
+const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;
 const MAX_EXPERIENCE = 50;
 
 /**


### PR DESCRIPTION
Closes #531.

Summary of What Has Been Done:
The MAX_SESSIONS constant in sessionController.js was declared with a double semicolon (;;) at the end. Removed the extra semicolon.

Changes Made:
- backend/controllers/sessionController.js: Changed const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;; to const MAX_SESSIONS = Number(process.env.MAX_SESSIONS) || 50;

Impact it Made:
- Cleaner code that passes stricter linters
- Syntax check passes

Note: Please assign this PR to the `tmdeveloper007` account.