### PR TITLE
fix: remove emoji from SkillAssessment coming soon page

### DIFF
--- a/frontend/src/components/SkillAssessment.jsx
+++ b/frontend/src/components/SkillAssessment.jsx
@@ -30,7 +30,7 @@ export default function SkillAssessmentComingSoon() {
           </div>
           <div className="mt-8">
             <span className="inline-block bg-purple-600 text-white px-6 py-3 rounded-full font-semibold text-lg shadow">
-              🚀 Stay tuned for launch!
+              Stay tuned for launch!
             </span>
           </div>
         </div>


### PR DESCRIPTION
### Summary of What Has Been Done

Removed the rocket emoji (🚀) from the "Stay tuned for launch!" message in `frontend/src/components/SkillAssessment.jsx`.

### Changes Made

- Replaced "🚀 Stay tuned for launch!" with "Stay tuned for launch!" in `frontend/src/components/SkillAssessment.jsx`

### Impact it Made

- Consistent codebase with no emoji usage per project guidelines
- Better compatibility with text-only environments

Note: Please assign this PR to the `tmdeveloper007` account.