### PR TITLE
perf(backend): optimize books directory traversal using git trees API

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -16,6 +16,8 @@ const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 const prefixFilesCache = new Map();
 let cachedCategoryDirs = null;
 let categoryDirsFetchedAt = 0;
+let cachedGitTree = null;
+let gitTreeFetchedAt = 0;
 
 async function fetchJson(url) {
   const resp = await fetch(url, {
@@ -35,6 +37,23 @@ function buildRawUrl(path) {
   return `https://raw.githubusercontent.com/${GITHUB_OWNER}/${GITHUB_REPO}/${BRANCH}/${encodeURI(path)}`;
 }
 
+async function getGitTree() {
+  if (cachedGitTree && (Date.now() - gitTreeFetchedAt < CACHE_TTL_MS)) {
+    return cachedGitTree;
+  }
+
+  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/trees/${BRANCH}?recursive=1`;
+  const response = await fetchJson(url);
+
+  if (response && Array.isArray(response.tree)) {
+    cachedGitTree = response.tree;
+    gitTreeFetchedAt = Date.now();
+    return cachedGitTree;
+  }
+
+  throw new Error("Invalid Git Trees response");
+}
+
 async function listFilesRecursive(prefix, page, limit) {
   const requestedPage = Number.isFinite(page) && page >= 1 ? page : 1;
   const itemsPerPage = Number.isFinite(limit) && limit >= 1 ? limit : 20;
@@ -42,34 +61,58 @@ async function listFilesRecursive(prefix, page, limit) {
   const endIndex = requestedPage * itemsPerPage;
 
   let allFiles = [];
-  const cached = prefixFilesCache.get(prefix);
+  let tree = cachedGitTree;
 
-  if (cached && (Date.now() - cached.fetchedAt < CACHE_TTL_MS)) {
-    allFiles = cached.files;
+  if (!tree) {
+    try {
+      tree = await getGitTree();
+    } catch (err) {
+      // Ignore tree fetch failure; it will fall back to legacy queue
+    }
+  }
+
+  if (tree && Array.isArray(tree)) {
+    const categoryFiles = tree.filter(
+      (e) => e.type === "blob" && (e.path === prefix || e.path.startsWith(`${prefix}/`))
+    );
+
+    allFiles = categoryFiles.map((e) => ({
+      path: e.path,
+      name: e.path.split("/").pop(),
+      size: e.size,
+      url: buildRawUrl(e.path),
+    }));
   } else {
-    const queue = [prefix];
-    while (queue.length) {
-      const current = queue.shift();
-      const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodeURI(current)}?ref=${BRANCH}`;
-      const entries = await fetchJson(url);
-      for (const entry of entries) {
-        if (entry.type === "dir") {
-          queue.push(`${current}/${entry.name}`);
-        } else if (entry.type === "file") {
-          allFiles.push({
-            path: `${current}/${entry.name}`,
-            name: entry.name,
-            size: entry.size,
-            url: entry.download_url || buildRawUrl(`${current}/${entry.name}`),
-          });
+    const cached = prefixFilesCache.get(prefix);
+    if (cached && (Date.now() - cached.fetchedAt < CACHE_TTL_MS)) {
+      allFiles = cached.files;
+    } else {
+      const queue = [prefix];
+      while (queue.length) {
+        const current = queue.shift();
+        const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodeURI(current)}?ref=${BRANCH}`;
+        const entries = await fetchJson(url);
+        if (!Array.isArray(entries)) {
+          break;
+        }
+        for (const entry of entries) {
+          if (entry.type === "dir") {
+            queue.push(`${current}/${entry.name}`);
+          } else if (entry.type === "file") {
+            allFiles.push({
+              path: `${current}/${entry.name}`,
+              name: entry.name,
+              size: entry.size,
+              url: entry.download_url || buildRawUrl(`${current}/${entry.name}`),
+            });
+          }
         }
       }
+      prefixFilesCache.set(prefix, {
+        files: allFiles,
+        fetchedAt: Date.now(),
+      });
     }
-    // Store in cache
-    prefixFilesCache.set(prefix, {
-      files: allFiles,
-      fetchedAt: Date.now(),
-    });
   }
 
   const paginatedItems = allFiles.slice(startIndex, endIndex);
@@ -103,17 +146,36 @@ async function listFilesRecursive(prefix, page, limit) {
 router.get("/", async (_req, res) => {
   try {
     let categoryDirs;
-    if (cachedCategoryDirs && (Date.now() - categoryDirsFetchedAt < CACHE_TTL_MS)) {
-      categoryDirs = cachedCategoryDirs;
-    } else {
-      const rootUrl = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents?ref=${BRANCH}`;
-      const rootEntries = await fetchJson(rootUrl);
+    let treeData = null;
 
-      categoryDirs = rootEntries.filter(
-        (e) => e.type === "dir" && e.name !== "src" && e.name !== "public",
-      );
-      cachedCategoryDirs = categoryDirs;
-      categoryDirsFetchedAt = Date.now();
+    try {
+      treeData = await getGitTree();
+    } catch (err) {
+      console.warn("[books] Failed to fetch git tree, trying contents fallback:", err.message);
+    }
+
+    if (treeData && Array.isArray(treeData)) {
+      categoryDirs = treeData
+        .filter(
+          (e) => e.type === "tree" && !e.path.includes("/") && e.path !== "src" && e.path !== "public"
+        )
+        .map((e) => ({
+          name: e.path,
+          type: "dir",
+        }));
+    } else {
+      if (cachedCategoryDirs && (Date.now() - categoryDirsFetchedAt < CACHE_TTL_MS)) {
+        categoryDirs = cachedCategoryDirs;
+      } else {
+        const rootUrl = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents?ref=${BRANCH}`;
+        const rootEntries = await fetchJson(rootUrl);
+
+        categoryDirs = rootEntries.filter(
+          (e) => e.type === "dir" && e.name !== "src" && e.name !== "public",
+        );
+        cachedCategoryDirs = categoryDirs;
+        categoryDirsFetchedAt = Date.now();
+      }
     }
 
     const warnings = [];

--- a/backend/tests/booksRoutes.pagination.unit.test.mjs
+++ b/backend/tests/booksRoutes.pagination.unit.test.mjs
@@ -42,3 +42,33 @@ describe("listFilesRecursive pagination", () => {
     expect(result.items[0].name).toBe("c.txt");
   });
 });
+
+describe("listFilesRecursive using Git Trees API", () => {
+  it("processes Git Trees API correctly and filters files in-memory", async () => {
+    const sampleTreeResponse = {
+      tree: [
+        { type: "blob", path: "category/a.txt", size: 10 },
+        { type: "blob", path: "category/b.txt", size: 20 },
+        { type: "tree", path: "category/sub", size: 0 },
+        { type: "blob", path: "other/c.txt", size: 30 },
+      ]
+    };
+
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      json: async () => sampleTreeResponse,
+      text: async () => "",
+    })));
+
+    const result = await listFilesRecursive("category", 1, 5);
+
+    expect(result.totalItems).toBe(2);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[0].path).toBe("category/a.txt");
+    expect(result.items[0].name).toBe("a.txt");
+    expect(result.items[0].size).toBe(10);
+    expect(result.items[1].path).toBe("category/b.txt");
+    expect(result.items[1].name).toBe("b.txt");
+    expect(result.items[1].size).toBe(20);
+  });
+});


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #597

### Summary
Replaced the recursive GitHub `/contents/{path}` directory traversal with the GitHub Git Trees API (`/git/trees/main?recursive=1`). This reduces the number of GitHub API requests from dozens to a single request, significantly improving response time and preventing API rate-limit issues while preserving the existing API response and pagination behavior.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [x] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?

- Verified that the `/api/books` endpoint returns the same response structure and pagination as before.
- Tested with a cold cache to ensure only a single GitHub API request is made.
- Confirmed that nested directories and book files are correctly parsed from the Git Trees API response.
- Compared the output with the previous implementation to ensure no functional regressions.

---

### Screenshots (if applicable)

N/A (Backend change)

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors