### PR TITLE
fix : replaced err.message with generic error in jobController getJobs error response

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -72,7 +72,7 @@ exports.getJobs = async (req, res) => {
     return res.json({ jobs, role, source: "api" });
   } catch (err) {
     console.error("[Jobs] getJobs error:", err.message);
-    res.status(500).json({ message: "Failed to fetch jobs", error: err.message });
+    res.status(500).json({ message: "Failed to fetch jobs", error: 'Internal server error' });
   }
 };
 


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced `error: err.message` in the 500 error response within the `getJobs` function in `backend/controllers/jobController.js` with a generic error message `'Internal server error'`.

## Changes Made
- Replaced `error: err.message` with `error: 'Internal server error'` in the catch block of the getJobs function

## Impact it Made
- Prevents internal error details from being exposed to API clients
- Improves security by not leaking database or API error messages

Closes #605

## Note: Please assign this PR to the `tmdeveloper007` account.
