### PR TITLE
fix : allowed empty note to clear question note in ValidateQuestions schema

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -18,7 +18,7 @@ const togglePinQuestionSchema = z.object({
 
 // Schema for updating note
 const updateQuestionNoteSchema = z.object({
-  note: z.string().min(1, "Note cannot be empty"),
+  note: z.string(),
 });
 
 


### PR DESCRIPTION
Closes #532.

Summary of What Has Been Done:
The updateQuestionNoteSchema required the note field to be at least 1 character (z.string().min(1)), preventing users from clearing a saved note. Changed to z.string() so empty strings are accepted.

Changes Made:
- backend/Input_validators/ValidateQuestions.js: Changed z.string().min(1, 'Note cannot be empty') to z.string().

Impact it Made:
- Users can now clear notes they previously saved
- Aligns validator with controller behavior (controller already handles empty strings)
- Syntax check passes

Note: Please assign this PR to the `tmdeveloper007` account.