### PR TITLE
fix : replaced error.message with generic error in flashcardController error responses

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -95,7 +95,7 @@ const createFlashcard = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to create flashcard",
-      error: error.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -129,7 +129,7 @@ const getUserFlashcards = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to fetch flashcards",
-      error: error.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -179,7 +179,7 @@ const reviewFlashcard = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to review flashcard",
-      error: error.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -210,7 +210,7 @@ const deleteFlashcard = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to delete flashcard",
-      error: error.message,
+      error: 'Internal server error',
     });
   }
 };
@@ -254,7 +254,7 @@ const getFlashcardStats = async (req, res) => {
     return res.status(500).json({
       success: false,
       message: "Failed to fetch SRS stats",
-      error: error.message,
+      error: 'Internal server error',
     });
   }
 };


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced instances of `error: error.message` in 500 error responses within `backend/controllers/flashcardController.js` with a generic error message `'Internal server error'`.

## Changes Made
- Replaced `error: error.message` with `error: 'Internal server error'` in all 5 catch blocks of flashcardController.js

## Impact it Made
- Prevents internal error details from being exposed to API clients
- Improves security by not leaking MongoDB or internal error messages

Closes #604

## Note: Please assign this PR to the `tmdeveloper007` account.
