### PR TITLE
Fix: Add limit(50) to unbounded DB queries

### DIFF
--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -363,7 +363,7 @@ const getMySummaries = async (req, res) => {
   try {
     const summaries = await NotesSummary.find({ user: req.user._id }).sort({
       updatedAt: -1,
-    });
+    }).limit(50);
     res.status(200).json({
       success: true,
       summaries: summaries.map((s) => s.toSafeObject()),

--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -228,7 +228,7 @@ const saveResume = async (req, res) => {
 const getMyResumes = async (req, res) => {
     try {
         const userId = req.user._id;
-        const resumes = await Resume.find({ user: userId }).sort({ updatedAt: -1 });
+        const resumes = await Resume.find({ user: userId }).sort({ updatedAt: -1 }).limit(50);
         res.status(200).json({ success: true, resumes });
     } catch (error) {
         console.error("Get Resumes Error:", error);

--- a/backend/controllers/roadmapController.js
+++ b/backend/controllers/roadmapController.js
@@ -50,6 +50,7 @@ const getUserRoadmaps = async (req, res) => {
     const userId = req.user._id;
     const roadmaps = await RoadmapProject.find({ userId })
       .sort({ updatedAt: -1 })
+      .limit(50)
       .select(
         "projectIdea overview progressPercent status milestones testingChecklist createdAt updatedAt lastStep"
       );

--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -8,7 +8,7 @@ exports.getAllProgress = async (req, res) => {
   const userId = req.user._id;
 
   try {
-    const progressList = await UserSheetProgress.find({ userId });
+    const progressList = await UserSheetProgress.find({ userId }).limit(50);
 
     res.json({
       success: true,


### PR DESCRIPTION
Resolves #898

Description
This PR appends \.limit(50)\ to \ind()\ queries across multiple controllers to prevent MongoDB out-of-memory errors on large user datasets.

Changes Made
- Appended limit to \userSheetProgressController.js\, \oadmapController.js\, \esumeController.js\, and \
otesSummaryController.js\.