### PR TITLE
Fix: Resolve Fast Refresh warning in userContext

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,7 @@ import AIHelper from "./components/AIHepler";
 import PracticePage from "./pages/InterviewPrep/components/PracticePage";
 import CognitiveGamesPage from "./pages/CognitiveGames/CognitiveGamesPage";
 import { useContext } from "react";
-import { UserContext } from "./context/userContext";
+import { useUser } from "./context/userContext";
 import MainLayout from "./components/Layouts/MainLayout";
 import { Navigate, Outlet } from "react-router-dom";
 import ResumeTemplates from "./pages/ResumeBuilder/ResumeTemplates";
@@ -47,7 +47,7 @@ import SpacedRepetitionPage from "./pages/SpacedRepetition/SpacedRepetitionPage"
 import DailyCodingChallenge from "./pages/DailyCodingChallenge/DailyCodingChallenge";
 import Analytics from "./pages/Analytics";
 const ProtectedRoute = ({ children }) => {
-  const { user, loading } = useContext(UserContext);
+  const { user, loading } = useUser();
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">

--- a/frontend/src/LandingPage.jsx
+++ b/frontend/src/LandingPage.jsx
@@ -14,7 +14,7 @@ import Modal from "./components/Loader/Modal";
 import Login from "./pages/Auth/Login";
 import SignUp from "./pages/Auth/SignUp";
 import ForgotPassword from "./pages/Auth/ForgotPAssword";
-import { UserContext } from "./context/userContext";
+import { useUser } from "./context/userContext";
 import { motion, AnimatePresence, useMotionValue, useSpring, useTransform } from "framer-motion";
 import ServicesMarquee from "./components/ServicesMarquee";
 import { Star, ChevronLeft, ChevronRight } from "lucide-react"; // Import icons for testimonials
@@ -234,7 +234,7 @@ const TestimonialCard = ({ testimonial }) => (
    Main Component
 ───────────────────────────────────────────── */
 const LandingPage = () => {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const navigate = useNavigate();
 
   const [openAuthModal, setOpenAuthModal] = useState(false);

--- a/frontend/src/components/AIHepler.jsx
+++ b/frontend/src/components/AIHepler.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useContext } from "react";
-import { UserContext } from "../context/userContext";
+import { useUser } from "../context/userContext";
 import { Bot, User as UserIcon, Send, Sparkles, Trash2 } from "lucide-react";
 import { BASE_URL } from "../utils/apiPaths";
 import AIResponsePreview from "../pages/InterviewPrep/components/AIResponsePreview";
 
 export default function AIHelper() {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const [messages, setMessages] = useState([
     { id: 0, role: "assistant", text: "Hi! I am your AI Interview Assistant. How can I help you prepare today?" },
   ]);

--- a/frontend/src/components/Cards/ProfileinfoCard.jsx
+++ b/frontend/src/components/Cards/ProfileinfoCard.jsx
@@ -1,11 +1,11 @@
 import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
 
 const ProfileinfoCard = () => {
-  const { user, clearUser } = useContext(UserContext);
+  const { user, clearUser } = useUser();
   const navigate = useNavigate();
   const handleLogout = async () => {
     try {

--- a/frontend/src/components/Layouts/DashboardLayout.jsx
+++ b/frontend/src/components/Layouts/DashboardLayout.jsx
@@ -1,9 +1,9 @@
 import Navbar from "./Navbar";
 import React, { useContext } from "react";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 
 const DashboardLayout = ({ children }) => {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   return (
     <div className="bg-white dark:bg-gray-900 min-h-screen transition-colors duration-300 w-full">
       <Navbar />

--- a/frontend/src/components/Layouts/Navbar.jsx
+++ b/frontend/src/components/Layouts/Navbar.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useState, useEffect } from "react";
 import { createPortal } from "react-dom";
 import ProfileInfoCard from "../Cards/ProfileinfoCard";
 import { Link, useNavigate, useLocation } from "react-router-dom";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import Modal from "../Loader/Modal";
 import Login from "../../pages/Auth/Login";
 import ThemeToggle from "../ThemeToggle";
@@ -18,7 +18,7 @@ const Navbar = () => {
 
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [portalNode, setPortalNode] = useState(null);
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   // Helper for initial letter or fallback
   const userInitial =
     user?.name?.charAt(0)?.toUpperCase() ||

--- a/frontend/src/components/Layouts/Sidebar.jsx
+++ b/frontend/src/components/Layouts/Sidebar.jsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import Modal from "../Loader/Modal";
 import Login from "../../pages/Auth/Login";
 import axiosInstance from "../../utils/axiosinstance";
@@ -131,7 +131,7 @@ const NAV_ITEMS = [
 
 /* ── Component ───────────────────────────────────────────────────────────── */
 const Sidebar = () => {
-  const { user, clearUser } = useContext(UserContext);
+  const { user, clearUser } = useUser();
   const location = useLocation();
   const navigate = useNavigate();
 

--- a/frontend/src/components/SheetDetailsPage.jsx
+++ b/frontend/src/components/SheetDetailsPage.jsx
@@ -6,7 +6,7 @@ import React, { useState, useEffect, useCallback, memo, useContext } from "react
 
 import { BASE_URL } from "../utils/apiPaths";
 import axiosInstance from "../utils/axiosinstance";
-import { UserContext } from "../context/userContext";
+import { useUser } from "../context/userContext";
 import { CheckCircle2, Circle, AlertCircle, BookOpen, Users, CheckSquare } from "lucide-react";
 
 const SubtopicRow = memo(({ sub, sectionIdx, topicIdx, subIdx, completed, followed, onToggle }) => {
@@ -87,7 +87,7 @@ const SubtopicRow = memo(({ sub, sectionIdx, topicIdx, subIdx, completed, follow
 
 function SheetDetail() {
   const { id } = useParams();
-  const { sheetProgress: ctxProgress, refreshSheetProgress } = useContext(UserContext);
+  const { sheetProgress: ctxProgress, refreshSheetProgress } = useUser();
   const [sheet, setSheet] = useState(null);
   const [loading, setLoading] = useState(true);
   const [completedTopics, setCompletedTopics] = useState({});

--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect } from "react";
+import React, { createContext, useState, useEffect, useContext } from "react";
 import axiosInstance from "../utils/axiosinstance";
 import { API_PATHS } from "../utils/apiPaths";
 import toast from "react-hot-toast";
@@ -8,8 +8,9 @@ import {
     clearMockUser,
 } from "../utils/mockAuth";
 
+const UserContext = createContext();
 
-export const UserContext = createContext();
+export const useUser = () => useContext(UserContext);
 
 export const UserProvider = ({ children }) => {
     const [user, setUser] = useState(null);

--- a/frontend/src/pages/Auth/AuthPage.jsx
+++ b/frontend/src/pages/Auth/AuthPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useContext } from "react";
 import { useNavigate, Navigate } from "react-router-dom";
 import Login from "./Login";
 import SignUp from "./SignUp";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 
 /**
  * Unified auth page that toggles between Login and SignUp.
@@ -11,7 +11,7 @@ import { UserContext } from "../../context/userContext";
  */
 const AuthPage = () => {
   const [page, setPage] = useState("login");
-  const { user, loading } = useContext(UserContext);
+  const { user, loading } = useUser();
   const navigate = useNavigate();
 
   // Already logged in → go to dashboard

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -4,7 +4,7 @@ import Input from "../../components/Inputs/Input";
 import Button from "../../components/Button/Button";
 import { validateEmail } from "../../utils/helper";
 import { API_PATHS } from "../../utils/apiPaths";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import axiosInstance from "../../utils/axiosinstance";
 import {
   isMockAuthEnabled,
@@ -20,7 +20,7 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
   const [loading, setLoading] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
 
-  const { updateUser } = useContext(UserContext);
+  const { updateUser } = useUser();
   const navigate = useNavigate();
 
   const clearError = () => {

--- a/frontend/src/pages/Auth/SignUp.jsx
+++ b/frontend/src/pages/Auth/SignUp.jsx
@@ -6,7 +6,7 @@ import ProfilePhotoSelector from "../../components/Inputs/ProfilePhotoSelector";
 import { validateEmail } from "../../utils/helper";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import uploadImage from "../../utils/uploadimage";
 import { LuArrowRight } from "react-icons/lu";
 
@@ -23,7 +23,7 @@ const SignUp = ({ setCurrentPage }) => {
   const [resendError, setResendError] = useState("");
   const [resendCooldown, setResendCooldown] = useState(0);
 
-  const { updateUser } = useContext(UserContext);
+  const { updateUser } = useUser();
   const navigate = useNavigate();
 
   // Computed inside the component so they react to `password` state

--- a/frontend/src/pages/CognitiveGames/CognitiveGamesPage.jsx
+++ b/frontend/src/pages/CognitiveGames/CognitiveGamesPage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import PatternMatrixGame from "../../components/PatternMatrixGame";
 import MemoryMatchGame from "../../components/MemoryMatchGame";
 import { Grid3x3, Gamepad2 } from "lucide-react";
@@ -26,7 +26,7 @@ const gamesData = [
 // ─── CognitiveGamesPage ────────────────────────────────────────────────────────
 const CognitiveGamesPage = () => {
   const [selectedGame, setSelectedGame] = useState(null);
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const navigate = useNavigate();
 
   const handleGameClick = (game) => {

--- a/frontend/src/pages/Home/ProgressTrackerDashboard.jsx
+++ b/frontend/src/pages/Home/ProgressTrackerDashboard.jsx
@@ -7,7 +7,7 @@ import {
   CheckCircle, PlusCircle, Settings, Code2, Star,
 } from "lucide-react";
 import toast from "react-hot-toast";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
 
@@ -101,7 +101,7 @@ function buildDifficultyStats(progress, sheetsMap) {
 
 /* ── Main ────────────────────────────────────────────────────────────────── */
 const ProgressTrackerDashboard = () => {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [sessions, setSessions] = useState([]);

--- a/frontend/src/pages/InterviewPrep/components/PracticePage.jsx
+++ b/frontend/src/pages/InterviewPrep/components/PracticePage.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useContext } from "react";
 import { useNavigate } from "react-router-dom";
-import { UserContext } from "../../../context/userContext";
+import { useUser } from "../../../context/userContext";
 import AptitudeQuestionCard from "../../../components/Cards/AptitudeQuestionCard";
 import Loader from "../../../components/Loader/Loader";
 
@@ -23,7 +23,7 @@ const PracticePage = () => {
   const [selectedTopic, setSelectedTopic] = useState(null);
   const [questions, setQuestions] = useState([]);
   const [loading, setLoading] = useState(false);
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const navigate = useNavigate();
 
   const handleTopicClick = async (topic) => {

--- a/frontend/src/pages/Jobs/JobsForYou.jsx
+++ b/frontend/src/pages/Jobs/JobsForYou.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useContext } from "react";
 import { Briefcase, MapPin, DollarSign, ExternalLink, RefreshCw } from "lucide-react";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
 import toast from "react-hot-toast";
@@ -59,7 +59,7 @@ const JobCard = ({ job }) => (
 );
 
 const JobsForYou = () => {
-  const { user } = useContext(UserContext);
+  const { user } = useUser();
   const [jobs, setJobs]       = useState([]);
   const [role, setRole]       = useState("");
   const [country, setCountry] = useState("in");

--- a/frontend/src/pages/Settings/Settings.jsx
+++ b/frontend/src/pages/Settings/Settings.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useContext, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import { UserContext } from "../../context/userContext";
+import { useUser } from "../../context/userContext";
 import { useTheme } from "../../context/themeContext";
 import axiosInstance from "../../utils/axiosinstance";
 import { API_PATHS } from "../../utils/apiPaths";
@@ -46,7 +46,7 @@ import {
 } from "lucide-react";
 const Settings = () => {
   const navigate = useNavigate();
-  const { user, clearUser, updateUser } = useContext(UserContext);
+  const { user, clearUser, updateUser } = useUser();
   const { theme, toggleTheme } = useTheme();
   // Sidebar Tabs State
   const [activeSection, setActiveSection] = useState("basic-info");


### PR DESCRIPTION
## Description
This pull request resolves an issue with Vite/React Fast Refresh throwing a warning in the \userContext.jsx\ file. Fast Refresh requires files to only export React components (and hooks) to work properly, but \UserContext\ was being exported and consumed directly across the application.

## Changes Made
- Refactored \userContext.jsx\ to export a \useUser\ hook instead of directly exporting \UserContext\.
- Removed the \export\ keyword from \UserContext\ to satisfy the fast-refresh rule (react-refresh/only-export-components).
- Updated all 16 files across the frontend that consumed the context to import and use the new \useUser\ hook.

Resolves #804