### PR TITLE
fix: add missing console.error logging in getSessionById error handler

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -167,6 +167,7 @@ exports.getSessionById = async (req, res) => {
     }
     res.status(200).json({ success:true , session })
   } catch (error) {
+    console.error("Error in getSessionById:", error);
     res.status(500).json({ success: false, message: "Server Error" });
   }
 };


### PR DESCRIPTION
### Summary of What Has Been Done

Added `console.error("Error in getSessionById:", error);` to the catch block of the `getSessionById` function in `backend/controllers/sessionController.js`. All other handler functions in the same file already log errors consistently.

### Changes Made

- Added 1 line: `console.error("Error in getSessionById:", error);` to the catch block of `getSessionById` in `backend/controllers/sessionController.js`

### Impact it Made

- Consistent error logging across all controller handlers in the file
- Easier production debugging when session fetch failures occur

Note: Please assign this PR to the `tmdeveloper007` account.