### PR TITLE
fix : removed debug console.log from sheetJsonUpload route

### DIFF
--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -6,7 +6,6 @@ const { protect } = require('../middlewares/authMiddleware');
 // POST /api/sheets/upload
 // Body: { filename: "file.json", data: {...sheet data...} }
 router.post('/upload', protect, async (req, res) => {
-  console.log('Received upload:', req.body.filename);
   const { filename, data } = req.body;
 
   if (!filename || !data) {


### PR DESCRIPTION
## Summary of What Has Been Done
Removed the debug console.log statement from backend/routes/sheetJsonUpload.js that logged the uploaded filename.

## Changes Made
- backend/routes/sheetJsonUpload.js: Removed console.log at line 9 that logged 'Received upload:' with the filename.

## Impact it Made
- Reduces server log noise in production environments.
- No functional changes to the sheet upload endpoint.

Closes #666

Note: Please assign this PR to the `tmdeveloper007` account.