### PR TITLE
Fix: Resolve Fast Refresh warning in themeContext

### DIFF
--- a/frontend/src/context/themeContext.jsx
+++ b/frontend/src/context/themeContext.jsx
@@ -1,6 +1,6 @@
 import { createContext, useState, useEffect, useContext } from "react";
 
-export const ThemeContext = createContext();
+const ThemeContext = createContext();
 
 export const ThemeProvider = ({ children }) => {
   const [theme, setTheme] = useState(() => {


### PR DESCRIPTION
## Description
This pull request resolves an issue with Vite/React Fast Refresh throwing a warning in the \	hemeContext.jsx\ file. Fast Refresh requires files to only export React components to work properly, but \ThemeContext\ was being exported directly.

## Changes Made
- Removed the \export\ keyword from \ThemeContext\. Since the context is only accessed via the \useTheme\ hook, exporting it was unnecessary and triggered the fast-refresh warning (react-refresh/only-export-components).

Resolves #803