### PR TITLE
fix(frontend): retrieve accurate reading time from dev.to API

### DIFF
--- a/frontend/src/pages/OpenSource/OSSBlog.jsx
+++ b/frontend/src/pages/OpenSource/OSSBlog.jsx
@@ -97,13 +97,6 @@ const scrollToTop = () => {
     return `${Math.ceil(diffDays / 365)} years ago`;
   };
 
-  const calculateReadTime = (content) => {
-    if (!content) return 1;
-    const wordsPerMinute = 200;
-    const wordCount = content.split(/\s+/).length;
-    return Math.max(1, Math.ceil(wordCount / wordsPerMinute));
-  };
-
   return (
     <div ref={scrollRef}  className="h-screen overflow-y-auto bg-gray-50 dark:bg-[#0f172a]">
        {showScrollTop && (
@@ -295,7 +288,7 @@ const scrollToTop = () => {
                       </div>
                       <div className="flex items-center gap-1.5">
                         <span>
-                          📖 {calculateReadTime(article.body_markdown)} min
+                          📖 {article.reading_time_minutes || 1} min
                         </span>
                       </div>
                     </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #599

### Summary
This PR fixes the incorrect reading time displayed for articles in the OSS Learning Hub. The previous implementation attempted to calculate reading time using `article.body_markdown`, which is not included in the Dev.to articles list API response, causing every article to display `1 min`. The component now uses the API-provided `reading_time_minutes` field for accurate reading time and removes the unused `calculateReadTime` utility.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Refactoring
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?

- Built the React application successfully using `npm run build`.
- Verified that articles now display the correct reading time using the `reading_time_minutes` field from the Dev.to API instead of always showing `1 min`.

---

### Screenshots (if applicable)

N/A (Minor frontend logic change)

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors
```