### PR TITLE
UX: Add loading and disabled states to Roadmap deletion

### DIFF
--- a/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
+++ b/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
@@ -35,7 +35,7 @@ const ProjectRoadmap = () => {
   const [saving, setSaving] = useState(false);
   const [regeneratingSection, setRegeneratingSection] = useState(null);
   const [savingPdf, setSavingPdf] = useState(false);
-
+  const [isDeleting, setIsDeleting] = useState(false);
   // ── Fetch saved roadmaps ──────────────────────────────
   const fetchRoadmaps = async () => {
     if (!user) {
@@ -137,6 +137,7 @@ const ProjectRoadmap = () => {
 
   const handleDeleteRoadmap = async (id) => {
     if (!window.confirm("Delete this roadmap? This can't be undone.")) return;
+    setIsDeleting(true);
     try {
       await axiosInstance.delete(API_PATHS.ROADMAP.DELETE(id));
       toast.success("Roadmap deleted");
@@ -147,6 +148,8 @@ const ProjectRoadmap = () => {
       fetchRoadmaps();
     } catch (err) {
       toast.error("Failed to delete roadmap");
+    } finally {
+      setIsDeleting(false);
     }
   };
 
@@ -311,6 +314,7 @@ const ProjectRoadmap = () => {
             onOpen={handleOpenRoadmap}
             onDelete={handleDeleteRoadmap}
             onCreateNew={handleCreateNew}
+            isDeleting={isDeleting}
           />
         )}
 

--- a/frontend/src/pages/ProjectRoadmap/components/RoadmapDashboard.jsx
+++ b/frontend/src/pages/ProjectRoadmap/components/RoadmapDashboard.jsx
@@ -19,7 +19,7 @@ const StatusBadge = ({ status }) => {
   );
 };
 
-const RoadmapCard = ({ roadmap, onOpen, onDelete }) => (
+const RoadmapCard = ({ roadmap, onOpen, onDelete, isDeleting }) => (
   <div
     onClick={() => onOpen(roadmap._id)}
     className="group flex flex-col bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl p-5 space-y-4 cursor-pointer hover:border-violet-400 dark:hover:border-violet-500/50 transition-all"
@@ -40,11 +40,12 @@ const RoadmapCard = ({ roadmap, onOpen, onDelete }) => (
       </div>
       <button
         type="button"
+        disabled={isDeleting}
         onClick={(e) => {
           e.stopPropagation();
           onDelete(roadmap._id);
         }}
-        className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-red-500 transition-all shrink-0"
+        className={`opacity-0 group-hover:opacity-100 transition-all shrink-0 ${isDeleting ? "text-gray-300 cursor-not-allowed" : "text-gray-400 hover:text-red-500"}`}
         aria-label="Delete roadmap"
       >
         <Trash2 size={16} strokeWidth={1.5} />
@@ -77,7 +78,7 @@ const RoadmapCard = ({ roadmap, onOpen, onDelete }) => (
   </div>
 );
 
-const RoadmapDashboard = ({ roadmaps, loading, onOpen, onDelete, onCreateNew }) => {
+const RoadmapDashboard = ({ roadmaps, loading, onOpen, onDelete, onCreateNew, isDeleting }) => {
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
@@ -127,7 +128,13 @@ const RoadmapDashboard = ({ roadmaps, loading, onOpen, onDelete, onCreateNew }) 
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
           {roadmaps.map((r) => (
-            <RoadmapCard key={r._id} roadmap={r} onOpen={onOpen} onDelete={onDelete} />
+            <RoadmapCard
+              key={r._id}
+              roadmap={r}
+              onOpen={onOpen}
+              onDelete={onDelete}
+              isDeleting={isDeleting}
+            />
           ))}
         </div>
       )}

--- a/frontend/src/pages/ProjectRoadmap/components/RoadmapDetail.jsx
+++ b/frontend/src/pages/ProjectRoadmap/components/RoadmapDetail.jsx
@@ -332,6 +332,7 @@ const RoadmapDetail = ({
   onExportMarkdown,
   onExportPDF,
   onDelete,
+  isDeleting,
 }) => {
   const [view, setView] = useState("checklist");
 
@@ -372,9 +373,11 @@ const RoadmapDetail = ({
             </button>
             <button
               onClick={onDelete}
-              className="flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-semibold border border-red-200 dark:border-red-500/30 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10 transition-all"
+              disabled={isDeleting}
+              className={`flex items-center gap-1.5 px-3.5 py-2 rounded-lg text-xs font-semibold transition-all ${isDeleting ? "bg-gray-100 border border-gray-200 text-gray-400 cursor-not-allowed" : "border border-red-200 dark:border-red-500/30 text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-500/10"}`}
             >
-              <Trash2 size={14} strokeWidth={1.5} /> Delete
+              {isDeleting ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} strokeWidth={1.5} />} 
+              {isDeleting ? "Deleting..." : "Delete"}
             </button>
           </div>
         </div>


### PR DESCRIPTION
Resolves #905

Description
This pull request adds an \isDeleting\ state to the Roadmap deletion process to prevent users from firing redundant API calls and to provide better visual feedback during destructive actions.

Changes Made
- Added \isDeleting\ state in \ProjectRoadmap.jsx\.
- Passed state down to \RoadmapDashboard.jsx\ and \RoadmapDetail.jsx\.
- Disabled trash buttons and replaced icons with loading spinners while deletion is in progress.