### PR TITLE
Fix: Resolve missing navigate and searchParams dependencies in verifyEmail useEffect

### DIFF
--- a/frontend/src/pages/Auth/verifyEmail.jsx
+++ b/frontend/src/pages/Auth/verifyEmail.jsx
@@ -43,7 +43,7 @@ const VerifyEmail = () => {
         };
 
         verify();
-    }, []);
+    }, [navigate, searchParams]);
 
     return (
         <div className="flex items-center justify-center min-h-screen bg-[#0a0a0f] px-4">


### PR DESCRIPTION
## Description
This pull request resolves an issue with the \useEffect\ hook in the \VerifyEmail\ component, where the \
avigate\ and \searchParams\ dependencies were missing from the dependency array, causing a linter warning.

## Changes Made
- Added \
avigate\ and \searchParams\ to the \useEffect\ dependency array to satisfy the exhaustive-deps rule and ensure consistent behavior across renders.

Resolves #801