### PR TITLE
fix: handle extra whitespace in getInitials

### DIFF
--- a/frontend/src/utils/helper.js
+++ b/frontend/src/utils/helper.js
@@ -7,7 +7,7 @@ export const validateEmail = (email) => {
 export const getInitials=(title)=>{
     if(!title) return "";
 
-    const words = title.split(" ");
+    const words = title.trim().split(/\s+/);
     let initials="";
     for(let i=0; i<Math.min(words.length,2);i++){
         if (!words[i]) continue;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #896 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

This PR improves the `getInitials()` utility by normalizing whitespace before extracting initials.

### Changes
- Trim leading and trailing whitespace.
- Split on one or more whitespace characters instead of a single space.
- Preserve the existing API and behavior for valid inputs.

### Example

| Input | Before | After |
|-------|--------|-------|
| `" John Doe "` | Inconsistent parsing | `JD` |
| `"John   Doe"` | Inconsistent parsing | `JD` |
| `"  Alice   Bob  "` | Inconsistent parsing | `AB` |

This is a small, backward-compatible bug fix that improves robustness for user-entered names.
---


### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
-Tested locally in browser console.
-

---

### Screenshots (if applicable)
Add screenshots or videos to demonstrate the changes.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors