### PR TITLE
fix(auth): implement automatic access token refresh flow

### DIFF
--- a/backend/Input_validators/ValidateAuth.js
+++ b/backend/Input_validators/ValidateAuth.js
@@ -21,9 +21,7 @@ const loginUserZod = z.object({
   password: z.string().min(8, "Password must be at least 8 characters"),
 });
 
-const refreshTokenZod = z.object({
-  refreshToken: z.string().min(1, "Refresh token is required"),
-});
+
 
 const resendVerificationZod = z.object({
   email: z.string().email("Enter a valid email"),

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -2,7 +2,7 @@ const express = require("express");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
 const { upload } = require("../middlewares/uploadMiddleware");
-const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
+const { validateUserLogin, validateUserSignup, validateResendEmail } = require("../Input_validators/ValidateAuth");
 const router = express.Router();
 
 const {
@@ -15,8 +15,8 @@ const {
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
 router.post("/login", authLimiter, validateUserLogin, loginUser);
-router.post("/refresh", authLimiter,validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, validateRefreshToken, logoutUser);
+router.post("/refresh", authLimiter, refreshToken);
+router.post("/logout", authLimiter, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/backend/tests/authController.tokens.unit.test.js
+++ b/backend/tests/authController.tokens.unit.test.js
@@ -1,55 +1,53 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-vi.mock("../models/User.js", () => ({
-  findById: vi.fn(),
-  findOne: vi.fn(),
-  create: vi.fn(),
-}));
+const { refreshToken, logoutUser } = require("../controllers/authController.js");
+const User = require("../models/User.js");
+const bcrypt = require("bcryptjs");
+const jwt = require("jsonwebtoken");
 
-vi.mock("bcryptjs", () => ({
-  compare: vi.fn(),
-  genSalt: vi.fn().mockResolvedValue("salt"),
-  hash: vi.fn().mockResolvedValue("hashed"),
-}));
+let originalUserFindById;
+let originalBcryptCompare;
+let originalBcryptHash;
+let originalJwtVerify;
+let originalJwtSign;
 
-const mockJwt = {
-  sign: vi.fn(),
-  verify: vi.fn(),
-};
+beforeEach(() => {
+  originalUserFindById = User.findById;
+  originalBcryptCompare = bcrypt.compare;
+  originalBcryptHash = bcrypt.hash;
+  originalJwtVerify = jwt.verify;
+  originalJwtSign = jwt.sign;
 
-vi.mock("jsonwebtoken", () => mockJwt);
-
-let refreshToken;
-let logoutUser;
-let User;
-let bcrypt;
-let jwt;
-
-beforeEach(async () => {
-  vi.resetModules();
-  vi.clearAllMocks();
+  User.findById = vi.fn();
+  bcrypt.compare = vi.fn();
+  bcrypt.hash = vi.fn().mockResolvedValue("hashed");
+  jwt.verify = vi.fn();
+  jwt.sign = vi.fn();
 
   process.env.JWT_SECRET = "test-secret";
+});
 
-  const ctrl = await import("../controllers/authController.js");
-  refreshToken = ctrl.refreshToken ?? ctrl.default?.refreshToken;
-  logoutUser = ctrl.logoutUser ?? ctrl.default?.logoutUser;
+afterEach(() => {
 
-  const UserModule = await import("../models/User.js");
-  User = UserModule.default ?? UserModule;
-
-  const bcryptModule = await import("bcryptjs");
-  bcrypt = bcryptModule.default ?? bcryptModule;
-
-  const jwtModule = await import("jsonwebtoken");
-  jwt = jwtModule.default ?? jwtModule;
+  User.findById = originalUserFindById;
+  bcrypt.compare = originalBcryptCompare;
+  bcrypt.hash = originalBcryptHash;
+  jwt.verify = originalJwtVerify;
+  jwt.sign = originalJwtSign;
 });
 
 function makeRes() {
   const res = {};
   res.status = vi.fn().mockReturnValue(res);
   res.json = vi.fn().mockReturnValue(res);
+  res.cookie = vi.fn().mockReturnValue(res);
+  res.clearCookie = vi.fn().mockReturnValue(res);
   return res;
+}
+
+
+function makeReq(refreshTokenCookieValue) {
+  return { cookies: { refreshToken: refreshTokenCookieValue }, body: {} };
 }
 
 describe("authController refresh-token rotation", () => {
@@ -57,17 +55,18 @@ describe("authController refresh-token rotation", () => {
     const mockUser = {
       _id: "user-123",
       refreshTokenHash: "stored-hash",
+      refreshTokenExpiresAt: new Date(Date.now() + 60_000),
       save: vi.fn().mockResolvedValue(true),
     };
 
     User.findById.mockResolvedValue(mockUser);
     bcrypt.compare.mockResolvedValue(true);
-    jwt.verify.mockReturnValue({ id: "user-123" });
+    jwt.verify.mockReturnValue({ id: "user-123", tokenType: "refresh" });
     jwt.sign
       .mockReturnValueOnce("new-access-token")
       .mockReturnValueOnce("new-refresh-token");
 
-    const req = { body: { refreshToken: "incoming-refresh-token" } };
+    const req = makeReq("incoming-refresh-token");
     const res = makeRes();
 
     await refreshToken(req, res);
@@ -76,15 +75,29 @@ describe("authController refresh-token rotation", () => {
     expect(bcrypt.compare).toHaveBeenCalledWith("incoming-refresh-token", "stored-hash");
     expect(mockUser.refreshTokenHash).toBe("hashed");
     expect(mockUser.save).toHaveBeenCalledOnce();
+    expect(res.cookie).toHaveBeenCalledWith(
+      "refreshToken",
+      "new-refresh-token",
+      expect.objectContaining({ httpOnly: true })
+    );
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({
-        success: true,
-        accessToken: "new-access-token",
-        refreshToken: "new-refresh-token",
-      })
+      expect.objectContaining({ success: true, accessToken: "new-access-token" })
     );
   });
 
+  it("rejects refresh when no refreshToken cookie is present", async () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+
+    await refreshToken(req, res);
+
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+  });
+});
+
+describe("authController logout", () => {
   it("revokes the stored refresh token on logout", async () => {
     const mockUser = {
       _id: "user-123",
@@ -94,9 +107,9 @@ describe("authController refresh-token rotation", () => {
 
     User.findById.mockResolvedValue(mockUser);
     bcrypt.compare.mockResolvedValue(true);
-    jwt.verify.mockReturnValue({ id: "user-123" });
+    jwt.verify.mockReturnValue({ id: "user-123", tokenType: "refresh" });
 
-    const req = { body: { refreshToken: "logout-token" } };
+    const req = makeReq("logout-token");
     const res = makeRes();
 
     await logoutUser(req, res);
@@ -105,8 +118,20 @@ describe("authController refresh-token rotation", () => {
     expect(bcrypt.compare).toHaveBeenCalledWith("logout-token", "stored-hash");
     expect(mockUser.refreshTokenHash).toBeNull();
     expect(mockUser.save).toHaveBeenCalledOnce();
+    expect(res.clearCookie).toHaveBeenCalledWith("refreshToken", expect.any(Object));
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ success: true, message: expect.stringContaining("logged out") })
     );
+  });
+
+  it("rejects logout when no refreshToken cookie is present", async () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+
+    await logoutUser(req, res);
+
+    expect(User.findById).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
   });
 });

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -13,6 +13,7 @@ export const API_PATHS = {
     UPDATE_PROFILE: "/api/auth/profile",
     CHANGE_PASSWORD: "/api/auth/change-password",
     DELETE_ACCOUNT: "/api/auth/delete-account",
+    REFRESH: "/api/auth/refresh", 
     LOGOUT: "/api/auth/logout",
 },
     IMAGE: {

--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { BASE_URL } from "./apiPaths";
+import { BASE_URL, API_PATHS } from "./apiPaths";
 
 const axiosInstance = axios.create({
     baseURL: BASE_URL,
@@ -15,8 +15,8 @@ const axiosInstance = axios.create({
 axiosInstance.interceptors.request.use(
     (config) => {
         const accessToken =
-  localStorage.getItem("token") ||
-  sessionStorage.getItem("token");
+            localStorage.getItem("token") ||
+            sessionStorage.getItem("token");
         if (accessToken) {
             config.headers.Authorization = `Bearer ${accessToken}`;
         }
@@ -27,33 +27,81 @@ axiosInstance.interceptors.request.use(
     }
 );
 
+
+const storeAccessToken = (accessToken) => {
+    if (localStorage.getItem("token") !== null) {
+        localStorage.setItem("token", accessToken);
+    } else {
+        sessionStorage.setItem("token", accessToken);
+    }
+};
+
+const clearSessionAndRedirect = () => {
+    localStorage.removeItem("token");
+    sessionStorage.removeItem("token");
+    window.location.href = "/";
+};
+
+let refreshPromise = null;
+
+const refreshAccessToken = () => {
+    if (!refreshPromise) {
+        refreshPromise = axiosInstance
+            .post(API_PATHS.AUTH.REFRESH) // refreshToken cookie is sent automatically (withCredentials: true)
+            .then((response) => {
+                const newAccessToken = response.data?.accessToken;
+                if (!newAccessToken) {
+                    throw new Error("Refresh response did not include an accessToken");
+                }
+                storeAccessToken(newAccessToken);
+                return newAccessToken;
+            })
+            .finally(() => {
+                refreshPromise = null;
+            });
+    }
+    return refreshPromise;
+};
+
 // Response Interceptor
 axiosInstance.interceptors.response.use(
-    (response)=>{
+    (response) => {
         return response;
     },
-    (error)=>{
-        // handle common error globally
-        if(error.response){
-            if(error.response.status === 401){
-                // Only redirect if this wasn't a login/register attempt itself
-                const url = error.config?.url || "";
-                const isAuthCall = url.includes("/auth/login") || url.includes("/auth/register") || url.includes("/auth/refresh");
-                if (!isAuthCall) {
-                    // Clear expired/invalid session token and redirect
-                    localStorage.removeItem("token");
-                    sessionStorage.removeItem("token");
-                    window.location.href = "/";
+    async (error) => {
+        const originalRequest = error.config;
+
+        if (error.response) {
+            if (error.response.status === 401) {
+                const url = originalRequest?.url || "";
+                const isAuthCall =
+                    url.includes("/auth/login") ||
+                    url.includes("/auth/register") ||
+                    url.includes("/auth/refresh");
+
+                if (!isAuthCall && originalRequest && !originalRequest._retry) {
+                    originalRequest._retry = true;
+                    try {
+                        const newAccessToken = await refreshAccessToken();
+                        originalRequest.headers = originalRequest.headers || {};
+                        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+                        return axiosInstance(originalRequest);
+                    } catch (refreshError) {
+                        clearSessionAndRedirect();
+                        return Promise.reject(refreshError);
+                    }
                 }
-            }
-            else if(error.response.status === 500){
+
+                if (isAuthCall && url.includes("/auth/refresh")) {
+                    clearSessionAndRedirect();
+                }
+            } else if (error.response.status === 500) {
                 console.error("Server error. Please try again later");
             }
-        }
-        else if(error.code === "ECONNABORTED"){
+        } else if (error.code === "ECONNABORTED") {
             console.error("Request timeout. Please try again");
         }
-        return Promise.reject(error);   
+        return Promise.reject(error);
     }
 );
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #524 

### Summary
This PR fixes the authentication token refresh flow by addressing issues in both the frontend and backend.

### Changes Made
- Added automatic access token refresh using an Axios response interceptor.
- Added the missing `REFRESH` API endpoint to `API_PATHS`.
- Implemented automatic retry of the original request after a successful token refresh.
- Prevented multiple simultaneous refresh requests by using a shared refresh promise.
- Removed the incorrect `validateRefreshToken` middleware from the `/refresh` and `/logout` routes since the refresh token is read from an HTTP-only cookie.
- Removed the unused refresh token validation schema from `ValidateAuth.js`.
- Updated the authentication token unit tests to reflect the cookie-based refresh token flow.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other

---

### How Has This Been Tested?

- Reduced the access token expiry time locally to reproduce the issue.
- Verified that protected API requests automatically call `/api/auth/refresh` after the access token expires.
- Confirmed that the original request is retried successfully without forcing the user to log out.
- Verified that logout correctly clears the refresh token and terminates the session.
- Updated and executed the authentication token unit tests for the cookie-based refresh token flow.

---

### Screenshots (if applicable)

N/A (Authentication flow changes)

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary (not required for this change)
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors related to this fix