### PR TITLE
fix(InterviewPrep): declare useState before early return in AIResponsePreview (#714)

### DIFF
--- a/frontend/src/pages/InterviewPrep/components/AIResponsePreview.jsx
+++ b/frontend/src/pages/InterviewPrep/components/AIResponsePreview.jsx
@@ -6,8 +6,8 @@ import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 const AIResponsePreview = ({ content }) => {
-    if (!content) return null;
     const [copied, setCopied] = useState(false);
+    if (!content) return null;
 
 const copyResponse = async () => {
     try {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #714

### Summary
`AIResponsePreview` declared `useState` **after** the `if (!content) return null;` early return — a Rules-of-Hooks violation. When `content` flips from falsy to truthy across renders (exactly what happens as an AI answer loads/streams in), the hook count changes between renders and React throws *"Rendered more hooks than during the previous render"*, crashing the component (caught by the ErrorBoundary). ESLint also flagged it as `react-hooks/rules-of-hooks`.

Fix is a one-line reorder: declare the hook at the top of the component, then keep the `if (!content) return null;` guard below it, so hooks always run unconditionally.

Verified with `npx eslint` on the file — the `react-hooks/rules-of-hooks` error is gone.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

### How Has This Been Tested?
- `npx eslint src/pages/InterviewPrep/components/AIResponsePreview.jsx` — the conditional-hook error no longer appears.
- Manually reasoned through the render sequence: with the hook above the guard, hook count is stable whether `content` is empty or filled.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._
