### PR TITLE
Fix: JSX syntax error in BehavioralCoach

### DIFF
--- a/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
+++ b/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
@@ -348,7 +348,7 @@ const BehavioralCoach = () => {
 
       </div> {/* End max-w-6xl */}
 
-    </div> {/* End Page */}
+    </div>
 
   );
 };


### PR DESCRIPTION
Description
This pull request resolves a syntax error in \BehavioralCoach.jsx\ (line 351) where a JSX comment was placed outside the root return element, causing the Vite build to fail with \Unexpected token {\.

Changes Made
- Removed invalid JSX comment \{/* End Page */}\.