### PR TITLE
fix : replaced err.message with generic error in booksRoutes error responses

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -145,8 +145,8 @@ router.get("/", async (_req, res) => {
             })),
           };
         } catch (err) {
-          console.error(`[books] Failed to read dir ${dir.name}:`, err.message);
-          warnings.push(`Skipped ${dir.name}: ${err.message}`);
+          console.error(`[books] Failed to read dir ${dir.name}`);
+          warnings.push(`Skipped ${dir.name}: Failed to read directory`);
           return null;
         }
       }),


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced `err.message` leaks in `backend/routes/booksRoutes.js` catch block with generic messages to prevent internal error details from being exposed.

## Changes Made

- `backend/routes/booksRoutes.js`: Replaced `err.message` in `console.error` and `warnings.push` with generic messages

## Impact it Made

- Prevents internal error details from leaking to server logs and API responses

Closes #615

## Note: Please assign this PR to the `tmdeveloper007` account.