### PR TITLE
Fix: Implement graceful shutdown for uncaught exceptions

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -187,11 +187,23 @@ server.on("error", (err) => {
 // Handle uncaught exceptions
 process.on("uncaughtException", (err) => {
   console.error("Uncaught Exception:", err);
-  process.exit(1);
+  if (server) {
+    server.close(() => {
+      process.exit(1);
+    });
+  } else {
+    process.exit(1);
+  }
 });
 
 // Handle unhandled promise rejections
 process.on("unhandledRejection", (reason, promise) => {
   console.error("Unhandled Rejection at:", promise, "reason:", reason);
-  process.exit(1);
+  if (server) {
+    server.close(() => {
+      process.exit(1);
+    });
+  } else {
+    process.exit(1);
+  }
 });


### PR DESCRIPTION
## Description
This pull request resolves an issue where the server would terminate abruptly on \uncaughtException\ or \unhandledRejection\, potentially causing active connections to be dropped immediately.

## Changes Made
- Added logic to server.js to call server.close() before calling process.exit(1) in the global exception handlers.
- This ensures that the Express server attempts a graceful shutdown, completing any in-flight requests before exiting the node process.

Resolves #794