### PR TITLE
Fix: Handle extra whitespace correctly in getInitials() utility

### DIFF
--- a/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
+++ b/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
@@ -348,7 +348,7 @@ const BehavioralCoach = () => {
 
       </div> {/* End max-w-6xl */}
 
-    </div> {/* End Page */}
+    </div>
 
   );
 };

--- a/frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx
+++ b/frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx
@@ -332,7 +332,6 @@ const DifficultyEstimator = () => {
             </div>
 
           </div>
-                      {/* AI Recommendation */}
 
             <div className="bg-white dark:bg-[#111827] rounded-3xl shadow border border-gray-200 dark:border-white/10 p-8">
 

--- a/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
+++ b/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
@@ -130,7 +130,7 @@ const ProjectRoadmap = () => {
       setActiveRoadmap(res.data.roadmap);
       setIsSaved(true);
       setMode("detail");
-    } catch (err) {
+    } catch {
       toast.error("Failed to load roadmap");
     }
   };
@@ -145,7 +145,7 @@ const ProjectRoadmap = () => {
         setActiveRoadmap(null);
       }
       fetchRoadmaps();
-    } catch (err) {
+    } catch {
       toast.error("Failed to delete roadmap");
     }
   };
@@ -159,7 +159,7 @@ const ProjectRoadmap = () => {
     try {
       const res = await axiosInstance.patch(API_PATHS.ROADMAP.TOGGLE_TASK(activeRoadmap._id), payload);
       setActiveRoadmap(res.data.roadmap);
-    } catch (err) {
+    } catch {
       toast.error("Failed to update progress");
     }
   };
@@ -194,7 +194,7 @@ const ProjectRoadmap = () => {
       });
       setActiveRoadmap(res.data.roadmap);
       toast.success("Milestone updated");
-    } catch (err) {
+    } catch {
       toast.error("Failed to update milestone");
     }
   };

--- a/frontend/src/utils/helper.js
+++ b/frontend/src/utils/helper.js
@@ -7,7 +7,7 @@ export const validateEmail = (email) => {
 export const getInitials=(title)=>{
     if(!title) return "";
 
-    const words = title.split(" ");
+    const words = title.trim().split(/\s+/);
     let initials="";
     for(let i=0; i<Math.min(words.length,2);i++){
         if (!words[i]) continue;


### PR DESCRIPTION
Resolves #896

Description
This pull request resolves an issue where multiple spaces in a name would cause the \getInitials()\ utility to return empty characters or fail.

Changes Made
- Replaced \.split(' ')\ with \.trim().split(/\s+/)\ to correctly split by any amount of whitespace.