### PR TITLE
fix : replaced err.message with generic error in userSheetProgressController error responses

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -17,7 +17,7 @@ exports.getAllProgress = async (req, res) => {
   } catch (err) {
     res.status(500).json({
       success: false,
-      error: err.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -90,14 +90,14 @@ exports.saveProgress = async (req, res) => {
       } catch (retryErr) {
         return res.status(500).json({
           success: false,
-          error: retryErr.message,
+          error: 'Internal server error',
         });
       }
     }
 
     return res.status(500).json({
       success: false,
-      error: err.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -137,7 +137,7 @@ exports.getProgress = async (req, res) => {
   } catch (err) {
     res.status(500).json({
       success: false,
-      error: err.message,
+      error: 'Internal server error',
     });
   }
 };


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced instances of `error: err.message` in 500 error responses within `backend/controllers/userSheetProgressController.js` with a generic error message `'Internal server error'`.

## Changes Made
- Replaced `error: err.message` with `error: 'Internal server error'` in all catch blocks of `getAllProgress`, `saveProgress`, and `getProgress` functions

## Impact it Made
- Prevents internal error details from being exposed to API clients
- Improves security by not leaking MongoDB or internal error messages

Closes #603

## Note: Please assign this PR to the `tmdeveloper007` account.
