### PR TITLE
Fix: Return 404 instead of 500 on invalid session ID in addQuestionToSession

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -52,6 +52,9 @@ const addQuestionToSession = async (req, res) => {
     await session.save();
     res.status(201).json(createdQuestions);
   } catch (error) {
+    if (error.name === 'CastError') {
+      return res.status(404).json({ success: false, message: "Requested session could not be found" });
+    }
     console.error("Add question error:", error);
     res.status(500).json({ success: false, message: "Internal server error occurred" });
   }


### PR DESCRIPTION
## Description
This pull request resolves an issue where the ddQuestionToSession controller was returning a 500 Internal Server Error when a requested session could not be found due to an invalid sessionId format (which triggers a Mongoose CastError).

## Changes Made
- Added a CastError check in the catch block of ddQuestionToSession.
- Ensures that if Mongoose fails to cast the sessionId string into an ObjectId, the API correctly returns a 404 Not Found with the appropriate failure message instead of throwing a 500 Internal Server Error.

Resolves #792