### PR TITLE
Fix: Add missing database indexes on foreign keys

### DIFF
--- a/backend/models/Question.js
+++ b/backend/models/Question.js
@@ -1,6 +1,6 @@
 const mongoose = require("mongoose");
 const questionSchema = new mongoose.Schema({
-    session:{type:mongoose.Schema.Types.ObjectId,ref:"Session"},
+    session:{type:mongoose.Schema.Types.ObjectId,ref:"Session", index: true},
     question:String,
     answer:String,
     note:String,

--- a/backend/models/Session.js
+++ b/backend/models/Session.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 const Question = require("./Question");
 const sessionSchema = new mongoose.Schema({
-    user: { type: mongoose.Schema.Types.ObjectId, ref: "User" },
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", index: true },
     role: { type: String, required: true },
     experience: { type: String, required: true },
     topicsToFocus: { type: [String], required: true },


### PR DESCRIPTION
Resolves #899

Description
This PR adds missing database indexes on frequently queried relational fields to prevent full-collection scans in MongoDB as the application scales.

Changes Made
- Added \{ index: true }\ to \user\ in \Session\ model.
- Added \{ index: true }\ to \session\ in \Question\ model.