### PR TITLE
feat: add Trie practice sheet

### DIFF
--- a/backend/sheets/trie-practice.json
+++ b/backend/sheets/trie-practice.json
@@ -1,0 +1,175 @@
+
+{
+  "sheets": [
+    {
+      "id": "trie-practice",
+      "title": "Trie Practice",
+      "description": "Master Trie (Prefix Tree) problems from fundamentals to advanced interview questions.",
+      "followers": 1745,
+      "questions": 15,
+      "category": "popular",
+      "sections": [
+        {
+          "title": "Trie Practice",
+          "topics": [
+            {
+              "title": "Trie (Prefix Tree)",
+              "subtopics": [
+                {
+                  "title": "Implement Trie (Insert, Search, StartsWith)",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/trie-insert-and-search/",
+                    "leetcode": "https://leetcode.com/problems/implement-trie-prefix-tree/",
+                    "youtube": "https://www.youtube.com/watch?v=oobqoCJlHA0"
+                  }
+                },
+                {
+                  "title": "Insert a Word in Trie",
+                  "difficulty": "easy",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/trie-insert-and-search/",
+                    "leetcode": "https://leetcode.com/problems/implement-trie-prefix-tree/",
+                    "youtube": "https://youtu.be/I6i4AyDsMQA"
+                  }
+                },
+                {
+                  "title": "Search a Word in Trie",
+                  "difficulty": "easy",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/trie-insert-and-search/",
+                    "leetcode": "https://leetcode.com/problems/implement-trie-prefix-tree/",
+                    "youtube": "https://youtu.be/7LEoZXI-i_0"
+                  }
+                },
+                {
+                  "title": "Delete a Word from Trie",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/trie-delete/",
+                    "leetcode": "",
+                    "youtube": "https://youtu.be/gmkvOEmhCgM"
+                  }
+                },
+                {
+                  "title": "Longest Common Prefix",
+                  "difficulty": "easy",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/problems/longest-common-prefix-in-an-array5129/1",
+                    "leetcode": "https://leetcode.com/problems/longest-common-prefix/",
+                    "youtube": "https://www.youtube.com/watch?v=0sWShKIJoo4"
+                  }
+                },
+                {
+                  "title": "Design Add and Search Words Data Structure",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/trie-data-structure-in-cpp/",
+                    "leetcode": "https://leetcode.com/problems/design-add-and-search-words-data-structure/",
+                    "youtube": "https://www.youtube.com/watch?v=BTf05gs_8iU"
+                  }
+                },
+                {
+                  "title": "Word Search II",
+                  "difficulty": "hard",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/boggle-find-possible-words-board-characters/",
+                    "leetcode": "https://leetcode.com/problems/word-search-ii/",
+                    "youtube": "https://www.youtube.com/watch?v=asbcE9mZz_U"
+                  }
+                },
+                {
+                  "title": "Replace Words",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "",
+                    "leetcode": "https://leetcode.com/problems/replace-words/",
+                    "youtube": "https://youtu.be/FxmFhwmKumU"
+                  }
+                },
+                {
+                  "title": "Map Sum Pairs",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/problems/find-the-longest-string--170645/0",
+                    "leetcode": "https://leetcode.com/problems/map-sum-pairs/",
+                    "youtube": "https://youtu.be/YiA7aP8zEko"
+                  }
+                },
+                {
+                  "title": "Longest Word in Dictionary",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/problems/find-the-longest-string--170645/0",
+                    "leetcode": "https://leetcode.com/problems/longest-word-in-dictionary/",
+                    "youtube": "https://youtu.be/MbvGOab6Sfg"
+                  }
+                },
+                {
+                  "title": "Search Suggestions System (Auto Complete)",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/implement-a-phone-directory/",
+                    "leetcode": "https://leetcode.com/problems/search-suggestions-system/",
+                    "youtube": "https://youtu.be/lbfi2OZL0Ls"
+                  }
+                },
+                {
+                  "title": "Longest Word With All Prefixes",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/problems/find-the-longest-string--170645/0",
+                    "leetcode": "https://leetcode.com/problems/longest-word-with-all-prefixes/",
+                    "youtube": "https://youtu.be/AWnBa91lThI"
+                  }
+                },
+                {
+                  "title": "Prefix and Suffix Search",
+                  "difficulty": "hard",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/prefix-suffix-search/",
+                    "leetcode": "https://leetcode.com/problems/prefix-and-suffix-search/",
+                    "youtube": "https://youtu.be/U7fIQ7qAeuE"
+                  }
+                },
+                {
+                  "title": "Maximum XOR of Two Numbers in an Array",
+                  "difficulty": "medium",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "https://www.geeksforgeeks.org/maximum-xor-of-two-numbers-in-an-array/",
+                    "leetcode": "https://leetcode.com/problems/maximum-xor-of-two-numbers-in-an-array/",
+                    "youtube": "https://www.youtube.com/watch?v=EIhAwfHubE8"
+                  }
+                },
+                {
+                  "title": "Stream of Characters",
+                  "difficulty": "hard",
+                  "status": "not-started",
+                  "links": {
+                    "gfg": "",
+                    "leetcode": "https://leetcode.com/problems/stream-of-characters/",
+                    "youtube": "https://youtu.be/CjJN_azEYEQ"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #645

### Summary
This PR adds a new **Trie Practice Sheet** for PrepPilot by creating `backend/sheets/trie-practice.json` following the existing schema used by `arrays-practice.json`.

The sheet includes 15 interview-focused Trie problems covering core concepts such as Insert, Search, Delete, Prefix Search, Longest Prefix Matching, Auto Complete/Search Suggestions, Word Search II, Maximum XOR using Trie, and more. Each problem includes appropriate difficulty levels along with GeeksforGeeks, LeetCode, and YouTube resource links where applicable.

---

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?

- Ran `node backend/seedSheets.js` to seed the new Trie sheet.
- Verified that the JSON follows the existing schema and the Trie Practice sheet loads correctly on the `/coding-sheets` page.

---

### Screenshots (if applicable)

N/A (Data-only change)

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors