### PR TITLE
fix : moved deleteResume before module.exports in resumeController

### DIFF
--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -236,8 +236,6 @@ const getMyResumes = async (req, res) => {
     }
 };
 
-module.exports = { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume };
-
 /**
  * Delete a resume by ID (owner only).
  * @route DELETE /api/resume/:id
@@ -251,3 +249,5 @@ async function deleteResume(req, res) {
         return res.status(500).json({ message: "Failed to delete resume.", error: err.message });
     }
 }
+
+module.exports = { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume };


### PR DESCRIPTION
Closes #533.

Summary of What Has Been Done:
The deleteResume function was defined after the module.exports statement in resumeController.js. Moved it before module.exports to follow conventional module structure (implementation before exports).

Changes Made:
- backend/controllers/resumeController.js: Moved the deleteResume function definition and its JSDoc comment to appear before module.exports.

Impact it Made:
- Follows conventional module structure
- Makes code easier to read and maintain
- Syntax check passes

Note: Please assign this PR to the `tmdeveloper007` account.