### PR TITLE
fix(frontend): prevent RepositoryHive crash on empty search/filter qu…

### DIFF
--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -63,7 +63,13 @@ const RepositoryHive = () => {
         queryParams.push(searchQuery.trim());
       }
 
-      const query = queryParams.join(" ");
+      const query = queryParams.join(" ").trim();
+      if (!query) {
+        setRepositories([]);
+        setLoading(false);
+        return;
+      }
+
       const sortMap = {
         stars: "sort=stars&order=desc",
         recent: "sort=updated&order=desc",


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #648 

## Description

This PR resolves a UI crash on the **Repository Hive** page (`/repository-hive`) that occurred when a user deselected all topic filters while leaving the search input blank. Previously, this state caused the application to generate an empty search query (`q=`) and send it to the GitHub Search API, which responded with an **HTTP 422 Unprocessable Entity** validation error.

This change introduces a validation layer that detects empty queries before initiating the API request. Instead of making an invalid request, the application now clears the repository list, resets the loading state, and gracefully displays the empty state.

---

## Technical Flow Comparison

The flowchart below demonstrates how the new validation layer intercepts empty inputs to prevent API failures.

```mermaid
flowchart TD
    Start([User deselects all filters<br/>and leaves search input empty])
    BuildQuery[Build query parameters]
    JoinQuery[Join query terms and trim]
    Guard{Is the query empty?}

    MakeAPI[Call GitHub Search API]
    APIError[GitHub returns HTTP 422]
    UICrash[Display API error]

    EarlyReturn[Clear repositories]
    ResetLoading[Set loading to false]
    SafeExit[Show empty state]

    Start --> BuildQuery
    BuildQuery --> JoinQuery
    JoinQuery --> Guard

    Guard -- No --> MakeAPI
    MakeAPI --> APIError
    APIError --> UICrash

    Guard -- Yes --> EarlyReturn
    EarlyReturn --> ResetLoading
    ResetLoading --> SafeExit

    classDef success fill:#10B981,stroke:#047857,color:#ffffff;
    classDef failure fill:#EF4444,stroke:#B91C1C,color:#ffffff;
    classDef process fill:#6366F1,stroke:#4338CA,color:#ffffff;
    classDef startNode fill:#3B82F6,stroke:#1D4ED8,color:#ffffff;

    class Start startNode;
    class BuildQuery,JoinQuery,Guard process;
    class EarlyReturn,ResetLoading,SafeExit success;
    class MakeAPI,APIError,UICrash failure;
```

---

## Why This Matters

- **Improved Robustness:** Prevents GitHub API validation errors from reaching the UI.
- **Better User Experience:** Displays a clean empty state instead of an error message when no search criteria are provided.
- **Reduced Network Overhead:** Prevents unnecessary API calls with invalid parameters.
- **API Rate Limit Protection:** GitHub's unauthenticated Search API has a low request quota. Blocking invalid requests helps preserve the available rate limit for valid searches.

---

## Proposed Changes

- Added an early-return guard inside `fetchRepositories()` in `RepositoryHive.jsx`.
- Validated the generated query before making a GitHub Search API request.
- Cleared the repository list and reset the loading state when the query is empty.
- Preserved the existing search functionality for all valid queries.

```javascript
const query = queryParams.join(" ").trim();

if (!query) {
  setRepositories([]);
  setLoading(false);
  return;
}
```

---

## Verification

### Production Build

Successfully compiled the production build:

```bash
npm run build
```

### Manual Testing

- ✅ Deselected all filters while keeping the search input empty.
- ✅ Confirmed that no GitHub Search API request was sent.
- ✅ Verified that the UI transitioned to the empty state without displaying any errors.
- ✅ Confirmed that repository searches continue to work correctly when filters or search text are provided.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

## Screenshots (if applicable)

N/A (Frontend logic change)

---

## Checklist

- [x] My code follows the project's guidelines.
- [x] I have tested my changes.
- [ ] I have updated documentation where necessary.
- [x] I have linked the related issue.
- [x] My changes do not introduce new warnings or errors.