### PR TITLE
fix: remove debug console.log statements from upload middleware file filter

### DIFF
--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -34,9 +34,6 @@ const diskStorage = multer.diskStorage({
 
 // File filter for image uploads
 const imageFileFilter = (req, file, cb) => {
-  console.log("FILE:", file.originalname);
-  console.log("MIMETYPE:", file.mimetype);
-
   const allowedTypes = [
     "image/jpeg",
     "image/png",
@@ -47,7 +44,6 @@ const imageFileFilter = (req, file, cb) => {
   if (allowedTypes.includes(file.mimetype)) {
     cb(null, true);
   } else {
-    console.log("REJECTED:", file.mimetype);
     cb(new Error(`Unsupported type: ${file.mimetype}`), false);
   }
 };


### PR DESCRIPTION
### Summary of What Has Been Done

Removed three debug `console.log` statements from the `imageFileFilter` function in `backend/middlewares/uploadMiddleware.js`:
- Removed `console.log("FILE:", file.originalname);`
- Removed `console.log("MIMETYPE:", file.mimetype);`
- Removed `console.log("REJECTED:", file.mimetype);`

### Changes Made

- Deleted 4 lines (3 console.log calls + 1 blank line) from `backend/middlewares/uploadMiddleware.js`

### Impact it Made

- Cleaner production logs without noisy debug output on every file upload
- No information leakage about file metadata in server logs
- Consistent with how other file filter functions in the codebase behave

Note: Please assign this PR to the `tmdeveloper007` account.