### PR TITLE
fix : correct off-by-one indexing in isContextualResponse history check

### DIFF
--- a/backend/utils/domainClassifier.js
+++ b/backend/utils/domainClassifier.js
@@ -57,9 +57,9 @@ const isContextualResponse = (prompt, history) => {
   
   if (contextualRegex.test(trimmed)) {
     // Only contextual if there's a previous assistant message
-    if (history && history.length > 0) {
-      const lastMessage = history[history.length - 1];
-      if (lastMessage.role === "model") {
+    if (history && history.length > 1) {
+      const lastMessage = history[history.length - 2];
+      if (lastMessage && lastMessage.role === "model") {
         return true;
       }
     }


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed an off-by-one error in the `isContextualResponse` function in `backend/utils/domainClassifier.js`.

The function checks `history[history.length - 1]` to verify that the last message in history is from the model before treating the user's current prompt as contextual. However, the last message in the array IS the user's current prompt. The function should check `history[history.length - 2]` (the second-to-last message) to determine whether the assistant previously asked a question that the user is now answering.

## Changes Made

Changed `history.length - 1` to `history.length - 2` and added a null guard before accessing `lastMessage.role`:

```js
// BEFORE
const lastMessage = history[history.length - 1];
if (lastMessage.role === "model") {

// AFTER
const lastMessage = history[history.length - 2];
if (lastMessage && lastMessage.role === "model") {
```

## Impact it Made

- Correctly identifies contextual user responses (yes, no, ok, etc.) when the assistant has asked a follow-up question
- Prevents false negatives where contextual responses are incorrectly rejected
- Makes the PrepPilot domain guard more accurate

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #561