### PR TITLE
fix : added Redis store support to express-rate-limit for distributed deployments

### DIFF
--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -1,5 +1,29 @@
 const rateLimit = require('express-rate-limit');
 
+// Attempt to load Redis store for distributed deployments.
+// When REDIS_URL is set and rate-limit-redis is installed, rate-limit counters
+// are shared across all instances. Falls back to the default in-memory store
+// when Redis is not configured (single-instance development behavior unchanged).
+let rateLimitStore;
+try {
+    const { RedisStore } = require('rate-limit-redis');
+    if (process.env.REDIS_URL) {
+        const { createClient } = require('redis');
+        const redisClient = createClient({ url: process.env.REDIS_URL });
+        redisClient.on('error', (err) => console.error('[rateLimiter] Redis client error:', err.message));
+        // Connect asynchronously so server startup is not blocked
+        redisClient.connect().catch((err) => console.error('[rateLimiter] Redis connect error:', err.message));
+        rateLimitStore = new RedisStore({ sendUpstreamResponseHeaders: false, prefix: 'rl:' });
+        rateLimitStore.initializeClient({ sendUpstreamResponseHeaders: false });
+        console.log('[rateLimiter] Redis store enabled via REDIS_URL');
+    }
+} catch (err) {
+    // rate-limit-redis not installed or Redis unavailable — use default in-memory store
+    rateLimitStore = undefined;
+}
+
+const storeOption = rateLimitStore ? { store: rateLimitStore } : {};
+
 // Authentication endpoints: 50 login/register attempts per 15 minutes
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -7,6 +31,7 @@ const authLimiter = rateLimit({
     message: { error: 'Too many login/registration attempts, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    ...storeOption,
 });
 
 // AI generation endpoints: 20 requests per hour (to control costs)
@@ -16,6 +41,7 @@ const aiLimiter = rateLimit({
     message: { error: 'AI generation limit reached (20 requests per hour) to prevent API abuse. Please try again later.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    ...storeOption,
 });
 
 // General API endpoints: 100 requests per 15 minutes
@@ -25,6 +51,7 @@ const generalLimiter = rateLimit({
     message: { error: 'Too many requests, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    ...storeOption,
 });
 
 // Sensitive account actions: 10 requests per 15 minutes
@@ -34,6 +61,7 @@ const sensitiveAuthLimiter = rateLimit({
     message: { error: 'Too many sensitive account action attempts, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    ...storeOption,
 });
 
 module.exports = {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,39 +1,41 @@
 {
-  "name": "backend",
-  "version": "1.0.0",
-  "main": "index.js",
-  "scripts": {
-    "start": "node server.js",
-    "dev": "nodemon server.js",
-    "test": "vitest run"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
-  "dependencies": {
-    "@google/genai": "^1.16.0",
-    "@google/generative-ai": "^0.21.0",
-    "axios": "^1.13.6",
-    "bcryptjs": "^3.0.2",
-    "cookie-parser": "^1.4.7",
-    "cors": "^2.8.5",
-    "dotenv": "^17.2.1",
-    "express": "^5.1.0",
-    "express-rate-limit": "^8.2.1",
-    "form-data": "^4.0.5",
-    "joi": "^18.0.2",
-    "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.18.0",
-    "multer": "^2.0.2",
-    "node-cache": "^5.1.2",
-    "nodemailer": "^8.0.10",
-    "pdf-parse": "^2.4.5",
-    "resend": "^6.12.4",
-    "zod": "^4.4.3"
-  },
-  "devDependencies": {
-    "nodemon": "^3.1.10",
-    "vitest": "^4.1.9"
-  }
+    "name": "backend",
+    "version": "1.0.0",
+    "main": "index.js",
+    "scripts": {
+        "start": "node server.js",
+        "dev": "nodemon server.js",
+        "test": "vitest run"
+    },
+    "keywords": [],
+    "author": "",
+    "license": "ISC",
+    "description": "",
+    "dependencies": {
+        "@google/genai": "^1.16.0",
+        "@google/generative-ai": "^0.21.0",
+        "axios": "^1.13.6",
+        "bcryptjs": "^3.0.2",
+        "cookie-parser": "^1.4.7",
+        "cors": "^2.8.5",
+        "dotenv": "^17.2.1",
+        "express": "^5.1.0",
+        "express-rate-limit": "^8.2.1",
+        "form-data": "^4.0.5",
+        "joi": "^18.0.2",
+        "jsonwebtoken": "^9.0.2",
+        "mongoose": "^8.18.0",
+        "multer": "^2.0.2",
+        "node-cache": "^5.1.2",
+        "nodemailer": "^8.0.10",
+        "pdf-parse": "^2.4.5",
+        "resend": "^6.12.4",
+        "zod": "^4.4.3",
+        "rate-limit-redis": "^4.2.0",
+        "redis": "^5.0.0"
+    },
+    "devDependencies": {
+        "nodemon": "^3.1.10",
+        "vitest": "^4.1.9"
+    }
 }


### PR DESCRIPTION
## Summary of What Has Been Done
Added Redis store support to `backend/middlewares/rateLimiter.js` for distributed deployments. When `REDIS_URL` is set and `rate-limit-redis` is installed, the rate-limit store is swapped from the default in-memory store to a shared Redis store, ensuring rate limiting is consistent across all instances.

## Changes Made
- Added conditional Redis store initialization via `rate-limit-redis` package
- Falls back to default in-memory store when `REDIS_URL` is not set (zero breaking change for single-instance setups)
- Added `rate-limit-redis` and `redis` as required dependencies to `backend/package.json`

## Impact it Made
- Rate limiting is now consistent across multiple pods/instances
- Prevents clients from circumventing rate limits by hitting different instances
- No breaking change for existing single-instance deployments

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #541