### PR TITLE
Fix: Define React PropTypes for components

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "html2pdf.js": "^0.14.0",
         "lucide-react": "^0.542.0",
         "moment": "^2.30.1",
+        "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-hot-toast": "^2.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "html2pdf.js": "^0.14.0",
     "lucide-react": "^0.542.0",
     "moment": "^2.30.1",
+    "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hot-toast": "^2.6.0",

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { AlertTriangle, RefreshCw, Home, ChevronDown, ChevronUp } from "lucide-react";
 
 class ErrorBoundary extends Component {
@@ -208,5 +209,10 @@ class ErrorBoundary extends Component {
     return this.props.children;
   }
 }
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node.isRequired,
+  variant: PropTypes.oneOf(["fullscreen", "section"]),
+};
 
 export default ErrorBoundary;


### PR DESCRIPTION
Description
This PR introduces React PropTypes for robust component type checking and validation.

✨ Features Added
- Installed the `prop-types` package.
- Defined explicit `propTypes` for the `ErrorBoundary` component as a foundation.
- Specified required nodes and specific variant options.

Benefits
- Catches unexpected prop types during development.
- Acts as built-in documentation for component expectations.
- Lays the groundwork for extending PropTypes across all reusable components.

Testing
✅ PropTypes added to ErrorBoundary.
✅ No syntax errors during compilation.

Related Issue
Closes #744
