### PR TITLE
fix: prioritize query parameter over session role in job search

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -52,7 +52,7 @@ exports.getJobs = async (req, res) => {
       .sort({ createdAt: -1 })
       .select("role");
 
-    const role    = latestSession?.role || req.query.role || "software engineer";
+    const role    = req.query.role || latestSession?.role || "software engineer";
     const country = req.query.country   || ADZUNA_COUNTRY;
     const cacheKey = `${role.toLowerCase()}|${country}`;
 


### PR DESCRIPTION
Fixed job role query parameter being ignored when users have existing sessions.

  Previously, when a user selected a different role from the Jobs page dropdown, the selection had no effect if they
  had any interview preparation sessions. The backend always used the role from their most recent session instead
  of the query parameter sent by the frontend.

  Changed `jobController.js:55` to check `req.query.role` before `latestSession?.role`, allowing explicit user
  selections to override session defaults while maintaining fallback behavior for initial page loads.

  **Change:** 1 line modified in `backend/controllers/jobController.js`

   Closes #661

  ---

  ### Type of Change
  - [x] 🐛 Bug fix (non-breaking change which fixes an issue)
  - [ ] ✨ New feature
  - [ ] ♻️  Refactoring
  - [ ] 📝 Documentation update
  - [ ] 🎨 UI/UX improvement
  - [ ] 🔥 Other(please describe) ______

  ---

  ### How Has This Been Tested?

  **Manual Testing:**

  1. **Setup:**
     - Created test account and logged in
     - Created interview session with role="Backend Engineer"

  2. **Before Fix (Verified bug exists):**
     - Navigated to `/jobs`
     - Page showed Backend Engineer jobs by default ✓
     - Selected "Frontend Engineer" from dropdown
     - Clicked search
     - Jobs still showed Backend Engineer positions ❌
     - Query param sent correctly (verified in DevTools Network tab)

  3. **After Fix:**
     - Same steps as above
     - Selected "Frontend Engineer" from dropdown
     - Clicked search
     - Jobs correctly showed Frontend Engineer positions ✓
     - Query param properly respected

  4. **Regression Testing:**
     - Verified fallback behavior: Initial page load with no query param still uses session role ✓
     - Verified default fallback: New users without sessions see "software engineer" jobs ✓
     - Tested country dropdown: Still works correctly ✓

  **Code Review:**
  - Verified frontend sends query param at `JobsForYou.jsx:75`: `params.role` ✓
  - Confirmed no breaking changes to API contract ✓
  - Checked precedence logic: explicit > session > default ✓

  ---


  ### Checklist
  - [x] My code follows the project's guidelines
  - [x] I have tested my changes
  - [x] I have updated documentation where necessary (N/A - internal logic change)
  - [ ] I have linked the related issue (pending issue creation)
  - [x] My changes do not introduce new warnings or errors
  - [x] No breaking changes to existing API
  - [x] Maintains backward compatibility (fallback logic preserved)

  ---
  **Before Fix:**
  User selects "Frontend Engineer" but gets "Backend Engineer" jobs (dropdown broken)

  **After Fix:**
  User selects "Frontend Engineer" and correctly receives Frontend Engineer job listings

  ---
