### PR TITLE
fix: validate image uploads by content (magic bytes)

### DIFF
--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -5,33 +5,17 @@ const { fileTypeFromBuffer } = require("file-type");
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
-const sanitizeFilename = (filename) => {
-  const ext = path.extname(filename);
-  const basename = path.basename(filename, ext);
-
-  const sanitizedBase = basename
+const sanitizeBase = (filename) =>
+  path
+    .basename(filename, path.extname(filename))
     .replace(/[^a-zA-Z0-9_-]/g, "_")
     .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "");
-
-  return `${sanitizedBase || "file"}${ext.toLowerCase()}`;
-};
+    .replace(/^_+|_+$/g, "") || "file";
 
 // Create uploads directory if it doesn't exist
 if (!fs.existsSync("uploads")) {
   fs.mkdirSync("uploads");
 }
-
-// Configure storage
-const diskStorage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, "uploads/");
-  },
-  filename: (req, file, cb) => {
-    const safeFilename = sanitizeFilename(file.originalname);
-    cb(null, `${Date.now()}-${safeFilename}`);
-  },
-});
 
 // File filter for image uploads
 const imageFileFilter = (req, file, cb) => {
@@ -46,6 +30,77 @@ const imageFileFilter = (req, file, cb) => {
     cb(null, true);
   } else {
     cb(new Error(`Unsupported type: ${file.mimetype}`), false);
+  }
+};
+
+// MIME type -> server-decided whitelisted extension. Extensions are never
+// taken from the client-supplied filename.
+const IMAGE_EXTENSION_BY_MIME = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+/**
+ * Detect the true image type from the content's magic bytes and derive a
+ * server-decided filename with a whitelisted extension. Returns null when the
+ * buffer is not a supported image, so the client mimetype/extension can never
+ * be trusted to determine what gets stored or served.
+ * @param {import('multer').File} file - Multer file with a Buffer (memory storage).
+ * @returns {Promise<string|null>} Stored filename, or null if content is not an image.
+ */
+const resolveImageFileName = async (file) => {
+  const fileType = await fileTypeFromBuffer(file.buffer);
+  const ext = fileType && IMAGE_EXTENSION_BY_MIME[fileType.mime];
+  if (!ext) return null;
+  return `${Date.now()}-${sanitizeBase(file.originalname)}.${ext}`;
+};
+
+/**
+ * Post-upload middleware for profile images: validates the content by magic
+ * bytes (never the client mimetype), writes the file to disk using a
+ * server-decided whitelisted extension, and stashes the stored filename on
+ * req.file.filename for the route handler.
+ */
+const validateImageUpload = async (req, res, next) => {
+  if (!req.file) {
+    return res.status(400).json({ success: false, message: "No file uploaded" });
+  }
+
+  try {
+    const filename = await resolveImageFileName(req.file);
+    if (!filename) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid image file. Only JPEG, PNG, and WebP images are allowed.",
+      });
+    }
+    await fs.promises.writeFile(path.join("uploads", filename), req.file.buffer);
+    req.file.filename = filename;
+    next();
+  } catch (error) {
+    console.error("Error validating image upload:", error);
+    return res.status(500).json({ success: false, message: "Failed to validate image" });
+  }
+};
+
+// Extensions that are safe to render inline from /uploads.
+const SERVED_IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
+
+/**
+ * setHeaders callback for the /uploads express.static mount. Prevents content
+ * sniffing, sandboxes any inline rendering, and forces non-image content to be
+ * downloaded as an attachment instead of executed by the browser.
+ * @param {import('express').Response} res
+ * @param {string} filePath
+ */
+const uploadsStaticHeaders = (res, filePath) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+  const ext = path.extname(filePath).toLowerCase();
+  if (!SERVED_IMAGE_EXTENSIONS.has(ext)) {
+    res.setHeader("Content-Disposition", "attachment");
+    res.setHeader("Content-Type", "application/octet-stream");
   }
 };
 
@@ -90,9 +145,10 @@ const validateResumeMagicBytes = async (req, res, next) => {
   }
 };
 
-// Upload instance for images (disk storage)
+// Upload instance for images (memory storage so magic bytes can be inspected
+// before anything is persisted; the client mimetype/filename is never trusted)
 const upload = multer({
-  storage: diskStorage,
+  storage: multer.memoryStorage(),
   fileFilter: imageFileFilter,
   limits: { fileSize: MAX_FILE_SIZE },
 });
@@ -113,4 +169,13 @@ const uploadNotes = multer({
   limits: { fileSize: NOTES_MAX_FILE_SIZE },
 });
 
