### PR TITLE
fix : allow empty string for note field in updateQuestionNoteSchema

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -18,7 +18,7 @@ const togglePinQuestionSchema = z.object({
 
 // Schema for updating note
 const updateQuestionNoteSchema = z.object({
-  note: z.string().min(1, "Note cannot be empty"),
+  note: z.string(),
 });
 
 


### PR DESCRIPTION
## Summary of What Has Been Done

Updated the `updateQuestionNoteSchema` in `backend/Input_validators/ValidateQuestions.js` to remove the `.min(1)` constraint on the `note` field, allowing empty strings to clear a question's note.

## Changes Made

```js
// BEFORE
note: z.string().min(1, "Note cannot be empty"),

// AFTER
note: z.string(),
```

## Impact it Made

- Allows users to clear a question note by sending an empty string
- Aligns the validator with the controller's intended behavior (`note || ""`)
- No security or functional risk since empty strings are a valid note value

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #562