### PR TITLE
fix(auth): short-lived access tokens + tokenVersion revocation (#712)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -5,7 +5,7 @@ const crypto = require("crypto");
 const { sendVerificationEmail } = require("../utils/sendEmail");
 const { validatePassword } = require('../utils/passwordPolicy');
 
-const ACCESS_TOKEN_EXPIRY = "7d";
+const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "30d";
 const REFRESH_TOKEN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_SALT_ROUNDS = 10;
@@ -20,16 +20,18 @@ const getRefreshCookieOptions = () => ({
 /**
  * Generate an access token for the authenticated user.
  * @param {string} userId - MongoDB user ID.
+ * @param {number} [tokenVersion=0] - User's current token version; embedded so
+ *   logout / password change can invalidate outstanding access tokens.
  * @returns {string} JWT access token valid for 15 minutes.
  */
-const generateAccessToken = (userId) => {
-    return jwt.sign({ id: userId, tokenType: "access" }, process.env.JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRY });
+const generateAccessToken = (userId, tokenVersion = 0) => {
+    return jwt.sign({ id: userId, tokenType: "access", tokenVersion }, process.env.JWT_SECRET, { expiresIn: ACCESS_TOKEN_EXPIRY });
 };
 
 /**
  * Generate a refresh token for the authenticated user.
  * @param {string} userId - MongoDB user ID.
- * @returns {string} JWT refresh token valid for 7 days.
+ * @returns {string} JWT refresh token valid for 30 days.
  */
 const generateRefreshToken = (userId) => {
     return jwt.sign({ id: userId, tokenType: "refresh" }, process.env.JWT_SECRET, { expiresIn: REFRESH_TOKEN_EXPIRY });
@@ -91,7 +93,7 @@ const registerUser = async (req, res) => {
             isEmailVerified: true, // skip email verification until SMTP is configured
         });
 
-        const accessToken = generateAccessToken(user._id);
+        const accessToken = generateAccessToken(user._id, user.tokenVersion);
         const refreshToken = generateRefreshToken(user._id);
 
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
@@ -141,7 +143,7 @@ const loginUser = async (req, res) => {
             });
         }
 
-        const accessToken = generateAccessToken(user._id);
+        const accessToken = generateAccessToken(user._id, user.tokenVersion);
         const refreshToken = generateRefreshToken(user._id);
 
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
@@ -202,7 +204,7 @@ const refreshToken = async (req, res) => {
             return res.status(401).json({ success: false, message: "Refresh token has been revoked. Please log in again." });
         }
 
-        const accessToken = generateAccessToken(user._id);
+        const accessToken = generateAccessToken(user._id, user.tokenVersion);
         const rotatedRefreshToken = generateRefreshToken(user._id);
 
         user.refreshTokenHash = await bcrypt.hash(rotatedRefreshToken, REFRESH_TOKEN_SALT_ROUNDS);
@@ -254,6 +256,8 @@ const logoutUser = async (req, res) => {
 
         user.refreshTokenHash = null;
         user.refreshTokenExpiresAt = null;
+        // Invalidate any access tokens already issued to this user.
+        user.tokenVersion = (user.tokenVersion || 0) + 1;
         await user.save();
 
         res.clearCookie("refreshToken", { path: "/api/auth" });
@@ -485,6 +489,8 @@ const changePassword = async (req, res) => {
 
         // Hash new password
         user.password = newPassword;
+        // Invalidate access tokens issued before the password change.
+        user.tokenVersion = (user.tokenVersion || 0) + 1;
         await user.save();
 
         res.json({ success: true, message: "Password updated successfully" });

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -29,6 +29,11 @@ const protect = async (req, res, next) => {
         });
       }
 
+      // Reject tokens issued before the user's current version (logout / password change).
+      if ((decoded.tokenVersion ?? 0) !== (req.user.tokenVersion ?? 0)) {
+        return res.status(401).json({ message: "Session expired, please log in again" });
+      }
+
       next();
     } else {
       res.status(401).json({ message: "Not authorized, no token" });

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -9,6 +9,8 @@ const UserSchema = new mongoose.Schema(
         profileImageUrl: { type: String, default: null },
         refreshTokenHash: { type: String, default: null },
         refreshTokenExpiresAt: { type: Date, default: null },
+        // Bumped on logout / password change to invalidate outstanding access tokens.
+        tokenVersion: { type: Number, default: 0 },
         
         // Basic Info
         firstName: { type: String, default: "" },

--- a/backend/tests/authMiddleware.tokenVersion.unit.test.js
+++ b/backend/tests/authMiddleware.tokenVersion.unit.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import jwt from "jsonwebtoken";
+import mongoose from "mongoose";
+import { protect } from "../middlewares/authMiddleware.js"; // compiles the User model once
+
+const User = mongoose.model("User"); // same instance the middleware uses
+const SECRET = "test-secret";
+const realFindById = User.findById;
+
+beforeEach(() => {
+  process.env.JWT_SECRET = SECRET;
+});
+
+afterEach(() => {
+  User.findById = realFindById; // restore the shared model instance
+});
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+// Patch the shared User model so findById(...).select("-password") resolves to `user`.
+function stubUser(user) {
+  User.findById = vi.fn().mockReturnValue({ select: vi.fn().mockResolvedValue(user) });
+}
+
+function bearer(payload) {
+  return { headers: { authorization: `Bearer ${jwt.sign(payload, SECRET)}` } };
+}
+
+describe("protect — access-token version check", () => {
+  it("allows a token whose version matches the user", async () => {
+    stubUser({ _id: "u1", tokenVersion: 3 });
+    const req = bearer({ id: "u1", tokenType: "access", tokenVersion: 3 });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await protect(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+    expect(req.user.tokenVersion).toBe(3);
+  });
+
+  it("rejects a token issued before a logout / password change (stale version)", async () => {
+    stubUser({ _id: "u1", tokenVersion: 4 }); // user bumped after this token was issued
+    const req = bearer({ id: "u1", tokenType: "access", tokenVersion: 3 });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await protect(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it("treats a legacy token with no version as version 0", async () => {
+    stubUser({ _id: "u1", tokenVersion: 1 }); // any bump invalidates legacy tokens
+    const req = bearer({ id: "u1", tokenType: "access" }); // no tokenVersion field
+    const res = makeRes();
+    const next = vi.fn();
+
+    await protect(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+});


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #712

### Summary
The access token was issued with a **7-day** lifetime and `protect` accepted it on signature alone — no server-side revocation. So logout and password change never actually ended a session: an access token handed out earlier kept working for up to a week, which quietly undercut the hashed/rotated refresh-token work already in place.

This PR makes the access token short-lived and revocable:

- `ACCESS_TOKEN_EXPIRY` **7d → 15m**, which matches the JSDoc ("valid for 15 minutes") and the frontend silent-refresh in `axiosinstance.js`.
- Added a `tokenVersion` field to the `User` model and embedded it in the access-token payload.
- `protect` now rejects a token whose `tokenVersion` is behind the user's current version.
- `logoutUser` and `changePassword` bump `tokenVersion`, so any outstanding access tokens are invalidated immediately.
- Fixed the stale refresh-token JSDoc (says 7 days, constant is 30).

Legacy tokens (no `tokenVersion`) are treated as version `0`, so the first logout / password change after deploy invalidates them too.

> Note: `tokenVersion` is a single per-user counter, so a bump revokes access tokens across all of that user's devices. That matches the issue's intent ("logout should end the session"); per-device revocation would need a session store and is out of scope here.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### How Has This Been Tested?
- Added `backend/tests/authMiddleware.tokenVersion.unit.test.js` covering `protect`: matching version passes, stale version is rejected (401), and a legacy no-version token is rejected once the user's version is bumped.
- `npx vitest run` — the new file passes (3/3) and the pre-existing failing tests are unchanged (this PR doesn't touch that harness issue).

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary (JSDoc)
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
