### PR TITLE
fix : replaced err.message leak with generic error in booksRoutes logs

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -151,7 +151,7 @@ router.get("/", async (_req, res) => {
     try {
       treeData = await getGitTree();
     } catch (err) {
-      console.warn("[books] Failed to fetch git tree, trying contents fallback:", err.message);
+      console.warn("[books] Failed to fetch git tree, trying contents fallback");
     }
 
     if (treeData && Array.isArray(treeData)) {
@@ -207,8 +207,8 @@ router.get("/", async (_req, res) => {
             })),
           };
         } catch (err) {
-          console.error(`[books] Failed to read dir ${dir.name}:`, err.message);
-          warnings.push(`Skipped ${dir.name}: ${err.message}`);
+          console.error(`[books] Failed to read dir ${dir.name}`);
+          warnings.push(`Skipped ${dir.name}`);
           return null;
         }
       }),


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced err.message references in backend/routes/booksRoutes.js with generic error messages to prevent internal error details from leaking into server logs and API responses.

## Changes Made
- backend/routes/booksRoutes.js: Replaced err.message in console.warn at line 154 with a generic message "Failed to fetch git tree, trying contents fallback".
- backend/routes/booksRoutes.js: Replaced err.message in console.error at line 210 with a generic message "Failed to read directory".
- backend/routes/booksRoutes.js: Replaced err.message in warnings.push at line 211 with a generic message "Skipped {dir.name}".

## Impact it Made
- Prevents internal error details (file paths, database errors, etc.) from being exposed in API responses and server logs.
- Improves security by not leaking implementation details.
- No functional changes to the books browsing feature.

Closes #667

Note: Please assign this PR to the `tmdeveloper007` account.