### PR TITLE
Fix: Resolve missing fetchRepositories dependency in RepositoryHive useEffect

### DIFF
--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -40,11 +40,12 @@ const RepositoryHive = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("stars");
 
+  const searchQueryRef = React.useRef(searchQuery);
   useEffect(() => {
-    fetchRepositories();
-  }, [selectedFilters, sortBy]);
+    searchQueryRef.current = searchQuery;
+  }, [searchQuery]);
 
-  const fetchRepositories = async () => {
+  const fetchRepositories = React.useCallback(async () => {
     setLoading(true);
     setError("");
 
@@ -59,8 +60,9 @@ const RepositoryHive = () => {
         }
       });
 
-      if (searchQuery.trim()) {
-        queryParams.push(searchQuery.trim());
+      const currentQuery = searchQueryRef.current;
+      if (currentQuery.trim()) {
+        queryParams.push(currentQuery.trim());
       }
 
       const query = queryParams.join(" ").trim();
@@ -98,7 +100,11 @@ const RepositoryHive = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedFilters, sortBy]);
+
+  useEffect(() => {
+    fetchRepositories();
+  }, [selectedFilters, sortBy, fetchRepositories]);
 
   const toggleFilter = (filterId) => {
     setSelectedFilters((prev) =>


### PR DESCRIPTION
## Description
This pull request resolves an issue with the \useEffect\ hook in the \RepositoryHive\ component where the \etchRepositories\ dependency was missing, causing a linter warning.

## Changes Made
- Wrapped \etchRepositories\ in a \useCallback\ hook to stabilize its reference.
- Implemented a \useRef\ for \searchQuery\ to allow \etchRepositories\ to fetch with the current search query without re-creating the function on every keystroke, which would otherwise trigger an immediate unwanted fetch.
- Added \etchRepositories\ to the \useEffect\ dependency array to satisfy the exhaustive-deps rule.

Resolves #802