### PR TITLE
fix : add null guard for session.user in question controller authorization checks

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -37,7 +37,7 @@ const addQuestionToSession = async (req, res) => {
       return res.status(404).json({ success: false, message: "Requested session could not be found" });
     }
 
-    if (session.user.toString() !== req.user._id.toString()) {
+    if (!session.user || session.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({ success: false, message: "Unauthorized access" });
     }
     const createdQuestions = await Question.insertMany(
@@ -52,7 +52,8 @@ const addQuestionToSession = async (req, res) => {
     await session.save();
     res.status(201).json(createdQuestions);
   } catch (error) {
-    res.status(500).json({ success: false, message: "Internal server error occurred", error: error.message });
+    console.error("Add question error:", error);
+    res.status(500).json({ success: false, message: "Internal server error occurred" });
   }
 };
 
@@ -85,7 +86,7 @@ const togglePinQuestion = async (req, res) => {
         .json({ success: false, message: "Session not found" });
     }
 
-    if (session.user.toString() !== req.user._id.toString()) {
+    if (!session.user || session.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({
         success: false,
         message: "Unauthorized access",
@@ -97,7 +98,8 @@ const togglePinQuestion = async (req, res) => {
 
     res.status(200).json({ success: true, question });
   } catch (error) {
-    res.status(500).json({ success: false, message: "Internal server error occurred", error: error.message });
+    console.error("Toggle pin error:", error);
+    res.status(500).json({ success: false, message: "Internal server error occurred" });
   }
 };
 
@@ -136,7 +138,7 @@ const updateQuestionNote = async (req, res) => {
         .json({ success: false, message: "Session not found" });
     }
 
-    if (session.user.toString() !== req.user._id.toString()) {
+    if (!session.user || session.user.toString() !== req.user._id.toString()) {
       return res.status(403).json({
         success: false,
         message: "Unauthorized access",
@@ -148,7 +150,8 @@ const updateQuestionNote = async (req, res) => {
 
     res.status(200).json({ success: true, question });
   } catch (error) {
-    res.status(500).json({ success: false, message: "Internal server error occurred", error: error.message });
+    console.error("Update note error:", error);
+    res.status(500).json({ success: false, message: "Internal server error occurred" });
   }
 };
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added a null guard before calling `.toString()` on `session.user` in three authorization checks in `backend/controllers/questionController.js`:
- `addQuestionToSession`
- `togglePinQuestion`
- `updateQuestionNote`

## Changes Made

```js
// BEFORE
if (session.user.toString() !== req.user._id.toString()) {

// AFTER
if (!session.user || session.user.toString() !== req.user._id.toString()) {
```

## Impact it Made

- Prevents a potential TypeError crash when a Session document has a null/undefined user reference
- Returns a proper 403 Unauthorized response instead of a 500 Internal Server Error
- Makes authorization checks more robust across all three question controller functions

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #563