### PR TITLE
fix : added refresh token reuse-detection grace window to prevent token theft replay

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -146,6 +146,7 @@ const loginUser = async (req, res) => {
 
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
+        user.refreshTokenReuseDetected = false;
         await user.save();
         res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         res.json({
@@ -187,20 +188,41 @@ const refreshToken = async (req, res) => {
             return res.status(401).json({ success: false, message: "User not found." });
         }
 
+        // If reuse was previously detected, deny all refresh attempts until user re-logs in.
+        if (user.refreshTokenReuseDetected) {
+            return res.status(401).json({ success: false, message: "Token reuse detected. Please log in again." });
+        }
+
         if (!user.refreshTokenHash || !user.refreshTokenExpiresAt || new Date(user.refreshTokenExpiresAt) < new Date()) {
             user.refreshTokenHash = null;
             user.refreshTokenExpiresAt = null;
+            user.refreshTokenIssuedAt = null;
             await user.save();
             return res.status(401).json({ success: false, message: "Refresh token has expired. Please log in again." });
         }
 
         const refreshIsValid = await bcrypt.compare(incomingRefreshToken, user.refreshTokenHash);
         if (!refreshIsValid) {
+            // Token does not match stored hash. Check if this is reuse after rotation
+            // (the same raw token was presented after it was already rotated).
+            // Detection: the incoming token's `iat` does not match the stored `refreshTokenIssuedAt`.
+            if (user.refreshTokenIssuedAt && decoded.iat && decoded.iat < user.refreshTokenIssuedAt) {
+                user.refreshTokenReuseDetected = true;
+                user.refreshTokenHash = null;
+                user.refreshTokenExpiresAt = null;
+                user.refreshTokenIssuedAt = null;
+                await user.save();
+                return res.status(401).json({ success: false, message: "Refresh token reuse detected. Please log in again." });
+            }
             user.refreshTokenHash = null;
             user.refreshTokenExpiresAt = null;
+            user.refreshTokenIssuedAt = null;
             await user.save();
             return res.status(401).json({ success: false, message: "Refresh token has been revoked. Please log in again." });
         }
+
+        // Record the iat of this token so future uses can be detected as reuse.
+        user.refreshTokenIssuedAt = decoded.iat;
 
         const accessToken = generateAccessToken(user._id);
         const rotatedRefreshToken = generateRefreshToken(user._id);
@@ -246,6 +268,7 @@ const logoutUser = async (req, res) => {
             if (!refreshIsValid) {
                 user.refreshTokenHash = null;
                 user.refreshTokenExpiresAt = null;
+                user.refreshTokenIssuedAt = null;
                 await user.save();
                 return res.status(401).json({ success: false, message: "Refresh token has already been revoked." });
             }
@@ -253,6 +276,7 @@ const logoutUser = async (req, res) => {
 
         user.refreshTokenHash = null;
         user.refreshTokenExpiresAt = null;
+        user.refreshTokenIssuedAt = null;
         await user.save();
 
         res.clearCookie("refreshToken", { path: "/api/auth" });

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -9,6 +9,12 @@ const UserSchema = new mongoose.Schema(
         profileImageUrl: { type: String, default: null },
         refreshTokenHash: { type: String, default: null },
         refreshTokenExpiresAt: { type: Date, default: null },
+        // Tracks the `iat` of the currently active refresh token.
+        // If a refresh token with a different `iat` is presented, it indicates reuse
+        // after rotation (potential token theft) and triggers revocation.
+        refreshTokenIssuedAt: { type: Number, default: null },
+        // Set to true when reuse is detected; all refresh attempts fail until login.
+        refreshTokenReuseDetected: { type: Boolean, default: false },
         
         // Basic Info
         firstName: { type: String, default: "" },


### PR DESCRIPTION
## Summary of What Has Been Done
Added refresh token reuse detection to `backend/controllers/authController.js` and `backend/models/User.js` to detect and halt token theft/replay attacks.

## Changes Made
- `backend/models/User.js`: Added two new fields: `refreshTokenIssuedAt` (records the `iat` of the currently active refresh token) and `refreshTokenReuseDetected` (boolean flag set to true when reuse is detected).
- `backend/controllers/authController.js`:
  - `refreshToken` function: after successful token validation, records `decoded.iat` in `refreshTokenIssuedAt`. On the next refresh attempt, if the incoming token's `iat` is older than `refreshTokenIssuedAt`, reuse is detected, `refreshTokenReuseDetected` is set to true, and all tokens are revoked.
  - `refreshToken` function: if `refreshTokenReuseDetected` is already true, all refresh attempts are denied until the user logs in again.
  - `loginUser` function: resets `refreshTokenReuseDetected = false` on successful login.
  - `logoutUser` function: clears `refreshTokenIssuedAt` alongside other token fields.

## Impact it Made
- Detects and halts refresh token theft/replay attacks
- When reuse is detected, the account is locked from refresh attempts until re-authentication
- Aligns with OAuth 2.0 token rotation security best practices

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #543