### PR TITLE
fix : replaced err.message with generic error in achievement controller

### DIFF
--- a/backend/controllers/achievementController.js
+++ b/backend/controllers/achievementController.js
@@ -7,14 +7,14 @@ exports.getAchievements = async (req, res) => {
         if (!user) return res.status(404).json({ success: false, error: 'User not found' });
         res.json({ success: true, unlockedAchievements: user.unlockedAchievements });
     } catch (err) {
-        res.status(500).json({ success: false, error: err.message });
+        res.status(500).json({ success: false, error: 'Internal server error occurred' });
     }
 };
 
 exports.saveAchievements = async (req, res) => {
     const { unlockedAchievements } = req.body;
 
-        if (!unlockedAchievements || !Array.isArray(unlockedAchievements)) {
+    if (!unlockedAchievements || !Array.isArray(unlockedAchievements)) {
         return res.status(400).json({
             success: false,
             error: "unlockedAchievements must be a valid array"
@@ -40,6 +40,6 @@ exports.saveAchievements = async (req, res) => {
         );
         res.json({ success: true });
     } catch (err) {
-        res.status(500).json({ success: false, error: err.message });
+        res.status(500).json({ success: false, error: 'Internal server error occurred' });
     }
 };


### PR DESCRIPTION
Closes #581

## Summary of What Has Been Done

Replaced `err.message` with a generic error message in both `catch` blocks of `backend/controllers/achievementController.js` to prevent internal error details from leaking to API clients.

## Changes Made

In both `getAchievements` and `saveAchievements` catch blocks, replaced:
```js
res.status(500).json({ success: false, error: err.message });
```
with:
```js
res.status(500).json({ success: false, error: 'Internal server error occurred' });
```

## Impact it Made

- Improved security: internal error details (stack traces, MongoDB errors) no longer exposed to API clients
- Consistent error response format across the achievement API

Note: Please assign this PR to the `tmdeveloper007` account.