### PR TITLE
fix: reject queued requests when token refresh fails

### DIFF
--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -27,15 +27,15 @@ axiosInstance.interceptors.request.use(
 
 // ── Token refresh state ───────────────────────────────────────────────────
 let isRefreshing = false;
-let refreshSubscribers = [];   // callbacks waiting for the new token
+let refreshSubscribers = [];   // subscribers waiting for the new token
 
 function onTokenRefreshed(newToken) {
-    refreshSubscribers.forEach((cb) => cb(newToken));
+    refreshSubscribers.forEach((subscriber) => subscriber.resolve(newToken));
     refreshSubscribers = [];
 }
 
-function addRefreshSubscriber(cb) {
-    refreshSubscribers.push(cb);
+function addRefreshSubscriber(resolveCb, rejectCb) {
+    refreshSubscribers.push({ resolve: resolveCb, reject: rejectCb });
 }
 
 // ── Response interceptor — silent token refresh on 401 ───────────────────
@@ -69,12 +69,13 @@ axiosInstance.interceptors.response.use(
             if (isRefreshing) {
                 // Another refresh is already in-flight — queue this request
                 return new Promise((resolve, reject) => {
-                    addRefreshSubscriber((newToken) => {
-                        originalRequest.headers.Authorization = `Bearer ${newToken}`;
-                        resolve(axiosInstance(originalRequest));
-                    });
-                    // If refresh ultimately fails, reject queued requests too
-                    // (handled below via the catch that calls reject)
+                    addRefreshSubscriber(
+                        (newToken) => {
+                            originalRequest.headers.Authorization = `Bearer ${newToken}`;
+                            resolve(axiosInstance(originalRequest));
+                        },
+                        (error) => reject(error)
+                    );
                 });
             }
 
@@ -108,8 +109,12 @@ axiosInstance.interceptors.response.use(
                 originalRequest.headers.Authorization = `Bearer ${newToken}`;
                 return axiosInstance(originalRequest);
             } catch (refreshError) {
-                // Refresh failed — clear tokens but don't force redirect here.
-                // ProtectedRoute and userContext will handle the redirect gracefully.
+                // Refresh failed — reject all queued requests before clearing
+                refreshSubscribers.forEach((subscriber) => {
+                    if (subscriber.reject) {
+                        subscriber.reject(refreshError);
+                    }
+                });
                 refreshSubscribers = [];
                 localStorage.removeItem("token");
                 sessionStorage.removeItem("token");


### PR DESCRIPTION
Title:
  fix: reject queued requests when token refresh fails

  Description:
  Fixes #611

  ## Problem

  When multiple requests were in-flight during token refresh and the refresh failed (expired refresh token), queued requests
  never resolved or rejected. The axios interceptor cleared the subscriber queue without calling reject callbacks, leaving
  promises pending indefinitely and freezing the UI.

  ## Root Cause

  - `addRefreshSubscriber` (line 37) only stored resolve callbacks
  - Queued promises (line 71) had no reject path
  - Catch block (line 113) cleared array without invoking reject
  - Comment at line 76-77 claimed reject was "handled below" but was never implemented

  ## Changes

  - **Line 32-35:** Store `{ resolve, reject }` objects instead of single callback
  - **Line 37-39:** Accept both `resolveCb` and `rejectCb` parameters
  - **Line 72-77:** Pass reject callback when queuing requests
  - **Line 110-116:** Invoke all `subscriber.reject()` before clearing queue

  ## Testing

  **Before fix:**
  1. Set backend `REFRESH_TOKEN_EXPIRY = "5s"`
  2. Login → wait 6s → click two routes rapidly
  3. First request rejected correctly
  4. Second request hung forever (Promise pending)

  **After fix:**
  1. Same steps
  2. Both requests rejected with same error
  3. App redirects to /login gracefully
  4. No hanging promises

  ## Impact

  - **High** — Affects all users when refresh tokens expire (common scenario)
  - Prevents app freeze on token expiry
  - Allows proper error handling and login redirect

  ## Checklist

  - [x] Tested locally with expired refresh token
  - [x] Verified both queued and primary requests reject correctly
  - [x] No breaking changes to existing refresh flow
  - [x] Follows repo coding style

  Labels: bug, ECSoC26

  ---
  Branch ready: fix/refresh-token-queue-hang
  Commit: 1e2bd4e
  Remote: https://github.com/yuviiios/PrepPilot
