### PR TITLE
fix : replaced err.message with generic error in AptitudeQuestions route error responses

### DIFF
--- a/backend/routes/AptitudeQuestions.js
+++ b/backend/routes/AptitudeQuestions.js
@@ -77,8 +77,7 @@ console.log(
         .status(500)
         .json({
           error: "Failed to parse Gemini response",
-          details: err.message,
-          raw: rawText,
+          details: 'Internal server error',
         });
     }
     questionCache.set(
@@ -91,7 +90,7 @@ res.json(questions);
     console.error("Gemini API error:", error);
     res
       .status(500)
-      .json({ error: "Failed to generate questions", details: error.message });
+      .json({ error: "Failed to generate questions", details: 'Internal server error' });
   }
 });
 module.exports = router;


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced `err.message` and `error.message` leaks in `backend/routes/AptitudeQuestions.js` catch blocks with generic error messages to prevent internal error details from being exposed to API consumers.

## Changes Made

- `backend/routes/AptitudeQuestions.js`: Replaced `details: err.message` and `details: error.message` in error responses with `details: 'Internal server error'`

## Impact it Made

- Prevents internal error details from leaking to API consumers
- Improves API security by not exposing implementation details

Closes #614

## Note: Please assign this PR to the `tmdeveloper007` account.