### PR TITLE
fix : added generic error response in jobController

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -72,7 +72,7 @@ exports.getJobs = async (req, res) => {
     return res.json({ jobs, role, source: "api" });
   } catch (err) {
     console.error("[Jobs] getJobs error:", err.message);
-    res.status(500).json({ message: "Failed to fetch jobs", error: err.message });
+    res.status(500).json({ message: "Failed to fetch jobs", error: "Internal server error" });
   }
 };
 


### PR DESCRIPTION
Summary of What Has Been Done:
Replaced `err.message` in jobController.js getJobs error response with a generic error message string to prevent internal server error details from being exposed to API clients.

Changes Made:
- `backend/controllers/jobController.js`: Replaced `error: err.message` with `error: "Internal server error"` in the getJobs function's res.status(500).json() call.

Impact it Made:
- Prevents internal error details (stack traces, database errors) from leaking to API clients
- Improves API security posture
- Maintains consistent error response format across the application

Closes #676

Note: Please assign this PR to the `tmdeveloper007` account.