### PR TITLE
fix : replaced err.message with generic error in achievement controller error responses

### DIFF
--- a/backend/controllers/achievementController.js
+++ b/backend/controllers/achievementController.js
@@ -7,7 +7,7 @@ exports.getAchievements = async (req, res) => {
         if (!user) return res.status(404).json({ success: false, error: 'User not found' });
         res.json({ success: true, unlockedAchievements: user.unlockedAchievements });
     } catch (err) {
-        res.status(500).json({ success: false, error: err.message });
+        res.status(500).json({ success: false, error: 'Internal server error' });
     }
 };
 
@@ -40,6 +40,6 @@ exports.saveAchievements = async (req, res) => {
         );
         res.json({ success: true });
     } catch (err) {
-        res.status(500).json({ success: false, error: err.message });
+        res.status(500).json({ success: false, error: 'Internal server error' });
     }
 };


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced instances of `error: err.message` in 500 error responses within `backend/controllers/achievementController.js` with a generic error message `'Internal server error'`.

## Changes Made
- Replaced `error: err.message` with `error: 'Internal server error'` in the catch blocks of `getAchievements` and `saveAchievements` functions

## Impact it Made
- Prevents internal error details from being exposed to API clients
- Improves security posture by not leaking MongoDB or validation error messages

Closes #602

## Note: Please assign this PR to the `tmdeveloper007` account.
