### PR TITLE
fix : added required role field validation in createSession endpoint

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -36,6 +36,13 @@ exports.createSession = async (req, res) => {
             const { role, experience, topicsToFocus, description } = req.body;
             const experienceNumber = Number(experience);
  
+            if (!role || role.trim() === "") {
+                return res.status(400).json({
+                    success: false,
+                    message: "Role is required.",
+                });
+            }
+
             if (isNaN(experienceNumber)) {
               return res.status(400).json({
                     success: false,

--- a/frontend/src/utils/helper.js
+++ b/frontend/src/utils/helper.js
@@ -1,4 +1,5 @@
 export const validateEmail = (email) => {
+    if (!email || typeof email !== 'string') return false;
     const regex = /^[^\s@]+@[^\s@]+\.[A-Za-z]{2,}$/;
     return regex.test(email);
 };


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #652

## Summary of What Has Been Done
Added a validation check for the `role` field in the `createSession` function in `backend/controllers/sessionController.js`. The function now returns a clear 400 error when `role` is missing or empty, rather than letting Mongoose reject the request with a cryptic validation error.

## Changes Made
Added after destructuring req.body:
```javascript
if (!role || role.trim() === "") {
    return res.status(400).json({
        success: false,
        message: "Role is required.",
    });
}
```

## Impact it Made
- Returns a clear 400 error with actionable message when role is missing
- Prevents cryptic Mongoose validation errors from leaking to API consumers
- Follows the same validation pattern already used for the `experience` field

## Note: Please assign this PR to the `tmdeveloper007` account.