### PR TITLE
fix : use conditional field updates in saveProgress to avoid unintended field clears

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -50,6 +50,13 @@ exports.saveProgress = async (req, res) => {
 
   const validatedSheetId = sheetId.trim();
 
+  // Build update fields only for fields that are explicitly defined in the request.
+  // This prevents $set from clearing fields when a client sends a partial payload.
+  const updateFields = {};
+  if (followed !== undefined) updateFields.followed = followed;
+  if (completedTopics !== undefined) updateFields.completedTopics = completedTopics;
+  if (percentage !== undefined) updateFields.percentage = percentage;
+
   try {
     const progress = await UserSheetProgress.findOneAndUpdate(
       {
@@ -57,11 +64,7 @@ exports.saveProgress = async (req, res) => {
         sheetId: validatedSheetId,
       },
       {
-        $set: {
-          followed,
-          completedTopics,
-          percentage,
-        },
+        $set: updateFields,
       },
       {
         upsert: true,


### PR DESCRIPTION
## Summary of What Has Been Done

Changed the `saveProgress` function in `backend/controllers/userSheetProgressController.js` to use conditional field updates instead of unconditionally `$set`-ing all fields.

## Changes Made

The `$set` object now only includes fields that are explicitly defined in the request body:

```js
// Build update fields only for fields that are explicitly defined
const updateFields = {};
if (followed !== undefined) updateFields.followed = followed;
if (completedTopics !== undefined) updateFields.completedTopics = completedTopics;
if (percentage !== undefined) updateFields.percentage = percentage;

await UserSheetProgress.findOneAndUpdate(..., { $set: updateFields }, ...);
```

## Impact it Made

- Prevents unintended field overwrites when clients send partial update payloads
- Makes the API more predictable for partial PATCH-style updates
- Aligns behavior with REST best practices for selective field updates

## Note

Please assign this PR to the `tmdeveloper007` account.

Closes #564