### PR TITLE
fix : removed debug console.log from jobController refreshJobCache

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -91,7 +91,6 @@ exports.refreshJobCache = async () => {
         { jobs, fetchedAt: new Date() },
         { upsert: true, new: true }
       );
-      console.log(`[JobCron] Refreshed cache for: ${role}`);
     }
   } catch (err) {
     console.error("[JobCron] Refresh failed:", err.message);


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the debug `console.log` statement from `backend/controllers/jobController.js` that logged each role being refreshed during the cron job cache refresh cycle.

## Changes Made
- Removed `console.log(`[JobCron] Refreshed cache for: ${role}`);` in the refreshJobCache function
- No functional changes to job caching logic

## Impact it Made
- Reduces log verbosity during background cron job execution
- Prevents potential log spam when many roles exist in the system
- Cleaner production-ready cron handler

## Note: Please assign this PR to the `tmdeveloper007` account.
Closes #590