### PR TITLE
fix : replaced err.message with generic error in jobController cron error logging

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -71,7 +71,7 @@ exports.getJobs = async (req, res) => {
 
     return res.json({ jobs, role, source: "api" });
   } catch (err) {
-    console.error("[Jobs] getJobs error:", err.message);
+    console.error("[Jobs] getJobs error");
     res.status(500).json({ message: "Failed to fetch jobs", error: err.message });
   }
 };
@@ -94,6 +94,6 @@ exports.refreshJobCache = async () => {
       console.log(`[JobCron] Refreshed cache for: ${role}`);
     }
   } catch (err) {
-    console.error("[JobCron] Refresh failed:", err.message);
+    console.error("[JobCron] Refresh failed");
   }
 };


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced `err.message` leaks in `backend/controllers/jobController.js` catch blocks with generic messages to prevent internal error details from being exposed via console.error.

## Changes Made

- `backend/controllers/jobController.js`: Replaced `err.message` in `console.error` calls at getJobs and refreshJobCache with generic messages

## Impact it Made

- Prevents internal error details from leaking to server logs
- Improves operational security by not logging sensitive error context

Closes #617

## Note: Please assign this PR to the `tmdeveloper007` account.