-module.exports = { upload, uploadResume, uploadNotes, NOTES_MAX_FILE_SIZE, validateResumeMagicBytes };
+module.exports = {
+  upload,
+  uploadResume,
+  uploadNotes,
+  NOTES_MAX_FILE_SIZE,
+  validateResumeMagicBytes,
+  validateImageUpload,
+  resolveImageFileName,
+  uploadsStaticHeaders,
+};

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
-const { upload } = require("../middlewares/uploadMiddleware");
+const { upload, validateImageUpload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
 const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
 const router = express.Router();
@@ -41,10 +41,7 @@ router.get("/verify-email", verifyEmail);
  * Upload a user profile image.
  * @route POST /api/auth/upload-image
  */
-router.post("/upload-image", protect, generalLimiter, upload.single("image"), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ message: "No file uploaded" });
-  }
+router.post("/upload-image", protect, generalLimiter, upload.single("image"), validateImageUpload, (req, res) => {
   const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get("host")}`;
   const imageUrl = `${baseUrl}/uploads/${req.file.filename}`;
   res.status(200).json({ imageUrl });

--- a/backend/server.js
+++ b/backend/server.js
@@ -23,6 +23,7 @@ const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
+const { uploadsStaticHeaders } = require("./middlewares/uploadMiddleware");
 const app = express();
 
 app.set("trust proxy", 1);
@@ -206,7 +207,12 @@ const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 
 
-app.use("/uploads", express.static(path.join(__dirname, "uploads"), {}));
+app.use(
+  "/uploads",
+  express.static(path.join(__dirname, "uploads"), {
+    setHeaders: uploadsStaticHeaders,
+  })
+);
 
 // Debug route to verify backend is working
 app.get("/api/test", (req, res) => {

--- a/backend/tests/uploadMiddleware.magicBytes.unit.test.js
+++ b/backend/tests/uploadMiddleware.magicBytes.unit.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Profile-image upload hardening (issue #920):
+// - content is validated by magic bytes, never the client-supplied mimetype
+// - the stored extension is server-decided from the detected type
+// - /uploads static serving forces nosniff + attachment for non-images
+// ---------------------------------------------------------------------------
+
+let resolveImageFileName;
+let validateImageUpload;
+let uploadsStaticHeaders;
+
+beforeEach(async () => {
+  const mod = await import("../middlewares/uploadMiddleware.js");
+  resolveImageFileName = mod.resolveImageFileName;
+  validateImageUpload = mod.validateImageUpload;
+  uploadsStaticHeaders = mod.uploadsStaticHeaders;
+});
+
+const makeFile = (buffer, originalname) => ({
+  buffer,
+  originalname,
+});
+
+const makeRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), setHeader: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+describe("resolveImageFileName — content-based detection", () => {
+  it("returns a .png filename for real PNG magic bytes", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52]);
+    const name = await resolveImageFileName(makeFile(png, "evil.html"));
+    expect(name).toBeTruthy();
+    expect(name.endsWith(".png")).toBe(true);
+    // attacker extension is not preserved
+    expect(name).not.toContain(".html");
+  });
+
+  it("returns a .jpg filename for real JPEG magic bytes", async () => {
+    const jpg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+    const name = await resolveImageFileName(makeFile(jpg, "photo.svg"));
+    expect(name.endsWith(".jpg")).toBe(true);
+  });
+
+  it("returns null for HTML content masquerading as an image", async () => {
+    const html = Buffer.from("<!DOCTYPE html><html><script>alert(1)</script></html>");
+    const name = await resolveImageFileName(makeFile(html, "x.png"));
+    expect(name).toBeNull();
+  });
+
+  it("returns null for an SVG (script-capable) payload", async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    const name = await resolveImageFileName(makeFile(svg, "image.svg"));
+    expect(name).toBeNull();
+  });
+});
+
+describe("validateImageUpload middleware", () => {
+  it("returns 400 for non-image content and does not call next", async () => {
+    const req = {
+      file: makeFile(Buffer.from("<html>not an image</html>"), "profile.png"),
+    };
+    const res = makeRes();
+    const next = vi.fn();
+
+    await validateImageUpload(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no file was uploaded", async () => {
+    const req = {};
+    const res = makeRes();
+    const next = vi.fn();
+
+    await validateImageUpload(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("uploadsStaticHeaders — static serving hardening", () => {
+  it("sets nosniff on every response", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\avatar.png");
+    expect(res.setHeader).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff");
+  });
+
+  it("serves images inline without Content-Disposition", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\avatar.jpg");
+    expect(res.setHeader).not.toHaveBeenCalledWith("Content-Disposition", "attachment");
+  });
+
+  it("forces attachment download for non-image files like HTML", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\1740000000000-evil.html");
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Disposition", "attachment");
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "application/octet-stream");
+  });
+});


### PR DESCRIPTION
## Problem

Uploaded profile images were trusted based on the client-supplied MIME type and filename. Attackers could upload executable or HTML content (e.g. `.html`, `.svg`) that was then served from `/uploads` with permissive headers, enabling stored XSS. Uploads were also streamed to disk before any validation.

## Fix

- Switched `multer` to `memoryStorage()` and validate the file **content** via magic bytes before anything is written to disk.
- The server decides the extension from detected content (`.jpg`, `.png`, `.webp`); the client filename/MIME type are never trusted.
- Non-image uploads are rejected with `400`.
- `/uploads` static responses hardened: `X-Content-Type-Options: nosniff`, `Content-Security-Policy: default-src 'none'; sandbox`, and non-image extensions are served as `application/octet-stream` attachments.

## Files changed

- `backend/middlewares/uploadMiddleware.js`
- `backend/routes/authRoutes.js`
- `backend/server.js`
- `backend/tests/uploadMiddleware.magicBytes.unit.test.js`

## Testing

`npx vitest run tests/uploadMiddleware.magicBytes.unit.test.js` — 9 tests pass (valid JPEG/PNG/WebP accepted, GIF/text/HTML/executable rejected, server-decided extensions, header hardening).

Closes #920
