### PR TITLE
Integrated the ai-powered pdf notes summarization

### DIFF
--- a/backend/Input_validators/ValidateNotesSummary.js
+++ b/backend/Input_validators/ValidateNotesSummary.js
@@ -1,0 +1,80 @@
+const { z } = require("zod");
+const { handleValidationError } = require("./ValidateQuestions");
+
+const topicsSchema = z.object({
+  chapters: z.array(z.string().min(1).max(120)).max(10).default([]),
+  subtopics: z.array(z.string().min(1).max(120)).max(10).default([]),
+  keywords: z.array(z.string().min(1).max(60)).max(15).default([]),
+});
+
+const difficultySchema = z.object({
+  level: z.enum(["Beginner", "Intermediate", "Advanced"]),
+  explanation: z.string().min(1).max(600),
+});
+
+const readingTimeSchema = z.object({
+  minutes: z.number().int().positive(),
+  label: z.string().min(1).max(50),
+  pages: z.number().int().nonnegative(),
+});
+
+
+const summarizeRequestSchema = z.object({
+  url: z.string().url("Provide a valid PDF URL").optional(),
+  fileName: z.string().max(200).optional(),
+});
+
+const validateSummarizeNotes = (req, res, next) => {
+  try {
+    req.body = summarizeRequestSchema.parse(req.body || {});
+    if (!req.file && !req.body.url) {
+      return res.status(400).json({
+        success: false,
+        message: "Please upload a PDF or choose one from Notes & Books.",
+      });
+    }
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
+
+const aiOutputSchema = z.object({
+  summary: z.string().min(1).max(3000),
+  topics: topicsSchema,
+  prerequisites: z.array(z.string().min(1).max(200)).max(10).default([]),
+  difficulty: difficultySchema,
+  learningOutcomes: z.array(z.string().min(1).max(300)).max(10).default([]),
+});
+
+
+const saveNotesSummarySchema = z.object({
+  fileName: z.string().min(1).max(200),
+  sourceType: z.enum(["upload", "platform"]),
+  sourceUrl: z.string().url().optional().nullable(),
+  pageCount: z.number().int().nonnegative().optional().default(0),
+  wordCount: z.number().int().nonnegative().optional().default(0),
+  contentHash: z.string().max(128).optional().nullable(),
+  summary: z.string().min(1).max(3000),
+  topics: topicsSchema,
+  prerequisites: z.array(z.string().min(1).max(200)).max(10).default([]),
+  difficulty: difficultySchema,
+  readingTime: readingTimeSchema,
+  learningOutcomes: z.array(z.string().min(1).max(300)).max(10).default([]),
+});
+
+const validateSaveNotesSummary = (req, res, next) => {
+  try {
+    req.body = saveNotesSummarySchema.parse(req.body);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
+module.exports = {
+  validateSummarizeNotes,
+  validateSaveNotesSummary,
+  aiOutputSchema,
+};

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,21 +9,8 @@ const ACCESS_TOKEN_EXPIRY = "7d";
 const REFRESH_TOKEN_EXPIRY = "30d";
 const REFRESH_TOKEN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_SALT_ROUNDS = 10;
-
 const getRefreshCookieOptions = () => ({
     httpOnly: true,
-    secure: process.env.NODE_ENV === "production",
-    sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
-    maxAge: REFRESH_TOKEN_MAX_AGE_MS,
-    path: "/api/auth",
-});
-
-// CSRF cookie must be readable by frontend JS so it can be echoed back in a
-// header on requests that rely on the ambient refreshToken cookie.
-// It intentionally mirrors the refreshToken cookie's SameSite/secure/path
-// settings so it is only ever sent alongside it.
-const getCsrfCookieOptions = () => ({
-    httpOnly: false,
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
     maxAge: REFRESH_TOKEN_MAX_AGE_MS,
@@ -49,38 +36,13 @@ const generateRefreshToken = (userId) => {
 };
 
 /**
- * Set the httpOnly refresh-token cookie together with a readable CSRF token
- * cookie (double-submit pattern). Any route that authenticates purely off
- * the refreshToken cookie (refresh, logout) should require the matching
- * X-CSRF-Token header via the requireCsrfToken middleware.
- * @param {import('express').Response} res
- * @param {string} refreshTokenValue
- * @returns {string} the generated CSRF token (rarely needed by callers)
- */
-const setAuthCookies = (res, refreshTokenValue) => {
-    const csrfToken = crypto.randomBytes(24).toString("hex");
-    res.cookie("refreshToken", refreshTokenValue, getRefreshCookieOptions());
-    res.cookie("csrfToken", csrfToken, getCsrfCookieOptions());
-    return csrfToken;
-};
-
-/**
- * Clear both the refresh-token cookie and its paired CSRF cookie.
- * @param {import('express').Response} res
- */
-const clearAuthCookies = (res) => {
-    res.clearCookie("refreshToken", { path: "/api/auth" });
-    res.clearCookie("csrfToken", { path: "/api/auth" });
-};
-
-/**
  * Register a new user account.
  * @route POST /api/auth/register
  */
 const registerUser = async (req, res) => {
     try {
         const { name, email, password, profileImageUrl } = req.body;
-
+        
         const emailRegex = /^[^\s@]+@[^\s@]+\.[A-Za-z]{2,}$/;
 
         if (!emailRegex.test(email)) {
@@ -135,14 +97,12 @@ const registerUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshTokenValue, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-
-        setAuthCookies(res, refreshTokenValue);
-
+        res.cookie("refreshToken", refreshTokenValue, getRefreshCookieOptions());
         return res.status(201).json({
             success: true,
             message: "Account created successfully. You can now log in.",
             accessToken,
-
+            
             _id: user._id,
             name: user.name,
             email: user.email,
@@ -187,9 +147,7 @@ const loginUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshTokenValue, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-
-        setAuthCookies(res, refreshTokenValue);
-
+        res.cookie("refreshToken", refreshTokenValue, getRefreshCookieOptions());
         res.json({
             success: true,
             _id: user._id,
@@ -205,12 +163,6 @@ const loginUser = async (req, res) => {
     }
 };
 
-/**
- * Rotate the refresh token using the ambient refreshToken cookie.
- * Requires a valid X-CSRF-Token header matching the csrfToken cookie
- * (enforced by the requireCsrfToken middleware on this route).
- * @route POST /api/auth/refresh-token
- */
 const refreshToken = async (req, res) => {
     try {
         const incomingRefreshToken = req.cookies?.refreshToken;
@@ -257,13 +209,12 @@ const refreshToken = async (req, res) => {
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
 
-        setAuthCookies(res, rotatedRefreshToken);
-
+        res.cookie("refreshToken", rotatedRefreshToken, getRefreshCookieOptions());
         res.json({
             success: true,
             message: "Token refreshed successfully.",
             accessToken,
-
+        
         });
     } catch (error) {
         console.error("Refresh token error:", error);
@@ -271,12 +222,6 @@ const refreshToken = async (req, res) => {
     }
 };
 
-/**
- * Log the user out and revoke their refresh token.
- * Requires a valid X-CSRF-Token header matching the csrfToken cookie
- * (enforced by the requireCsrfToken middleware on this route).
- * @route POST /api/auth/logout
- */
 const logoutUser = async (req, res) => {
     try {
         const incomingRefreshToken = req.cookies?.refreshToken;
@@ -311,7 +256,7 @@ const logoutUser = async (req, res) => {
         user.refreshTokenExpiresAt = null;
         await user.save();
 
-        clearAuthCookies(res);
+        res.clearCookie("refreshToken", { path: "/api/auth" });
         res.json({ success: true, message: "User logged out successfully." });
     } catch (error) {
         console.error("Logout error:", error);

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,8 +9,21 @@ const ACCESS_TOKEN_EXPIRY = "7d";
 const REFRESH_TOKEN_EXPIRY = "30d";
 const REFRESH_TOKEN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_SALT_ROUNDS = 10;
+
 const getRefreshCookieOptions = () => ({
     httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
+    maxAge: REFRESH_TOKEN_MAX_AGE_MS,
+    path: "/api/auth",
+});
+
+// CSRF cookie must be readable by frontend JS so it can be echoed back in a
+// header on requests that rely on the ambient refreshToken cookie.
+// It intentionally mirrors the refreshToken cookie's SameSite/secure/path
+// settings so it is only ever sent alongside it.
+const getCsrfCookieOptions = () => ({
+    httpOnly: false,
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
     maxAge: REFRESH_TOKEN_MAX_AGE_MS,
@@ -36,13 +49,38 @@ const generateRefreshToken = (userId) => {
 };
 
 /**
+ * Set the httpOnly refresh-token cookie together with a readable CSRF token
+ * cookie (double-submit pattern). Any route that authenticates purely off
+ * the refreshToken cookie (refresh, logout) should require the matching
+ * X-CSRF-Token header via the requireCsrfToken middleware.
+ * @param {import('express').Response} res
+ * @param {string} refreshTokenValue
+ * @returns {string} the generated CSRF token (rarely needed by callers)
+ */
+const setAuthCookies = (res, refreshTokenValue) => {
+    const csrfToken = crypto.randomBytes(24).toString("hex");
+    res.cookie("refreshToken", refreshTokenValue, getRefreshCookieOptions());
+    res.cookie("csrfToken", csrfToken, getCsrfCookieOptions());
+    return csrfToken;
+};
+
+/**
+ * Clear both the refresh-token cookie and its paired CSRF cookie.
+ * @param {import('express').Response} res
+ */
+const clearAuthCookies = (res) => {
+    res.clearCookie("refreshToken", { path: "/api/auth" });
+    res.clearCookie("csrfToken", { path: "/api/auth" });
+};
+
+/**
  * Register a new user account.
  * @route POST /api/auth/register
  */
 const registerUser = async (req, res) => {
     try {
         const { name, email, password, profileImageUrl } = req.body;
-        
+
         const emailRegex = /^[^\s@]+@[^\s@]+\.[A-Za-z]{2,}$/;
 
         if (!emailRegex.test(email)) {
@@ -92,17 +130,19 @@ const registerUser = async (req, res) => {
         });
 
         const accessToken = generateAccessToken(user._id);
-        const refreshToken = generateRefreshToken(user._id);
+        const refreshTokenValue = generateRefreshToken(user._id);
 
-        user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
+        user.refreshTokenHash = await bcrypt.hash(refreshTokenValue, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-        res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
+
+        setAuthCookies(res, refreshTokenValue);
+
         return res.status(201).json({
             success: true,
             message: "Account created successfully. You can now log in.",
             accessToken,
-            
+
             _id: user._id,
             name: user.name,
             email: user.email,
@@ -142,12 +182,14 @@ const loginUser = async (req, res) => {
         }
 
         const accessToken = generateAccessToken(user._id);
-        const refreshToken = generateRefreshToken(user._id);
+        const refreshTokenValue = generateRefreshToken(user._id);
 
-        user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
+        user.refreshTokenHash = await bcrypt.hash(refreshTokenValue, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-        res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
+
+        setAuthCookies(res, refreshTokenValue);
+
         res.json({
             success: true,
             _id: user._id,
@@ -163,6 +205,12 @@ const loginUser = async (req, res) => {
     }
 };
 
+/**
+ * Rotate the refresh token using the ambient refreshToken cookie.
+ * Requires a valid X-CSRF-Token header matching the csrfToken cookie
+ * (enforced by the requireCsrfToken middleware on this route).
+ * @route POST /api/auth/refresh-token
+ */
 const refreshToken = async (req, res) => {
     try {
         const incomingRefreshToken = req.cookies?.refreshToken;
@@ -209,12 +257,13 @@ const refreshToken = async (req, res) => {
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
 
-        res.cookie("refreshToken", rotatedRefreshToken, getRefreshCookieOptions());
+        setAuthCookies(res, rotatedRefreshToken);
+
         res.json({
             success: true,
             message: "Token refreshed successfully.",
             accessToken,
-        
+
         });
     } catch (error) {
         console.error("Refresh token error:", error);
@@ -222,6 +271,12 @@ const refreshToken = async (req, res) => {
     }
 };
 
+/**
+ * Log the user out and revoke their refresh token.
+ * Requires a valid X-CSRF-Token header matching the csrfToken cookie
+ * (enforced by the requireCsrfToken middleware on this route).
+ * @route POST /api/auth/logout
+ */
 const logoutUser = async (req, res) => {
     try {
         const incomingRefreshToken = req.cookies?.refreshToken;
@@ -256,7 +311,7 @@ const logoutUser = async (req, res) => {
         user.refreshTokenExpiresAt = null;
         await user.save();
 
-        res.clearCookie("refreshToken", { path: "/api/auth" });
+        clearAuthCookies(res);
         res.json({ success: true, message: "User logged out successfully." });
     } catch (error) {
         console.error("Logout error:", error);

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -239,7 +239,6 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
   }
 };
 
-const Joi = require("joi");
 
 const saveSummarySchema = Joi.object({
   fileName: Joi.string().trim().max(255).required(),

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -9,7 +9,7 @@ const {
 const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
 const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
 const NotesSummary = require("../models/NotesSummary");
-
+const Joi = require("joi");
 
 const ALLOWED_REMOTE_HOSTS = new Set(["raw.githubusercontent.com"]);
 const MAX_SAVED_SUMMARIES_PER_USER = 30;
@@ -239,6 +239,34 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
   }
 };
 
+const Joi = require("joi");
+
+const saveSummarySchema = Joi.object({
+  fileName: Joi.string().trim().max(255).required(),
+
+  sourceType: Joi.string().trim().required(),
+
+  sourceUrl: Joi.string().uri().allow("", null),
+
+  pageCount: Joi.number().integer().min(0).required(),
+
+  wordCount: Joi.number().integer().min(0).required(),
+
+  contentHash: Joi.string().required(),
+
+  summary: Joi.string().required(),
+
+  topics: Joi.array().items(Joi.string()).required(),
+
+  prerequisites: Joi.array().items(Joi.string()).required(),
+
+  difficulty: Joi.string().required(),
+
+  readingTime: Joi.number().min(0).required(),
+
+  learningOutcomes: Joi.array().items(Joi.string()).required(),
+});
+
 /**
  * @route POST /api/notes-summary/save
  * @access Private
@@ -246,67 +274,85 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
 const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
-    const {
-    fileName,
-    sourceType,
-    sourceUrl,
-    pageCount,
-    wordCount,
-    contentHash,
-    summary,
-    topics,
-    prerequisites,
-    difficulty,
-    readingTime,
-    learningOutcomes,
-  } = req.body;
 
-  if (typeof fileName !== "string" || fileName.trim() === "") {
-    return res.status(400).json({
-      success: false,
-      message: "Invalid file name.",
+    const { error, value } = saveSummarySchema.validate(req.body, {
+      abortEarly: false,
+      stripUnknown: true,
     });
-  }
-  const update = {
-    user: userId,
-    fileName: String(fileName),
-    sourceType: String(sourceType),
-    sourceUrl: typeof sourceUrl === "string" ? sourceUrl : "",
-    pageCount: Number(pageCount),
-    wordCount: Number(wordCount),
-    contentHash: String(contentHash),
-    summary: String(summary),
-    topics: Array.isArray(topics) ? topics : [],
-    prerequisites: Array.isArray(prerequisites) ? prerequisites : [],
-    difficulty: String(difficulty),
-    readingTime: Number(readingTime),
-    learningOutcomes: Array.isArray(learningOutcomes)
-      ? learningOutcomes
-      : [],
-  };
 
-   await NotesSummary.findOneAndUpdate(
-    { user: userId, fileName },
-    update,
-    {
-      new: true,
-      upsert: true,
-      setDefaultsOnInsert: true,
+    if (error) {
+      return res.status(400).json({
+        success: false,
+        message: error.details.map((d) => d.message),
+      });
     }
-  );
+
+    const {
+      fileName,
+      sourceType,
+      sourceUrl,
+      pageCount,
+      wordCount,
+      contentHash,
+      summary: summaryText,
+      topics,
+      prerequisites,
+      difficulty,
+      readingTime,
+      learningOutcomes,
+    } = value;
+
+    const savedSummary = await NotesSummary.findOneAndUpdate(
+      {
+        user: userId,
+        fileName,
+      },
+      {
+        user: userId,
+        fileName,
+        sourceType,
+        sourceUrl,
+        pageCount,
+        wordCount,
+        contentHash,
+        summary: summaryText,
+        topics,
+        prerequisites,
+        difficulty,
+        readingTime,
+        learningOutcomes,
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      }
+    );
+
     const count = await NotesSummary.countDocuments({ user: userId });
+
     if (count > MAX_SAVED_SUMMARIES_PER_USER) {
       const excess = await NotesSummary.find({ user: userId })
         .sort({ updatedAt: 1 })
         .limit(count - MAX_SAVED_SUMMARIES_PER_USER)
         .select("_id");
-      await NotesSummary.deleteMany({ _id: { $in: excess.map((d) => d._id) } });
+
+      await NotesSummary.deleteMany({
+        _id: { $in: excess.map((d) => d._id) },
+      });
     }
 
-    res.status(200).json({ success: true, summary: summary.toSafeObject() });
+    res.status(200).json({
+      success: true,
+      summary: savedSummary.toSafeObject(),
+    });
   } catch (error) {
     console.error("Save Notes Summary Error:", error);
-    res.status(500).json({ success: false, message: "Failed to save summary." });
+
+    res.status(500).json({
+      success: false,
+      message: "Failed to save summary.",
+    });
   }
 };
 

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -267,30 +267,33 @@ const saveSummary = async (req, res) => {
       message: "Invalid file name.",
     });
   }
+  const update = {
+    user: userId,
+    fileName: String(fileName),
+    sourceType: String(sourceType),
+    sourceUrl: typeof sourceUrl === "string" ? sourceUrl : "",
+    pageCount: Number(pageCount),
+    wordCount: Number(wordCount),
+    contentHash: String(contentHash),
+    summary: String(summary),
+    topics: Array.isArray(topics) ? topics : [],
+    prerequisites: Array.isArray(prerequisites) ? prerequisites : [],
+    difficulty: String(difficulty),
+    readingTime: Number(readingTime),
+    learningOutcomes: Array.isArray(learningOutcomes)
+      ? learningOutcomes
+      : [],
+  };
 
-    const summary = await NotesSummary.findOneAndUpdate(
-      { user: userId, fileName },
-      {
-        user: userId,
-        fileName,
-        sourceType,
-        sourceUrl,
-        pageCount,
-        wordCount,
-        contentHash,
-        summary,
-        topics,
-        prerequisites,
-        difficulty,
-        readingTime,
-        learningOutcomes,
-      },
-      {
-        new: true,
-        upsert: true,
-        setDefaultsOnInsert: true,
-      }
-    );
+   await NotesSummary.findOneAndUpdate(
+    { user: userId, fileName },
+    update,
+    {
+      new: true,
+      upsert: true,
+      setDefaultsOnInsert: true,
+    }
+  );
     const count = await NotesSummary.countDocuments({ user: userId });
     if (count > MAX_SAVED_SUMMARIES_PER_USER) {
       const excess = await NotesSummary.find({ user: userId })

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -1,0 +1,295 @@
+const axios = require("axios");
+const crypto = require("crypto");
+const { generateWithFallback } = require("../utils/geminiHelper");
+const {
+  inspectPdfBuffer,
+  computeReadingTime,
+  PdfIntegrityError,
+} = require("../utils/pdfIntegrity");
+const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
+const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
+const NotesSummary = require("../models/NotesSummary");
+
+
+const ALLOWED_REMOTE_HOSTS = new Set(["raw.githubusercontent.com"]);
+const MAX_SAVED_SUMMARIES_PER_USER = 30;
+
+/**
+ * @param {string} url
+ * @returns {Promise<Buffer>}
+ */
+async function fetchRemotePdf(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new PdfIntegrityError("The provided URL is not valid.");
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new PdfIntegrityError("PDF URLs must use https.");
+  }
+  if (!ALLOWED_REMOTE_HOSTS.has(parsed.hostname)) {
+    throw new PdfIntegrityError("This PDF source is not allowed.");
+  }
+
+  try {
+    const response = await axios.get(parsed.toString(), {
+      responseType: "arraybuffer",
+      timeout: 20000,
+      maxContentLength: NOTES_MAX_FILE_SIZE,
+      maxBodyLength: NOTES_MAX_FILE_SIZE,
+      headers: { Accept: "application/pdf" },
+    });
+    return Buffer.from(response.data);
+  } catch (err) {
+    if (err.code === "ERR_FR_MAX_CONTENT_LENGTH_EXCEEDED") {
+      throw new PdfIntegrityError(
+        "That PDF is too large to summarize (limit 15MB)."
+      );
+    }
+    throw new PdfIntegrityError(
+      "Could not download that PDF from the platform. It may have moved."
+    );
+  }
+}
+
+/**
+ * @param {string} raw
+ * @returns {object}
+ */
+function parseAiJson(raw) {
+  let cleaned = raw
+    .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
+    .replace(/(\s*```\s*)+$/i, "")
+    .trim();
+
+  try {
+    return JSON.parse(cleaned);
+  } catch {
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (match) return JSON.parse(match[0]);
+    throw new Error("Model response was not valid JSON");
+  }
+}
+
+/**
+ * @route 
+ * @access 
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ * @example
+ * @example
+ * @example
+ */
+const summarizeNotes = async (req, res) => {
+  try {
+    let buffer;
+    let fileName;
+    let sourceType;
+    let sourceUrl = null;
+
+    if (req.file) {
+      buffer = req.file.buffer;
+      fileName = req.file.originalname;
+      sourceType = "upload";
+    } else {
+      sourceUrl = req.body.url;
+      fileName = req.body.fileName || sourceUrl.split("/").pop() || "notes.pdf";
+      sourceType = "platform";
+      try {
+        buffer = await fetchRemotePdf(sourceUrl);
+      } catch (err) {
+        if (err instanceof PdfIntegrityError) {
+          return res.status(400).json({ success: false, message: err.message });
+        }
+        throw err;
+      }
+    }
+
+    let pdfStats;
+    try {
+      pdfStats = await inspectPdfBuffer(buffer);
+    } catch (err) {
+      if (err instanceof PdfIntegrityError) {
+        return res.status(400).json({ success: false, message: err.message });
+      }
+      throw err;
+    }
+
+    const readingTime = computeReadingTime(pdfStats);
+    const contentHash = crypto.createHash("sha256").update(buffer).digest("hex");
+
+    const prompt = `You are an expert academic tutor helping a student decide whether a set of study notes is useful before they read it.
+
+The attached PDF has ${pdfStats.numPages} page(s) and roughly ${pdfStats.wordCount} extractable word(s)${pdfStats.isLikelyScanned ? " (it appears to be mostly scanned/image content, so rely on what you can visually infer)" : ""}.
+
+Return the analysis STRICTLY as a JSON object with this exact shape and nothing else:
+{
+  "summary": "2-4 sentence overview of the main topics, key concepts, and purpose of the document",
+  "topics": {
+    "chapters": [array of up to 6 short major chapter/section names],
+    "subtopics": [array of up to 6 short subtopic names],
+    "keywords": [array of up to 10 short frequently-occurring keywords/terms]
+  },
+  "prerequisites": [array of up to 5 short prior-knowledge items a reader should have before studying this],
+  "difficulty": {
+    "level": "Beginner" | "Intermediate" | "Advanced",
+    "explanation": "one sentence justifying the difficulty rating"
+  },
+  "learningOutcomes": [array of up to 5 short statements describing what a student should be able to do after completing these notes]
+}
+
+DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON object. Do not include a readingTime field — that is calculated separately.`;
+
+    const { result } = await generateWithFallback(
+      process.env.GEMINI_API_KEY.trim(),
+      [
+        prompt,
+        {
+          inlineData: {
+            data: buffer.toString("base64"),
+            mimeType: "application/pdf",
+          },
+        },
+      ]
+    );
+
+    const rawText = await result.response.text();
+
+    let parsed;
+    try {
+      parsed = parseAiJson(rawText);
+    } catch (e) {
+      console.error("Failed to parse Gemini JSON:", rawText);
+      return res.status(502).json({
+        success: false,
+        message: "The AI response couldn't be understood. Please try again.",
+      });
+    }
+
+    const validated = aiOutputSchema.safeParse(parsed);
+    if (!validated.success) {
+      console.error("AI output failed schema validation:", validated.error.issues);
+      return res.status(502).json({
+        success: false,
+        message: "The AI response was malformed. Please try again.",
+      });
+    }
+
+    const data = validated.data;
+
+    res.status(200).json({
+      success: true,
+      fileName,
+      fileSize: buffer.length,
+      sourceType,
+      sourceUrl,
+      pageCount: pdfStats.numPages,
+      wordCount: pdfStats.wordCount,
+      contentHash,
+      summary: data.summary,
+      topics: data.topics,
+      prerequisites: data.prerequisites,
+      difficulty: data.difficulty,
+      readingTime,
+      learningOutcomes: data.learningOutcomes,
+      generatedAt: new Date().toISOString(),
+    });
+  } catch (error) {
+    console.error("Notes Summary Error:", error);
+    if (error instanceof PdfIntegrityError) {
+      return res.status(400).json({ success: false, message: error.message });
+    }
+
+    const geminiStatus = error?.status || error?.code;
+    if (geminiStatus === 429) {
+      return res.status(429).json({
+        success: false,
+        message:
+          "The AI service has no available quota on this API key right now. Check the Gemini API plan/billing for this key, or try again in a minute.",
+      });
+    }
+    if (geminiStatus === 503) {
+      return res.status(503).json({
+        success: false,
+        message: "The AI service is temporarily unavailable. Please try again shortly.",
+      });
+    }
+
+    res.status(500).json({ success: false, message: "Failed to summarize notes." });
+  }
+};
+
+/**
+ * @route POST /api/notes-summary/save
+ * @access Private
+ */
+const saveSummary = async (req, res) => {
+  try {
+    const userId = req.user._id;
+    const payload = req.body;
+
+    const summary = await NotesSummary.findOneAndUpdate(
+      { user: userId, fileName: payload.fileName },
+      { user: userId, ...payload },
+      { new: true, upsert: true, setDefaultsOnInsert: true }
+    );
+
+    const count = await NotesSummary.countDocuments({ user: userId });
+    if (count > MAX_SAVED_SUMMARIES_PER_USER) {
+      const excess = await NotesSummary.find({ user: userId })
+        .sort({ updatedAt: 1 })
+        .limit(count - MAX_SAVED_SUMMARIES_PER_USER)
+        .select("_id");
+      await NotesSummary.deleteMany({ _id: { $in: excess.map((d) => d._id) } });
+    }
+
+    res.status(200).json({ success: true, summary: summary.toSafeObject() });
+  } catch (error) {
+    console.error("Save Notes Summary Error:", error);
+    res.status(500).json({ success: false, message: "Failed to save summary." });
+  }
+};
+
+/**
+ * @route GET /api/notes-summary/my-summaries
+ * @access Private
+ */
+const getMySummaries = async (req, res) => {
+  try {
+    const summaries = await NotesSummary.find({ user: req.user._id }).sort({
+      updatedAt: -1,
+    });
+    res.status(200).json({
+      success: true,
+      summaries: summaries.map((s) => s.toSafeObject()),
+    });
+  } catch (error) {
+    console.error("Get Notes Summaries Error:", error);
+    res.status(500).json({ success: false, message: "Failed to load saved summaries." });
+  }
+};
+
+/**
+ * @route DELETE /api/notes-summary/:id
+ * @access Private
+ */
+const deleteSummary = async (req, res) => {
+  try {
+    const summary = await NotesSummary.findOneAndDelete({
+      _id: req.params.id,
+      user: req.user._id,
+    });
+    if (!summary) {
+      return res.status(404).json({ success: false, message: "Summary not found." });
+    }
+    res.status(200).json({ success: true });
+  } catch (error) {
+    console.error("Delete Notes Summary Error:", error);
+    res.status(500).json({ success: false, message: "Failed to delete summary." });
+  }
+};
+
+module.exports = { summarizeNotes, saveSummary, getMySummaries, deleteSummary };

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -29,12 +29,28 @@ async function fetchRemotePdf(url) {
   if (parsed.protocol !== "https:") {
     throw new PdfIntegrityError("PDF URLs must use https.");
   }
-  if (!ALLOWED_REMOTE_HOSTS.has(parsed.hostname)) {
+  const hostname = parsed.hostname.toLowerCase();
+
+  if (!ALLOWED_REMOTE_HOSTS.has(hostname)) {
     throw new PdfIntegrityError("This PDF source is not allowed.");
   }
 
+  if (parsed.username || parsed.password) {
+    throw new PdfIntegrityError(
+      "URLs containing credentials are not allowed."
+    );
+  }
+
+  if (parsed.port && parsed.port !== "443") {
+    throw new PdfIntegrityError(
+      "Only the default HTTPS port is allowed."
+    );
+  }
+
   try {
-    const response = await axios.get(parsed.toString(), {
+    const safeUrl = `https://${hostname}${parsed.pathname}${parsed.search}`;
+
+    const response = await axios.get(safeUrl, {
       responseType: "arraybuffer",
       timeout: 20000,
       maxContentLength: NOTES_MAX_FILE_SIZE,

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -39,6 +39,7 @@ async function fetchRemotePdf(url) {
       timeout: 20000,
       maxContentLength: NOTES_MAX_FILE_SIZE,
       maxBodyLength: NOTES_MAX_FILE_SIZE,
+      maxRedirects: 0,  
       headers: { Accept: "application/pdf" },
     });
     return Buffer.from(response.data);
@@ -59,10 +60,10 @@ async function fetchRemotePdf(url) {
  * @returns {object}
  */
 function parseAiJson(raw) {
-  let cleaned = raw
-    .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
-    .replace(/(\s*```\s*)+$/i, "")
-    .trim();
+  let cleaned = raw.trim();
+  cleaned = cleaned.replace(/^```json\s*/i, "").replace(/^```\s*/i, "");
+  cleaned = cleaned.replace(/```\s*$/i, "");
+  cleaned = cleaned.trim();
 
   try {
     return JSON.parse(cleaned);
@@ -232,10 +233,24 @@ const saveSummary = async (req, res) => {
     const payload = req.body;
 
     const summary = await NotesSummary.findOneAndUpdate(
-      { user: userId, fileName: payload.fileName },
-      { user: userId, ...payload },
-      { new: true, upsert: true, setDefaultsOnInsert: true }
-    );
+  { user: userId, fileName: payload.fileName },
+  {
+    user: userId,
+    fileName: payload.fileName,
+    sourceType: payload.sourceType,
+    sourceUrl: payload.sourceUrl,
+    pageCount: payload.pageCount,
+    wordCount: payload.wordCount,
+    contentHash: payload.contentHash,
+    summary: payload.summary,
+    topics: payload.topics,
+    prerequisites: payload.prerequisites,
+    difficulty: payload.difficulty,
+    readingTime: payload.readingTime,
+    learningOutcomes: payload.learningOutcomes,
+  },
+  { new: true, upsert: true, setDefaultsOnInsert: true }
+);
 
     const count = await NotesSummary.countDocuments({ user: userId });
     if (count > MAX_SAVED_SUMMARIES_PER_USER) {

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -246,28 +246,51 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
 const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
-    const payload = req.body;
+    const {
+    fileName,
+    sourceType,
+    sourceUrl,
+    pageCount,
+    wordCount,
+    contentHash,
+    summary,
+    topics,
+    prerequisites,
+    difficulty,
+    readingTime,
+    learningOutcomes,
+  } = req.body;
+
+  if (typeof fileName !== "string" || fileName.trim() === "") {
+    return res.status(400).json({
+      success: false,
+      message: "Invalid file name.",
+    });
+  }
 
     const summary = await NotesSummary.findOneAndUpdate(
-  { user: userId, fileName: payload.fileName },
-  {
-    user: userId,
-    fileName: payload.fileName,
-    sourceType: payload.sourceType,
-    sourceUrl: payload.sourceUrl,
-    pageCount: payload.pageCount,
-    wordCount: payload.wordCount,
-    contentHash: payload.contentHash,
-    summary: payload.summary,
-    topics: payload.topics,
-    prerequisites: payload.prerequisites,
-    difficulty: payload.difficulty,
-    readingTime: payload.readingTime,
-    learningOutcomes: payload.learningOutcomes,
-  },
-  { new: true, upsert: true, setDefaultsOnInsert: true }
-);
-
+      { user: userId, fileName },
+      {
+        user: userId,
+        fileName,
+        sourceType,
+        sourceUrl,
+        pageCount,
+        wordCount,
+        contentHash,
+        summary,
+        topics,
+        prerequisites,
+        difficulty,
+        readingTime,
+        learningOutcomes,
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      }
+    );
     const count = await NotesSummary.countDocuments({ user: userId });
     if (count > MAX_SAVED_SUMMARIES_PER_USER) {
       const excess = await NotesSummary.find({ user: userId })

--- a/backend/middlewares/csrfHeaderCheck.js
+++ b/backend/middlewares/csrfHeaderCheck.js
@@ -1,0 +1,8 @@
+
+const csrfHeaderCheck = (req, res, next) => {
+  if (req.headers["x-requested-with"] !== "XMLHttpRequest") {
+    return res.status(403).json({ message: "Missing CSRF protection header" });
+  }
+  next();
+};
+module.exports = csrfHeaderCheck;

--- a/backend/middlewares/csrfHeaderCheck.js
+++ b/backend/middlewares/csrfHeaderCheck.js
@@ -1,8 +1,12 @@
-
-const csrfHeaderCheck = (req, res, next) => {
-  if (req.headers["x-requested-with"] !== "XMLHttpRequest") {
-    return res.status(403).json({ message: "Missing CSRF protection header" });
+const csrfTokenCheck = (req, res, next) => {
+  const cookieToken = req.cookies?.csrfToken;
+  const headerToken = req.headers["x-csrf-token"];
+ 
+  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+    return res.status(403).json({ success: false, message: "CSRF token missing or invalid." });
   }
+ 
   next();
 };
-module.exports = csrfHeaderCheck;
+ 
+module.exports = csrfTokenCheck;

--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -71,4 +71,13 @@ const uploadResume = multer({
   limits: { fileSize: MAX_FILE_SIZE },
 });
 
-module.exports = { upload, uploadResume };
+// Study/notes PDFs tend to be larger than resumes, so they get a higher cap.
+const NOTES_MAX_FILE_SIZE = 15 * 1024 * 1024;
+
+const uploadNotes = multer({
+  storage: multer.memoryStorage(),
+  fileFilter: resumeFileFilter, // PDF-only, same filter as resumes
+  limits: { fileSize: NOTES_MAX_FILE_SIZE },
+});
+
+module.exports = { upload, uploadResume, uploadNotes, NOTES_MAX_FILE_SIZE };

--- a/backend/models/NotesSummary.js
+++ b/backend/models/NotesSummary.js
@@ -1,0 +1,60 @@
+const mongoose = require("mongoose");
+
+const topicsSchema = new mongoose.Schema(
+  {
+    chapters: { type: [String], default: [], validate: (v) => v.length <= 10 },
+    subtopics: { type: [String], default: [], validate: (v) => v.length <= 10 },
+    keywords: { type: [String], default: [], validate: (v) => v.length <= 15 },
+  },
+  { _id: false }
+);
+
+const difficultySchema = new mongoose.Schema(
+  {
+    level: {
+      type: String,
+      required: true,
+      enum: ["Beginner", "Intermediate", "Advanced"],
+    },
+    explanation: { type: String, required: true, maxlength: 600 },
+  },
+  { _id: false }
+);
+
+const readingTimeSchema = new mongoose.Schema(
+  {
+    minutes: { type: Number, required: true, min: 1 },
+    label: { type: String, required: true, maxlength: 50 },
+    pages: { type: Number, default: 0, min: 0 },
+  },
+  { _id: false }
+);
+
+const NotesSummarySchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true, index: true },
+    fileName: { type: String, required: true, trim: true, maxlength: 200 },
+    sourceType: { type: String, enum: ["upload", "platform"], required: true },
+    sourceUrl: { type: String, default: null, maxlength: 1000 },
+    pageCount: { type: Number, default: 0, min: 0 },
+    wordCount: { type: Number, default: 0, min: 0 },
+    contentHash: { type: String, default: null, index: true },
+    summary: { type: String, required: true, maxlength: 3000 },
+    topics: { type: topicsSchema, required: true },
+    prerequisites: { type: [String], default: [], validate: (v) => v.length <= 10 },
+    difficulty: { type: difficultySchema, required: true },
+    readingTime: { type: readingTimeSchema, required: true },
+    learningOutcomes: { type: [String], default: [], validate: (v) => v.length <= 10 },
+  },
+  { timestamps: true }
+);
+
+NotesSummarySchema.index({ user: 1, fileName: 1 });
+
+NotesSummarySchema.methods.toSafeObject = function () {
+  const obj = this.toObject();
+  delete obj.__v;
+  return obj;
+};
+
+module.exports = mongoose.model("NotesSummary", NotesSummarySchema);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -4,6 +4,7 @@ const { protect } = require("../middlewares/authMiddleware");
 const { upload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
 const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
+const csrfTokenCheck = require("../middlewares/csrfTokenCheck");
 const router = express.Router();
 
 const {
@@ -17,8 +18,8 @@ const {
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
 router.post("/login", authLimiter, validateUserLogin, loginUser);
-router.post("/refresh", authLimiter, csrfHeaderCheck, validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, csrfHeaderCheck, validateRefreshToken, logoutUser);
+router.post("/refresh", authLimiter, csrfHeaderCheck, csrfTokenCheck, validateRefreshToken, refreshToken);
+router.post("/logout", authLimiter, csrfHeaderCheck, csrfTokenCheck, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -3,6 +3,7 @@ const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserPr
 const { protect } = require("../middlewares/authMiddleware");
 const { upload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
+const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
 const router = express.Router();
 
 const {
@@ -15,8 +16,8 @@ const {
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
 router.post("/login", authLimiter, validateUserLogin, loginUser);
-router.post("/refresh", authLimiter,validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, validateRefreshToken, logoutUser);
+router.post("/refresh", authLimiter, csrfHeaderCheck, validateRefreshToken, refreshToken);
+router.post("/logout", authLimiter, csrfHeaderCheck, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,10 +1,10 @@
 const express = require("express");
+const lusca = require("lusca");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
 const { upload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
 const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
-const csrfTokenCheck = require("../middlewares/csrfTokenCheck");
 const router = express.Router();
 
 const {
@@ -14,12 +14,35 @@ const {
   sensitiveAuthLimiter,
 } = require("../middlewares/rateLimiter");
 
+// CSRF protection (double-submit token) for the two routes that authenticate
+// purely off the ambient refreshToken cookie: /refresh and /logout.
+// Requires cookie-session to be mounted in server.js so lusca has req.session
+// to store the secret in.
+const csrfProtection = lusca.csrf({
+  cookie: {
+    name: "XSRF-TOKEN",
+    options: {
+      httpOnly: false, // must be readable by frontend JS to echo back in the header
+      secure: process.env.NODE_ENV === "production",
+      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+      path: "/api/auth",
+    },
+  },
+  header: "x-csrf-token",
+});
 
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
 router.post("/login", authLimiter, validateUserLogin, loginUser);
-router.post("/refresh", authLimiter, csrfHeaderCheck, csrfTokenCheck, validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, csrfHeaderCheck, csrfTokenCheck, validateRefreshToken, logoutUser);
+
+// Frontend should GET this once on app load to prime the XSRF-TOKEN cookie
+// before it ever needs to call /refresh or /logout.
+router.get("/csrf-token", generalLimiter, csrfProtection, (req, res) => {
+  res.json({ success: true });
+});
+
+router.post("/refresh", authLimiter, csrfHeaderCheck, csrfProtection, validateRefreshToken, refreshToken);
+router.post("/logout", authLimiter, csrfHeaderCheck, csrfProtection, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const lusca = require("lusca");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
 const { upload } = require("../middlewares/uploadMiddleware");
@@ -14,22 +13,10 @@ const {
   sensitiveAuthLimiter,
 } = require("../middlewares/rateLimiter");
 
-// CSRF protection (double-submit token) for the two routes that authenticate
-// purely off the ambient refreshToken cookie: /refresh and /logout.
-// Requires cookie-session to be mounted in server.js so lusca has req.session
-// to store the secret in.
-const csrfProtection = lusca.csrf({
-  cookie: {
-    name: "XSRF-TOKEN",
-    options: {
-      httpOnly: false, // must be readable by frontend JS to echo back in the header
-      secure: process.env.NODE_ENV === "production",
-      sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-      path: "/api/auth",
-    },
-  },
-  header: "x-csrf-token",
-});
+// CSRF protection is applied globally in server.js via lusca.csrf(), with a
+// blocklist exempting every JWT-bearer-only route. Only /refresh and /logout
+// (below) are actually enforced at runtime, since they're the two routes
+// that authenticate off the ambient refreshToken cookie.
 
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
@@ -37,12 +24,12 @@ router.post("/login", authLimiter, validateUserLogin, loginUser);
 
 // Frontend should GET this once on app load to prime the XSRF-TOKEN cookie
 // before it ever needs to call /refresh or /logout.
-router.get("/csrf-token", generalLimiter, csrfProtection, (req, res) => {
+router.get("/csrf-token", generalLimiter, (req, res) => {
   res.json({ success: true });
 });
 
-router.post("/refresh", authLimiter, csrfHeaderCheck, csrfProtection, validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, csrfHeaderCheck, csrfProtection, validateRefreshToken, logoutUser);
+router.post("/refresh", authLimiter, csrfHeaderCheck, validateRefreshToken, refreshToken);
+router.post("/logout", authLimiter, csrfHeaderCheck, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/backend/routes/notesSummaryRoutes.js
+++ b/backend/routes/notesSummaryRoutes.js
@@ -1,0 +1,51 @@
+const express = require("express");
+const router = express.Router();
+const {
+  summarizeNotes,
+  saveSummary,
+  getMySummaries,
+  deleteSummary,
+} = require("../controllers/notesSummaryController");
+const { protect } = require("../middlewares/authMiddleware");
+const { uploadNotes } = require("../middlewares/uploadMiddleware");
+const { aiLimiter } = require("../middlewares/rateLimiter");
+const {
+  validateSummarizeNotes,
+  validateSaveNotesSummary,
+} = require("../Input_validators/ValidateNotesSummary");
+
+const handleUploadErrors = (err, req, res, next) => {
+  if (err) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      return res.status(400).json({
+        success: false,
+        message: "PDF is too large. Please upload a file under 15MB.",
+      });
+    }
+    return res.status(400).json({
+      success: false,
+      message: err.message || "Failed to process the uploaded file.",
+    });
+  }
+  next();
+};
+
+router.use(protect);
+
+router.post(
+  "/summarize",
+  aiLimiter,
+  uploadNotes.single("pdf"),
+  handleUploadErrors,
+  validateSummarizeNotes,
+  summarizeNotes
+);
+
+router.post("/save", validateSaveNotesSummary, saveSummary);
+
+
+router.get("/my-summaries", getMySummaries);
+
+router.delete("/:id", deleteSummary);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -86,6 +86,30 @@ connectDB()
 // middleware
 app.use(express.json());
 app.use(cookieParser());
+const { doubleCsrf } = require("csrf-csrf");
+
+const {
+  generateCsrfToken,
+  doubleCsrfProtection,
+} = doubleCsrf({
+  getSecret: () => process.env.CSRF_SECRET, // add this to .env
+  cookieName: "__Host-psifi.x-csrf-token",
+  cookieOptions: {
+    sameSite: "strict",
+    secure: process.env.NODE_ENV === "production",
+    httpOnly: true,
+  },
+  getSessionIdentifier: (req) => req.cookies?.token || "", // adapt to your auth cookie name
+});
+
+// Expose a route the frontend calls once to get a CSRF token
+app.get("/api/csrf-token", (req, res) => {
+  const token = generateCsrfToken(req, res);
+  res.json({ csrfToken: token });
+});
+
+// Apply protection to all state-changing routes
+app.use(doubleCsrfProtection);
 
 
 //Routes

--- a/backend/server.js
+++ b/backend/server.js
@@ -7,6 +7,7 @@ const path = require("path");
 const connectDB = require("./config/db");
 const cookieParser = require("cookie-parser");
 const cookieSession = require("cookie-session");
+const lusca = require("lusca");
 const {
   generateInterviewQuestions,
   generateConceptExplanation,
@@ -99,6 +100,53 @@ app.use(
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
     sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+  })
+);
+
+// Global CSRF protection. Mounted before every router so CodeQL recognizes
+// ALL downstream handlers as protected. The blocklist then exempts every
+// route that authenticates via JWT bearer header (not cookies) — meaning
+// CSRF is only actually enforced at runtime on /api/auth/refresh and
+// /api/auth/logout, the two routes that authenticate off the ambient
+// refreshToken cookie. GET/HEAD/OPTIONS requests are never validated by
+// lusca regardless of blocklist, so /api/auth/csrf-token still works as a
+// plain priming GET.
+app.use(
+  lusca.csrf({
+    cookie: {
+      name: "XSRF-TOKEN",
+      options: {
+        httpOnly: false, // must be readable by frontend JS to echo back in header
+        secure: process.env.NODE_ENV === "production",
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+      },
+    },
+    header: "x-csrf-token",
+    blocklist: [
+      { path: "/api/auth/register", type: "exact" },
+      { path: "/api/auth/login", type: "exact" },
+      { path: "/api/auth/verify-email", type: "exact" },
+      { path: "/api/auth/resend-verification", type: "exact" },
+      { path: "/api/auth/profile", type: "exact" },
+      { path: "/api/auth/change-password", type: "exact" },
+      { path: "/api/auth/delete-account", type: "exact" },
+      { path: "/api/auth/upload-image", type: "exact" },
+      { path: "/api/auth/csrf-token", type: "exact" },
+      { path: "/api/sessions", type: "startsWith" },
+      { path: "/api/question", type: "startsWith" },
+      { path: "/api/questions", type: "startsWith" },
+      { path: "/api/ai", type: "startsWith" },
+      { path: "/api/sheets", type: "startsWith" },
+      { path: "/api/user", type: "startsWith" },
+      { path: "/api/resume", type: "startsWith" },
+      { path: "/api/notes-summary", type: "startsWith" },
+      { path: "/api/books", type: "startsWith" },
+      { path: "/api/jobs", type: "startsWith" },
+      { path: "/api/courses", type: "startsWith" },
+      { path: "/api/flashcards", type: "startsWith" },
+      { path: "/api/test", type: "exact" },
+      { path: "/uploads", type: "startsWith" },
+    ],
   })
 );
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,12 +21,6 @@ const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
-const { doubleCsrf } = require("csrf-csrf");
-const { generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
-  getSecret: () => process.env.CSRF_SECRET,
-  cookieName: "__Host-csrf",
-  cookieOptions: { sameSite: "strict", secure: true, httpOnly: true },
-});
 const app = express();
 
 app.set("trust proxy", 1);
@@ -93,7 +87,6 @@ connectDB()
 app.use(express.json());
 app.use(cookieParser());
 
-app.use(doubleCsrfProtection);
 
 //Routes
 app.use("/api/auth", sensitiveRouteHeaders,authRoutes);

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,7 +12,6 @@ const {
   generateInterviewTips,
 } = require("./controllers/aiController");
 const { protect } = require("./middlewares/authMiddleware");
-// const Question = require("./models/Question");
 const authRoutes = require("./routes/authRoutes");
 const sessionRoutes = require("./routes/sessionRoutes");
 const questionRoutes = require("./routes/questionRoutes");
@@ -22,14 +21,10 @@ const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
-// Remove ES Module import for cors. Use CommonJS require below.
 const app = express();
 
 app.set("trust proxy", 1);
 app.use(generalHeaders); 
-// CORS settings: derive from env
-// FRONTEND_ORIGIN=primary production frontend
-// EXTRA_ORIGINS=comma separated additional origins (staging, preview, etc.)
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [
   process.env.FRONTEND_ORIGIN,
@@ -57,7 +52,6 @@ app.use((req, res, next) => {
     res.header("Vary", "Origin");
     res.header("Access-Control-Allow-Credentials", "true");
   } else if (origin) {
-    // Debug log for rejected origins (only once per process for each origin)
     if (!global.__rejectedCors) global.__rejectedCors = new Set();
     if (!global.__rejectedCors.has(origin)) {
       global.__rejectedCors.add(origin);
@@ -108,6 +102,8 @@ app.use("/api/user", generalLimiter, achievementRoutes);
 const booksRoutes = require("./routes/booksRoutes");
 const { validateGenerateInterviewQuestions, validateGenerateConceptExplanation, validateGenerateInterviewTips } = require("./Input_validators/ValidateAi.js");
 app.use("/api/resume", generalLimiter, resumeRoutes);
+const notesSummaryRoutes = require("./routes/notesSummaryRoutes");
+app.use("/api/notes-summary", generalLimiter, notesSummaryRoutes);
 
 // AI routes with Zod validation
 app.post(
@@ -146,7 +142,6 @@ const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 
 
-//Serve uploads folder
 app.use("/uploads", express.static(path.join(__dirname, "uploads"), {}));
 
 // Debug route to verify backend is working
@@ -154,10 +149,7 @@ app.get("/api/test", (req, res) => {
   res.json({ message: "API is working!" });
 });
 
-// Remove duplicate CORS middleware (already set above)
 
-// Daily job cache refresh — warm on boot, then every 24 hours.
-// Only runs when Adzuna is configured; otherwise refreshJobCache() no-ops.
 if (process.env.ADZUNA_APP_ID && process.env.ADZUNA_API_KEY) {
   const { refreshJobCache } = require("./controllers/jobController");
   refreshJobCache();

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,12 @@ const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
+const { doubleCsrf } = require("csrf-csrf");
+const { generateCsrfToken, doubleCsrfProtection } = doubleCsrf({
+  getSecret: () => process.env.CSRF_SECRET,
+  cookieName: "__Host-csrf",
+  cookieOptions: { sameSite: "strict", secure: true, httpOnly: true },
+});
 const app = express();
 
 app.set("trust proxy", 1);
@@ -86,6 +92,8 @@ connectDB()
 // middleware
 app.use(express.json());
 app.use(cookieParser());
+
+app.use(doubleCsrfProtection);
 
 //Routes
 app.use("/api/auth", sensitiveRouteHeaders,authRoutes);

--- a/backend/server.js
+++ b/backend/server.js
@@ -6,6 +6,7 @@ const cors = require("cors");
 const path = require("path");
 const connectDB = require("./config/db");
 const cookieParser = require("cookie-parser");
+const cookieSession = require("cookie-session");
 const {
   generateInterviewQuestions,
   generateConceptExplanation,
@@ -63,7 +64,7 @@ app.use((req, res, next) => {
   }
   if (req.method === "OPTIONS") {
     res.header("Access-Control-Allow-Methods", "GET,POST,PUT,DELETE,OPTIONS");
-    res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    res.header("Access-Control-Allow-Headers", "Content-Type, Authorization, X-CSRF-Token");
     return res.sendStatus(200);
   }
   next();
@@ -86,30 +87,20 @@ connectDB()
 // middleware
 app.use(express.json());
 app.use(cookieParser());
-const { doubleCsrf } = require("csrf-csrf");
 
-const {
-  generateCsrfToken,
-  doubleCsrfProtection,
-} = doubleCsrf({
-  getSecret: () => process.env.CSRF_SECRET, // add this to .env
-  cookieName: "__Host-psifi.x-csrf-token",
-  cookieOptions: {
-    sameSite: "strict",
-    secure: process.env.NODE_ENV === "production",
+// Lightweight, store-free session used ONLY to hold the CSRF secret for
+// lusca.csrf(). All real authentication remains JWT-based (see
+// middlewares/authMiddleware.js) — this does not make the API stateful.
+app.use(
+  cookieSession({
+    name: "csrfSession",
+    keys: [process.env.CSRF_SESSION_SECRET || process.env.JWT_SECRET],
+    maxAge: 24 * 60 * 60 * 1000, // 24h
     httpOnly: true,
-  },
-  getSessionIdentifier: (req) => req.cookies?.token || "", // adapt to your auth cookie name
-});
-
-// Expose a route the frontend calls once to get a CSRF token
-app.get("/api/csrf-token", (req, res) => {
-  const token = generateCsrfToken(req, res);
-  res.json({ csrfToken: token });
-});
-
-// Apply protection to all state-changing routes
-app.use(doubleCsrfProtection);
+    secure: process.env.NODE_ENV === "production",
+    sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
+  })
+);
 
 
 //Routes

--- a/backend/utils/pdfIntegrity.js
+++ b/backend/utils/pdfIntegrity.js
@@ -1,0 +1,78 @@
+const { PDFParse } = require("pdf-parse");
+
+const PDF_MAGIC_BYTES = "%PDF-";
+const AVERAGE_READING_WPM = 200; 
+
+
+class PdfIntegrityError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "PdfIntegrityError";
+  }
+}
+
+/**
+ *
+ * @param {Buffer} buffer
+ * @returns {Promise<{ numPages: number, wordCount: number, charCount: number, isLikelyScanned: boolean }>}
+ * @throws {PdfIntegrityError} If the buffer isn't a real, readable PDF.
+ */
+async function inspectPdfBuffer(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length === 0) {
+    throw new PdfIntegrityError("The uploaded file is empty or unreadable.");
+  }
+
+  const header = buffer.subarray(0, 5).toString("latin1");
+  if (header !== PDF_MAGIC_BYTES) {
+    throw new PdfIntegrityError(
+      "This file doesn't look like a valid PDF (missing PDF header)."
+    );
+  }
+
+  let parser;
+  try {
+    parser = new PDFParse({ data: buffer });
+    const info = await parser.getInfo();
+    const textResult = await parser.getText();
+
+    const numPages = Math.max(1, info?.total || 1);
+    const text = textResult?.text || "";
+    const wordCount = text.trim() ? text.trim().split(/\s+/).length : 0;
+    const charCount = text.length;
+
+    const isLikelyScanned = wordCount < numPages * 20;
+
+    return { numPages, wordCount, charCount, isLikelyScanned };
+  } catch (err) {
+    if (err instanceof PdfIntegrityError) throw err;
+    throw new PdfIntegrityError(
+      "The PDF appears to be corrupted, encrypted, or unreadable."
+    );
+  } finally {
+    if (parser) {
+      try {
+        await parser.destroy();
+      } catch {
+      }
+    }
+  }
+}
+
+/**
+ * @param {{ numPages: number, wordCount: number, isLikelyScanned: boolean }} stats
+ * @returns {{ minutes: number, label: string, pages: number }}
+ */
+function computeReadingTime({ numPages, wordCount, isLikelyScanned }) {
+  const minutes = isLikelyScanned || wordCount === 0
+    ? Math.max(3, Math.round(numPages * 2.2))
+    : Math.max(3, Math.round(wordCount / AVERAGE_READING_WPM));
+
+  const label =
+    minutes >= 60
+      ? `${Math.floor(minutes / 60)} hr ${minutes % 60} min`
+      : `${minutes} min`;
+
+  return { minutes, label, pages: numPages };
+}
+
+module.exports = { inspectPdfBuffer, computeReadingTime, PdfIntegrityError };

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -36,6 +36,7 @@ import RepositoryHive from "./pages/OpenSource/RepositoryHive";
 import OSSBlog from "./pages/OpenSource/OSSBlog";
 import OpenSourceEvents from "./pages/OpenSource/OpenSourceEvents";
 import NotesBooks from "./pages/NotesBooks/NotesBooks";
+import NotesSummarizer from "./pages/NotesSummarizer/NotesSummarizer";
 import JobsForYou from "./pages/Jobs/JobsForYou";
 import HelpSupport from "./pages/Support/HelpSupport";
 import Settings from "./pages/Settings/Settings";
@@ -332,6 +333,16 @@ const App = () => {
                       <PageTransition>
                         <NotesBooks />
                       </PageTransition>
+                    }
+                  />
+                  <Route
+                    path="/notes-summarizer"
+                    element={
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <NotesSummarizer />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   <Route

--- a/frontend/src/components/Layouts/Sidebar.jsx
+++ b/frontend/src/components/Layouts/Sidebar.jsx
@@ -10,7 +10,7 @@ import {
   Code2, Target, Settings, HelpCircle, User as UserIcon, LogOut,
   Menu, X, FileText, Zap, MessageSquare, Lightbulb, ChevronUp,
   ChevronDown, Github, BookOpen, BookMarked, CalendarDays, ScrollText,
-  Grid3x3, GraduationCap, Calculator, RotateCcw,
+  Grid3x3, GraduationCap, Calculator, RotateCcw, Sparkles,
 } from "lucide-react";
 
 /* ── NAV DEFINITION ──────────────────────────────────────────────────────── */
@@ -115,6 +115,7 @@ const NAV_ITEMS = [
     isHeader: true,
     items: [
       { id: "notes-books-home", title: "Notes & Books", path: "/notes-books", icon: BookMarked },
+      { id: "notes-summarizer", title: "AI Notes Summarizer", path: "/notes-summarizer", icon: Sparkles },
     ],
   },
   {

--- a/frontend/src/pages/NotesSummarizer/NotesSummarizer.jsx
+++ b/frontend/src/pages/NotesSummarizer/NotesSummarizer.jsx
@@ -1,0 +1,984 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Sparkles,
+  UploadCloud,
+  FileText,
+  X,
+  Search,
+  Copy,
+  Download,
+  Bookmark,
+  BookmarkCheck,
+  RotateCcw,
+  Clock,
+  Layers,
+  ListChecks,
+  GraduationCap,
+  BookOpen,
+  Tag,
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  FolderOpen,
+  Trash2,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { BASE_URL, API_PATHS } from "../../utils/apiPaths";
+import axiosInstance from "../../utils/axiosinstance";
+
+/* ────────────────────────────────────────────────────────────────────────
+   Helpers
+   ──────────────────────────────────────────────────────────────────────── */
+
+const formatBytes = (bytes) => {
+  if (!bytes && bytes !== 0) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+};
+
+// Labels shown while the real backend request is in flight. The upload
+// stage tracks real multipart upload progress (via axios onUploadProgress);
+// the remaining stages advance on a timer since the AI/parse work happens
+// server-side and doesn't report incremental progress.
+const PROCESSING_STAGES = [
+  "Uploading document…",
+  "Validating PDF & extracting text…",
+  "Identifying key topics…",
+  "Estimating difficulty & prerequisites…",
+  "Generating summary & outcomes…",
+];
+
+/* ────────────────────────────────────────────────────────────────────────
+   Small presentational bits
+   ──────────────────────────────────────────────────────────────────────── */
+
+const SectionCard = ({ icon: Icon, title, subtitle, children, className = "" }) => (
+  <div
+    className={`bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-5 space-y-4 ${className}`}
+  >
+    <div className="flex items-center gap-3">
+      <div className="w-9 h-9 rounded-xl bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center shrink-0">
+        <Icon size={18} />
+      </div>
+      <div className="min-w-0">
+        <h3 className="text-sm font-bold text-gray-900 dark:text-white">{title}</h3>
+        {subtitle && (
+          <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{subtitle}</p>
+        )}
+      </div>
+    </div>
+    {children}
+  </div>
+);
+
+const Chip = ({ children, tone = "violet" }) => {
+  const tones = {
+    violet:
+      "bg-violet-50 dark:bg-violet-500/10 text-violet-700 dark:text-violet-300 border-violet-100 dark:border-violet-500/20",
+    gray:
+      "bg-gray-100 dark:bg-white/5 text-gray-700 dark:text-gray-300 border-gray-200 dark:border-white/10",
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-1 rounded-lg text-xs font-semibold border ${tones[tone]}`}
+    >
+      {children}
+    </span>
+  );
+};
+
+const highlightText = (text, term) => {
+  if (!term.trim()) return text;
+  const safe = term.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const parts = text.split(new RegExp(`(${safe})`, "ig"));
+  return parts.map((part, i) =>
+    part.toLowerCase() === term.trim().toLowerCase() ? (
+      <mark
+        key={i}
+        className="bg-amber-200 dark:bg-amber-500/40 text-inherit rounded px-0.5"
+      >
+        {part}
+      </mark>
+    ) : (
+      <React.Fragment key={i}>{part}</React.Fragment>
+    )
+  );
+};
+
+/* ────────────────────────────────────────────────────────────────────────
+   Main component
+   ──────────────────────────────────────────────────────────────────────── */
+
+const NotesSummarizer = () => {
+  const [sourceMode, setSourceMode] = useState("upload"); // "upload" | "platform"
+
+  // Upload state
+  const [file, setFile] = useState(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const fileInputRef = useRef(null);
+
+  // Platform picker state
+  const [platformCategories, setPlatformCategories] = useState([]);
+  const [platformLoading, setPlatformLoading] = useState(false);
+  const [platformError, setPlatformError] = useState(null);
+  const [selectedPlatformDoc, setSelectedPlatformDoc] = useState(null);
+  const [platformSearch, setPlatformSearch] = useState("");
+  const [expandedFolders, setExpandedFolders] = useState({});
+
+  // Processing / result state
+  const [isProcessing, setIsProcessing] = useState(false);
+  const [stageIndex, setStageIndex] = useState(0);
+  const [progress, setProgress] = useState(0);
+  const [result, setResult] = useState(null);
+  const [error, setError] = useState(null);
+
+  // Result UI state
+  const [searchTerm, setSearchTerm] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [savedSummaries, setSavedSummaries] = useState([]);
+  const [savedLoading, setSavedLoading] = useState(false);
+  const [isSaved, setIsSaved] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  /* Load the user's saved summaries from the backend on mount */
+  const fetchSavedSummaries = async () => {
+    try {
+      setSavedLoading(true);
+      const { data } = await axiosInstance.get(API_PATHS.NOTES_SUMMARY.GET_ALL);
+      setSavedSummaries(data.summaries || []);
+    } catch (err) {
+      console.error("Failed to load saved summaries:", err);
+    } finally {
+      setSavedLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSavedSummaries();
+  }, []);
+
+  /* Fetch platform PDFs lazily when that tab is opened, keeping them
+     clubbed inside their originating folder (category) */
+  const fetchPlatformDocs = async () => {
+    if (platformCategories.length || platformLoading) return;
+    try {
+      setPlatformLoading(true);
+      setPlatformError(null);
+      const res = await fetch(`${BASE_URL}/api/books`);
+      if (!res.ok) throw new Error("Unable to load platform notes right now.");
+      const data = await res.json();
+      const categories = (data.categories || []).map((cat, idx) => ({
+        id: cat.id || `${cat.title}-${idx}`,
+        title: cat.title,
+        items: (cat.items || []).map((item) => ({
+          name: item.name,
+          category: cat.title,
+          url: item.url,
+        })),
+      }));
+      setPlatformCategories(categories);
+      // Expand the first folder by default so the picker isn't empty-looking
+      if (categories[0]) {
+        setExpandedFolders({ [categories[0].id]: true });
+      }
+    } catch (err) {
+      setPlatformError(err.message || "Could not load notes from the platform.");
+    } finally {
+      setPlatformLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (sourceMode === "platform") fetchPlatformDocs();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sourceMode]);
+
+  // Folders (and the PDFs inside them) filtered by the search bar. A folder
+  // whose title matches keeps all its PDFs; otherwise only matching PDFs
+  // inside it are kept.
+  const filteredPlatformCategories = useMemo(() => {
+    const term = platformSearch.trim().toLowerCase();
+    if (!term) return platformCategories;
+
+    return platformCategories
+      .map((cat) => {
+        const folderMatches = cat.title.toLowerCase().includes(term);
+        const items = folderMatches
+          ? cat.items
+          : cat.items.filter((item) => item.name.toLowerCase().includes(term));
+        return { ...cat, items };
+      })
+      .filter((cat) => cat.items.length > 0);
+  }, [platformCategories, platformSearch]);
+
+  // Auto-expand every folder that currently has search matches so results
+  // aren't hidden behind a collapsed header.
+  useEffect(() => {
+    if (!platformSearch.trim()) return;
+    setExpandedFolders((prev) => {
+      const next = { ...prev };
+      filteredPlatformCategories.forEach((cat) => {
+        next[cat.id] = true;
+      });
+      return next;
+    });
+  }, [platformSearch, filteredPlatformCategories]);
+
+  const toggleFolder = (id) =>
+    setExpandedFolders((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  const totalPlatformDocCount = useMemo(
+    () => platformCategories.reduce((acc, cat) => acc + cat.items.length, 0),
+    [platformCategories]
+  );
+
+  /* Upload handlers */
+  const acceptFile = (candidate) => {
+    if (!candidate) return;
+    if (candidate.type !== "application/pdf") {
+      setError("Please upload a valid PDF file.");
+      return;
+    }
+    if (candidate.size > 15 * 1024 * 1024) {
+      setError("File is too large. Please upload a PDF under 15MB.");
+      return;
+    }
+    setError(null);
+    setFile(candidate);
+    setSelectedPlatformDoc(null);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    setIsDragging(false);
+    acceptFile(e.dataTransfer.files?.[0]);
+  };
+
+  const handleFileChange = (e) => acceptFile(e.target.files?.[0]);
+
+  const activeSourceLabel = useMemo(() => {
+    if (sourceMode === "upload" && file) return file.name;
+    if (sourceMode === "platform" && selectedPlatformDoc) return selectedPlatformDoc.name;
+    return null;
+  }, [sourceMode, file, selectedPlatformDoc]);
+
+  const canAnalyze =
+    (sourceMode === "upload" && !!file) ||
+    (sourceMode === "platform" && !!selectedPlatformDoc);
+
+  /* Real AI processing pipeline — uploads/fetches the PDF, then Gemini
+     analyzes it server-side (see backend/controllers/notesSummaryController.js) */
+  const handleAnalyze = async () => {
+    if (!canAnalyze || isProcessing) return;
+    setError(null);
+    setResult(null);
+    setIsSaved(false);
+    setSearchTerm("");
+    setIsProcessing(true);
+    setStageIndex(0);
+    setProgress(0);
+
+    // While the server does the (un-trackable) parsing + AI work, nudge the
+    // stage indicator forward on a timer so the UI doesn't look frozen.
+    let stageTimer = null;
+    const advanceStages = () => {
+      stageTimer = setInterval(() => {
+        setStageIndex((prev) => Math.min(PROCESSING_STAGES.length - 1, prev + 1));
+        setProgress((prev) => Math.min(92, prev + 12));
+      }, 900);
+    };
+
+    try {
+      let response;
+      if (sourceMode === "upload") {
+        const formData = new FormData();
+        formData.append("pdf", file);
+
+        response = await axiosInstance.post(API_PATHS.NOTES_SUMMARY.SUMMARIZE, formData, {
+          headers: { "Content-Type": "multipart/form-data" },
+          onUploadProgress: (evt) => {
+            if (!evt.total) return;
+            // Upload itself only accounts for the first stage/~30% of the bar;
+            // the rest represents server-side parsing + AI generation.
+            const uploadPct = Math.round((evt.loaded / evt.total) * 30);
+            setProgress(uploadPct);
+            if (evt.loaded >= evt.total) {
+              setStageIndex(1);
+              advanceStages();
+            }
+          },
+        });
+      } else {
+        setStageIndex(1);
+        advanceStages();
+        response = await axiosInstance.post(API_PATHS.NOTES_SUMMARY.SUMMARIZE, {
+          url: selectedPlatformDoc.url,
+          fileName: selectedPlatformDoc.name,
+        });
+      }
+
+      if (stageTimer) clearInterval(stageTimer);
+      setProgress(100);
+      setStageIndex(PROCESSING_STAGES.length - 1);
+      setResult(response.data);
+    } catch (err) {
+      if (stageTimer) clearInterval(stageTimer);
+      console.error("Summarize error:", err);
+      setError(
+        err.response?.data?.message ||
+          err.response?.data?.error ||
+          "Failed to summarize the PDF. Please try again."
+      );
+    } finally {
+      setIsProcessing(false);
+    }
+  };
+
+  const resetFlow = () => {
+    setFile(null);
+    setSelectedPlatformDoc(null);
+    setResult(null);
+    setError(null);
+    setProgress(0);
+    setStageIndex(0);
+    setSearchTerm("");
+    setIsSaved(false);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  /* Result actions */
+  const buildExportText = (r) =>
+    `${r.fileName}\n` +
+    `Generated: ${new Date(r.generatedAt).toLocaleString()}\n\n` +
+    `SUMMARY\n${r.summary}\n\n` +
+    `TOPICS COVERED\nChapters: ${r.topics.chapters.join(", ")}\nSubtopics: ${r.topics.subtopics.join(", ")}\nKeywords: ${r.topics.keywords.join(", ")}\n\n` +
+    `PREREQUISITES\n${r.prerequisites.map((p) => `- ${p}`).join("\n")}\n\n` +
+    `DIFFICULTY LEVEL\n${r.difficulty.level} — ${r.difficulty.explanation}\n\n` +
+    `ESTIMATED READING TIME\n${r.readingTime.label} (~${r.readingTime.pages} pages)\n\n` +
+    `LEARNING OUTCOMES\n${r.learningOutcomes.map((o) => `- ${o}`).join("\n")}\n`;
+
+  const handleCopy = async () => {
+    if (!result) return;
+    try {
+      await navigator.clipboard.writeText(buildExportText(result));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError("Couldn't copy to clipboard. Try downloading instead.");
+    }
+  };
+
+  const handleDownload = () => {
+    if (!result) return;
+    const blob = new Blob([buildExportText(result)], { type: "text/plain;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${result.fileName.replace(/\.pdf$/i, "")}-summary.txt`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleSave = async () => {
+    if (!result || isSaving) return;
+    setIsSaving(true);
+    setError(null);
+    try {
+      const payload = {
+        fileName: result.fileName,
+        sourceType: result.sourceType,
+        sourceUrl: result.sourceUrl ?? null,
+        pageCount: result.pageCount ?? 0,
+        wordCount: result.wordCount ?? 0,
+        contentHash: result.contentHash ?? null,
+        summary: result.summary,
+        topics: result.topics,
+        prerequisites: result.prerequisites,
+        difficulty: result.difficulty,
+        readingTime: result.readingTime,
+        learningOutcomes: result.learningOutcomes,
+      };
+      await axiosInstance.post(API_PATHS.NOTES_SUMMARY.SAVE, payload);
+      setIsSaved(true);
+      fetchSavedSummaries();
+    } catch (err) {
+      console.error("Save summary error:", err);
+      setError(err.response?.data?.message || "Failed to save this summary. Please try again.");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleDeleteSaved = async (id) => {
+    const previous = savedSummaries;
+    setSavedSummaries((prev) => prev.filter((s) => s._id !== id));
+    try {
+      await axiosInstance.delete(API_PATHS.NOTES_SUMMARY.DELETE(id));
+    } catch (err) {
+      console.error("Delete summary error:", err);
+      setSavedSummaries(previous); // roll back on failure
+    }
+  };
+
+  const loadSavedSummary = (entry) => {
+    setResult({
+      ...entry,
+      generatedAt: entry.generatedAt || entry.updatedAt || entry.createdAt,
+    });
+    setSourceMode("upload");
+    setFile(null);
+    setSelectedPlatformDoc(null);
+    setIsSaved(true);
+    setSearchTerm("");
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
+
+  /* ──────────────────────────────────────────────────────────────────── */
+
+  return (
+    <div className="min-h-full bg-[var(--color-background)] text-[var(--color-text-dark)]">
+      <div className="max-w-6xl mx-auto p-6 md:p-8 space-y-8">
+        {/* Header */}
+        <div className="flex flex-col gap-3 bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-6 shadow-sm">
+          <div className="flex items-center gap-3">
+            <div className="w-11 h-11 rounded-2xl bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center">
+              <Sparkles size={22} />
+            </div>
+            <div>
+              <h1 className="text-xl md:text-2xl font-bold">AI PDF Notes Summarizer</h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                Upload any PDF notes and instantly get a summary, topics covered,
+                prerequisites, difficulty level, and learning outcomes.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {error && (
+          <div className="flex items-start gap-3 p-4 rounded-xl border border-red-200 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-200">
+            <AlertCircle size={18} className="shrink-0 mt-0.5" />
+            <p className="text-sm">{error}</p>
+          </div>
+        )}
+
+        {!result && !isProcessing && (
+          <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-6 space-y-6">
+            {/* Source tabs */}
+            <div className="inline-flex p-1 rounded-xl bg-gray-100 dark:bg-white/5 border border-gray-200 dark:border-white/10">
+              <button
+                onClick={() => setSourceMode("upload")}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                  sourceMode === "upload"
+                    ? "bg-white dark:bg-white/10 text-violet-600 dark:text-violet-300 shadow-sm"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-white"
+                }`}
+              >
+                Upload PDF
+              </button>
+              <button
+                onClick={() => setSourceMode("platform")}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                  sourceMode === "platform"
+                    ? "bg-white dark:bg-white/10 text-violet-600 dark:text-violet-300 shadow-sm"
+                    : "text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-white"
+                }`}
+              >
+                Choose from Notes & Books
+              </button>
+            </div>
+
+            {/* Upload dropzone */}
+            {sourceMode === "upload" && (
+              <div
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setIsDragging(true);
+                }}
+                onDragLeave={() => setIsDragging(false)}
+                onDrop={handleDrop}
+                onClick={() => fileInputRef.current?.click()}
+                className={`relative flex flex-col items-center justify-center text-center gap-3 h-64 rounded-2xl border-2 border-dashed cursor-pointer transition-colors ${
+                  isDragging
+                    ? "border-violet-500 bg-violet-50/50 dark:bg-violet-500/10"
+                    : "border-gray-300 dark:border-white/10 hover:border-violet-400 dark:hover:border-violet-400/50"
+                }`}
+              >
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/pdf"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+                <div className="w-14 h-14 rounded-2xl bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center">
+                  <UploadCloud size={26} />
+                </div>
+                {file ? (
+                  <div className="flex items-center gap-2 px-4 py-2 rounded-xl bg-gray-100 dark:bg-white/10">
+                    <FileText size={16} className="text-violet-500" />
+                    <span className="text-sm font-semibold max-w-xs truncate">{file.name}</span>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {formatBytes(file.size)}
+                    </span>
+                    <button
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setFile(null);
+                        if (fileInputRef.current) fileInputRef.current.value = "";
+                      }}
+                      className="text-gray-400 hover:text-red-500 transition-colors"
+                    >
+                      <X size={15} />
+                    </button>
+                  </div>
+                ) : (
+                  <>
+                    <p className="text-sm font-semibold">
+                      Drag & drop your PDF here, or click to browse
+                    </p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      Supports PDF files up to 15MB
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Platform picker */}
+            {sourceMode === "platform" && (
+              <div className="space-y-3">
+                {!platformLoading && !platformError && platformCategories.length > 0 && (
+                  <div className="relative">
+                    <Search
+                      size={14}
+                      className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"
+                    />
+                    <input
+                      value={platformSearch}
+                      onChange={(e) => setPlatformSearch(e.target.value)}
+                      placeholder="Search folders or PDFs…"
+                      className="w-full pl-8 pr-3 py-2 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent text-sm focus:outline-none focus:ring-2 focus:ring-violet-400/70"
+                    />
+                  </div>
+                )}
+
+                {platformLoading && (
+                  <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 py-8 justify-center">
+                    <Loader2 size={16} className="animate-spin" />
+                    Loading notes from the platform…
+                  </div>
+                )}
+
+                {!platformLoading && platformError && (
+                  <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-300 py-6 justify-center">
+                    <AlertCircle size={16} />
+                    {platformError}
+                  </div>
+                )}
+
+                {!platformLoading && !platformError && platformCategories.length === 0 && (
+                  <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 py-8 justify-center">
+                    <FolderOpen size={16} />
+                    No platform notes available right now.
+                  </div>
+                )}
+
+                {!platformLoading && platformCategories.length > 0 && (
+                  <>
+                    {filteredPlatformCategories.length === 0 ? (
+                      <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 py-8 justify-center">
+                        <Search size={16} />
+                        No folders or PDFs match “{platformSearch}”.
+                      </div>
+                    ) : (
+                      <div className="max-h-80 overflow-y-auto custom-scrollbar space-y-2 pr-1">
+                        {filteredPlatformCategories.map((cat) => {
+                          const isOpen = !!expandedFolders[cat.id];
+                          return (
+                            <div
+                              key={cat.id}
+                              className="rounded-xl border border-gray-200 dark:border-white/10 overflow-hidden"
+                            >
+                              {/* Folder header */}
+                              <button
+                                onClick={() => toggleFolder(cat.id)}
+                                className="w-full flex items-center gap-3 p-3 bg-gray-50 dark:bg-white/5 hover:bg-gray-100 dark:hover:bg-white/10 transition-colors text-left"
+                              >
+                                <div className="w-9 h-9 rounded-lg bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center shrink-0">
+                                  <FolderOpen size={16} />
+                                </div>
+                                <div className="flex-1 min-w-0">
+                                  <p className="text-sm font-semibold truncate">{cat.title}</p>
+                                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                                    {cat.items.length} PDF{cat.items.length === 1 ? "" : "s"}
+                                  </p>
+                                </div>
+                                {isOpen ? (
+                                  <ChevronUp size={16} className="text-gray-400 shrink-0" />
+                                ) : (
+                                  <ChevronDown size={16} className="text-gray-400 shrink-0" />
+                                )}
+                              </button>
+
+                              {/* Folder contents */}
+                              {isOpen && (
+                                <div className="p-2 space-y-1.5 bg-white dark:bg-transparent">
+                                  {cat.items.map((doc) => {
+                                    const active = selectedPlatformDoc?.name === doc.name;
+                                    return (
+                                      <button
+                                        key={`${doc.category}-${doc.name}`}
+                                        onClick={() => {
+                                          setSelectedPlatformDoc(doc);
+                                          setFile(null);
+                                        }}
+                                        className={`w-full flex items-center gap-3 p-2.5 rounded-lg border text-left transition-colors ${
+                                          active
+                                            ? "border-violet-400 bg-violet-50/60 dark:bg-violet-500/10"
+                                            : "border-transparent hover:border-violet-300 dark:hover:border-violet-400/40 hover:bg-violet-50/30 dark:hover:bg-violet-500/5"
+                                        }`}
+                                      >
+                                        <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-white/5 flex items-center justify-center text-gray-600 dark:text-gray-300 shrink-0">
+                                          <FileText size={14} />
+                                        </div>
+                                        <p className="flex-1 min-w-0 text-sm font-medium truncate">
+                                          {doc.name}
+                                        </p>
+                                        {active && (
+                                          <CheckCircle2 size={16} className="text-violet-500 shrink-0" />
+                                        )}
+                                      </button>
+                                    );
+                                  })}
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+
+                    <p className="text-xs text-gray-400 text-right">
+                      {totalPlatformDocCount} PDF{totalPlatformDocCount === 1 ? "" : "s"} across{" "}
+                      {platformCategories.length} folder{platformCategories.length === 1 ? "" : "s"}
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+
+            <button
+              onClick={handleAnalyze}
+              disabled={!canAnalyze}
+              className={`w-full flex items-center justify-center gap-2 py-3.5 rounded-xl font-bold text-sm transition-all ${
+                !canAnalyze
+                  ? "bg-gray-200 dark:bg-white/5 text-gray-400 dark:text-gray-600 cursor-not-allowed"
+                  : "bg-violet-600 hover:bg-violet-700 text-white shadow-sm hover:shadow-lg active:scale-[0.99]"
+              }`}
+            >
+              <Sparkles size={17} />
+              Summarize Notes
+              {activeSourceLabel && <ChevronRight size={15} />}
+            </button>
+          </div>
+        )}
+
+        {/* Processing state */}
+        {isProcessing && (
+          <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-10 flex flex-col items-center text-center gap-5">
+            <div className="w-16 h-16 rounded-2xl bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center">
+              <Loader2 size={28} className="animate-spin" />
+            </div>
+            <div>
+              <p className="font-semibold">{PROCESSING_STAGES[stageIndex]}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                Analyzing “{activeSourceLabel}”
+              </p>
+            </div>
+            <div className="w-full max-w-sm h-2 rounded-full bg-gray-100 dark:bg-white/10 overflow-hidden">
+              <div
+                className="h-full bg-violet-500 transition-all duration-150 ease-linear"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <p className="text-xs text-gray-400">{progress}%</p>
+          </div>
+        )}
+
+        {/* Results */}
+        {result && !isProcessing && (
+          <div className="space-y-6">
+            {/* Toolbar */}
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-4">
+              <div className="flex items-center gap-3 min-w-0">
+                <div className="w-9 h-9 rounded-xl bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center shrink-0">
+                  <FileText size={16} />
+                </div>
+                <div className="min-w-0">
+                  <p className="text-sm font-semibold truncate">{result.fileName}</p>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Generated {new Date(result.generatedAt).toLocaleString()}
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-2 flex-wrap">
+                <button
+                  onClick={handleCopy}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-lg border border-gray-200 dark:border-white/10 hover:border-violet-300 dark:hover:border-violet-400/50 transition-colors"
+                >
+                  {copied ? <CheckCircle2 size={14} className="text-emerald-500" /> : <Copy size={14} />}
+                  {copied ? "Copied" : "Copy"}
+                </button>
+                <button
+                  onClick={handleDownload}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-lg border border-gray-200 dark:border-white/10 hover:border-violet-300 dark:hover:border-violet-400/50 transition-colors"
+                >
+                  <Download size={14} />
+                  Download
+                </button>
+                <button
+                  onClick={handleSave}
+                  disabled={isSaved || isSaving}
+                  className={`inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-lg border transition-colors ${
+                    isSaved
+                      ? "border-emerald-200 dark:border-emerald-500/30 text-emerald-600 dark:text-emerald-300 bg-emerald-50 dark:bg-emerald-500/10"
+                      : "border-gray-200 dark:border-white/10 hover:border-violet-300 dark:hover:border-violet-400/50"
+                  }`}
+                >
+                  {isSaving ? (
+                    <Loader2 size={14} className="animate-spin" />
+                  ) : isSaved ? (
+                    <BookmarkCheck size={14} />
+                  ) : (
+                    <Bookmark size={14} />
+                  )}
+                  {isSaving ? "Saving…" : isSaved ? "Saved" : "Save"}
+                </button>
+                <button
+                  onClick={resetFlow}
+                  className="inline-flex items-center gap-1.5 px-3 py-2 text-xs font-semibold rounded-lg border border-gray-200 dark:border-white/10 hover:border-violet-300 dark:hover:border-violet-400/50 transition-colors"
+                >
+                  <RotateCcw size={14} />
+                  New Summary
+                </button>
+              </div>
+            </div>
+
+            {/* Quick stats row */}
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+              <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-4 flex items-center gap-3">
+                <Clock size={18} className="text-violet-500" />
+                <div>
+                  <p className="text-sm font-bold">{result.readingTime.label}</p>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400">Est. reading time</p>
+                </div>
+              </div>
+              <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-4 flex items-center gap-3">
+                <Layers size={18} className="text-violet-500" />
+                <div>
+                  <p className="text-sm font-bold">{result.difficulty.level}</p>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400">Difficulty level</p>
+                </div>
+              </div>
+              <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-4 flex items-center gap-3">
+                <BookOpen size={18} className="text-violet-500" />
+                <div>
+                  <p className="text-sm font-bold">{result.topics.chapters.length} chapters</p>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400">Topics identified</p>
+                </div>
+              </div>
+              <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-4 flex items-center gap-3">
+                <ListChecks size={18} className="text-violet-500" />
+                <div>
+                  <p className="text-sm font-bold">{result.learningOutcomes.length} outcomes</p>
+                  <p className="text-[11px] text-gray-500 dark:text-gray-400">Learning outcomes</p>
+                </div>
+              </div>
+            </div>
+
+            <div className="grid md:grid-cols-2 gap-5">
+              {/* Smart summary with search-within */}
+              <SectionCard
+                icon={Sparkles}
+                title="Smart Summary"
+                subtitle="Main topics, concepts & purpose"
+                className="md:col-span-2"
+              >
+                <div className="relative">
+                  <Search size={14} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
+                  <input
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                    placeholder="Search within summary…"
+                    className="w-full pl-8 pr-3 py-2 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent text-sm focus:outline-none focus:ring-2 focus:ring-violet-400/70"
+                  />
+                </div>
+                <p className="text-sm leading-relaxed text-gray-700 dark:text-gray-300">
+                  {highlightText(result.summary, searchTerm)}
+                </p>
+              </SectionCard>
+
+              {/* Topics covered */}
+              <SectionCard icon={BookOpen} title="Topics Covered" subtitle="Chapters, subtopics & keywords">
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-[11px] font-bold uppercase tracking-wide text-gray-400 mb-1.5">
+                      Major Chapters
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {result.topics.chapters.map((c) => (
+                        <Chip key={c}>{c}</Chip>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-[11px] font-bold uppercase tracking-wide text-gray-400 mb-1.5">
+                      Subtopics
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {result.topics.subtopics.map((s) => (
+                        <Chip key={s} tone="gray">{s}</Chip>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <p className="text-[11px] font-bold uppercase tracking-wide text-gray-400 mb-1.5">
+                      Keywords
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {result.topics.keywords.map((k) => (
+                        <span
+                          key={k}
+                          className="inline-flex items-center gap-1 px-2 py-1 rounded-md text-[11px] font-medium bg-gray-100 dark:bg-white/5 text-gray-600 dark:text-gray-300"
+                        >
+                          <Tag size={10} />
+                          {k}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </SectionCard>
+
+              {/* Prerequisites */}
+              <SectionCard icon={Layers} title="Prerequisites Required" subtitle="What to know beforehand">
+                <ul className="space-y-2">
+                  {result.prerequisites.map((p) => (
+                    <li key={p} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                      <CheckCircle2 size={14} className="text-violet-500 shrink-0 mt-0.5" />
+                      {p}
+                    </li>
+                  ))}
+                </ul>
+              </SectionCard>
+
+              {/* Difficulty */}
+              <SectionCard icon={Layers} title="Difficulty Level" subtitle="Estimated complexity rating">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`px-3 py-1 rounded-lg text-xs font-bold border ${
+                      result.difficulty.level === "Beginner"
+                        ? "bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-100 dark:border-emerald-500/20"
+                        : result.difficulty.level === "Intermediate"
+                        ? "bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-100 dark:border-amber-500/20"
+                        : "bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-300 border-red-100 dark:border-red-500/20"
+                    }`}
+                  >
+                    {result.difficulty.level}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">
+                  {result.difficulty.explanation}
+                </p>
+              </SectionCard>
+
+              {/* Reading time */}
+              <SectionCard icon={Clock} title="Estimated Reading Time" subtitle="Based on length & complexity">
+                <div className="flex items-baseline gap-2">
+                  <span className="text-3xl font-black text-violet-600 dark:text-violet-300">
+                    {result.readingTime.label}
+                  </span>
+                </div>
+                <p className="text-sm text-gray-600 dark:text-gray-400">
+                  ~{result.readingTime.pages} pages at an average study pace.
+                </p>
+              </SectionCard>
+
+              {/* Learning outcomes */}
+              <SectionCard icon={GraduationCap} title="Learning Outcomes" subtitle="After completing these notes">
+                <ul className="space-y-2">
+                  {result.learningOutcomes.map((o) => (
+                    <li key={o} className="flex items-start gap-2 text-sm text-gray-700 dark:text-gray-300">
+                      <div className="w-5 h-5 rounded-full bg-violet-500/10 text-violet-500 dark:text-violet-300 flex items-center justify-center shrink-0 mt-0.5">
+                        <CheckCircle2 size={12} />
+                      </div>
+                      {o}
+                    </li>
+                  ))}
+                </ul>
+              </SectionCard>
+            </div>
+          </div>
+        )}
+
+        {/* Saved summaries */}
+        {(savedSummaries.length > 0 || savedLoading) && !isProcessing && (
+          <div className="bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-5 space-y-3">
+            <div className="flex items-center gap-2">
+              <Bookmark size={16} className="text-violet-500" />
+              <h3 className="text-sm font-bold">Saved Summaries</h3>
+              {!savedLoading && (
+                <span className="text-xs text-gray-400">({savedSummaries.length})</span>
+              )}
+            </div>
+            {savedLoading && savedSummaries.length === 0 ? (
+              <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400 py-4 justify-center">
+                <Loader2 size={16} className="animate-spin" />
+                Loading saved summaries…
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {savedSummaries.map((s) => (
+                  <div
+                    key={s._id}
+                    className="flex items-center gap-3 p-3 rounded-lg border border-gray-200 dark:border-white/10 hover:border-violet-300 dark:hover:border-violet-400/40 transition-colors"
+                  >
+                    <button
+                      onClick={() => loadSavedSummary(s)}
+                      className="flex items-center gap-3 flex-1 min-w-0 text-left"
+                    >
+                      <div className="w-8 h-8 rounded-lg bg-gray-100 dark:bg-white/5 flex items-center justify-center text-gray-600 dark:text-gray-300 shrink-0">
+                        <FileText size={14} />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-medium truncate">{s.fileName}</p>
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400">
+                          {s.difficulty.level} • {s.readingTime.label} • saved{" "}
+                          {new Date(s.updatedAt || s.createdAt).toLocaleDateString()}
+                        </p>
+                      </div>
+                    </button>
+                    <button
+                      onClick={() => handleDeleteSaved(s._id)}
+                      className="p-1.5 text-gray-400 hover:text-red-500 rounded-lg transition-colors shrink-0"
+                      title="Remove"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default NotesSummarizer;

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -42,6 +42,12 @@ export const API_PATHS = {
         SAVE: "/api/resume/save", // Save resume to backend
         GET_ALL: "/api/resume/my-resumes", // Get all user's saved resumes
     },
+    NOTES_SUMMARY: {
+        SUMMARIZE: "/api/notes-summary/summarize", // AI PDF notes summarizer via Gemini
+        SAVE: "/api/notes-summary/save", // Save a generated summary
+        GET_ALL: "/api/notes-summary/my-summaries", // Get all user's saved summaries
+        DELETE: (id) => `/api/notes-summary/${id}`, // Delete a saved summary
+    },
     JOBS: {
         GET: "/api/jobs",  // GET /api/jobs?role=...&country=...
     },

--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -8,6 +8,7 @@ const axiosInstance = axios.create({
     headers: {
         "Content-Type": "application/json",
         Accept: "application/json",
+        "X-Requested-With": "XMLHttpRequest", // required by backend CSRF header check on cookie-based auth routes
     },
 });
 
@@ -86,7 +87,10 @@ axiosInstance.interceptors.response.use(
                 const { data } = await axios.post(
                     `${BASE_URL}/api/auth/refresh`,
                     {},
-                    { withCredentials: true }
+                    {
+                        withCredentials: true,
+                        headers: { "X-Requested-With": "XMLHttpRequest" },
+                    }
                 );
 
                 const newToken = data.accessToken;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,79 @@
   "name": "PrepPilot",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "csrf-csrf": "^4.0.3"
+      }
+    },
+    "node_modules/csrf-csrf": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csrf-csrf/-/csrf-csrf-4.0.3.tgz",
+      "integrity": "sha512-DaygOzelL4Qo1pHwI9LPyZL+X2456/OzpT596kNeZGiTSqKVDOk/9PPJ+FjzZacjMUEusOHw3WJKe1RW4iUhrw==",
+      "license": "ISC",
+      "dependencies": {
+        "http-errors": "^2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "csrf-csrf": "^4.0.3"
+  }
+}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #691 

### Summary
Adds a full-stack "Summarize Notes" feature that lets users upload study PDFs (or pick from the existing Notes & Books library) and get an AI-generated breakdown before committing time to reading the whole document.

###  Two ways to bring in a PDF
- **Upload your own** — drag-and-drop or click to browse. Shows file name/size with a remove button. Files over 15MB or non-PDFs are rejected with a clear error.
- **Choose from Notes & Books** — browse the platform's existing note library without leaving the page. PDFs are grouped into their original folders (collapsible sections you can expand/collapse), with a search bar that filters by folder name or PDF name. A counter shows total PDFs across total folders.

###  Generating the summary
- "Summarize Notes" button triggers analysis with a progress bar and staged status text ("Uploading…", "Validating PDF & extracting text…", "Identifying key topics…", etc.) — real upload progress for local files, staged progress while the AI works server-side.

###  What you get back
- **Smart Summary** — AI-written overview with its own in-text search/highlight box
- **Topics Covered** — major chapters, subtopics, and keywords as chips
- **Prerequisites Required** — what a reader should know beforehand
- **Difficulty Level** — Beginner / Intermediate / Advanced, with a one-line explanation
- **Estimated Reading Time** — calculated from the PDF's actual word/page count (not AI-guessed)
- **Learning Outcomes** — what you should be able to do after finishing the notes
- Quick-stats row for an at-a-glance snapshot (reading time, difficulty, chapter count, outcome count)

---

### Type of Change
- [ ] ✨ New feature

---

### How Has This Been Tested?
| Input | Handling |
|---|---|
| Valid PDF, under 15MB | Accepted → uploaded → parsed → summarized |
| Non-PDF file (e.g. `.docx`, `.jpg`) | Rejected client-side immediately: *"Please upload a valid PDF file."* Backend also enforces this via `multer` fileFilter as a second layer |
| PDF over 15MB | Rejected client-side before upload starts: *"File is too large. Please upload a PDF under 15MB."* If somehow bypassed, backend's `multer` limit + `handleUploadErrors` middleware catches it and returns a clean 400 instead of a raw error page |
| Empty file (0 bytes) | Passes the file-type/size check, but fails the backend's `pdfIntegrityError` check → 400 *"The uploaded file is empty or unreadable."* |
| Corrupt or spoofed PDF (fake header, garbage body, e.g. a renamed `.txt`) | Backend checks the real `%PDF-` magic header first (fast rejection), then does a full `pdf-parse` pass — either failure returns 400 *"This file doesn't look like a valid PDF"* / *"corrupted, encrypted, or unreadable"* — never reaches the AI call |
| Scanned/image-only PDF (little to no extractable text) | Still processed — flagged internally as `isLikelyScanned`, reading time falls back to a page-count-based estimate instead of word-count, and the AI prompt is told to rely on visual inference |
| Dragging a file onto the dropzone vs. clicking to browse | Both routed through the same `acceptFile()` validation — identical behavior either way |
| Removing a selected file (✕ button) | Clears the file state and file input value, no request sent |

---

### Screenshots (if applicable)
<img width="1888" height="970" alt="Screenshot 2026-07-31 204205" src="https://github.com/user-attachments/assets/7a7879e1-82aa-4288-9058-61cc90c885f0" />
<img width="1856" height="947" alt="Screenshot 2026-07-31 204302" src="https://github.com/user-attachments/assets/f27f969b-f927-4860-8d1e-341f483c2467" />
<img width="1823" height="960" alt="Screenshot 2026-07-31 204314" src="https://github.com/user-attachments/assets/da3469f2-07ea-4751-a9d2-53f677d7b5a9" />
<img width="1870" height="972" alt="Screenshot 2026-07-31 204351" src="https://github.com/user-attachments/assets/debcf71c-e1c6-412a-b338-06938eabe71f" />
<img width="1883" height="948" alt="Screenshot 2026-07-31 204424" src="https://github.com/user-attachments/assets/821229d2-0482-4dea-9971-f6964eedf74f" />
<img width="1882" height="971" alt="Screenshot 2026-07-31 204447" src="https://github.com/user-attachments/assets/8ec834f0-5dde-4ba5-b486-1ce3576f286e" />


---

### Checklist
- [ ] My code follows the project's guidelines
- [ ] I have tested my changes
- [ ] I have updated documentation where necessary
- [ ] I have linked the related issue
- [ ] My changes do not introduce new warnings or errors