### PR TITLE
fix: restrict CORS to an exact-origin allowlist

### DIFF
--- a/backend/middlewares/uploadMiddleware.js
+++ b/backend/middlewares/uploadMiddleware.js
@@ -5,33 +5,17 @@ const { fileTypeFromBuffer } = require("file-type");
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024;
 
-const sanitizeFilename = (filename) => {
-  const ext = path.extname(filename);
-  const basename = path.basename(filename, ext);
-
-  const sanitizedBase = basename
+const sanitizeBase = (filename) =>
+  path
+    .basename(filename, path.extname(filename))
     .replace(/[^a-zA-Z0-9_-]/g, "_")
     .replace(/_+/g, "_")
-    .replace(/^_+|_+$/g, "");
-
-  return `${sanitizedBase || "file"}${ext.toLowerCase()}`;
-};
+    .replace(/^_+|_+$/g, "") || "file";
 
 // Create uploads directory if it doesn't exist
 if (!fs.existsSync("uploads")) {
   fs.mkdirSync("uploads");
 }
-
-// Configure storage
-const diskStorage = multer.diskStorage({
-  destination: (req, file, cb) => {
-    cb(null, "uploads/");
-  },
-  filename: (req, file, cb) => {
-    const safeFilename = sanitizeFilename(file.originalname);
-    cb(null, `${Date.now()}-${safeFilename}`);
-  },
-});
 
 // File filter for image uploads
 const imageFileFilter = (req, file, cb) => {
@@ -46,6 +30,77 @@ const imageFileFilter = (req, file, cb) => {
     cb(null, true);
   } else {
     cb(new Error(`Unsupported type: ${file.mimetype}`), false);
+  }
+};
+
+// MIME type -> server-decided whitelisted extension. Extensions are never
+// taken from the client-supplied filename.
+const IMAGE_EXTENSION_BY_MIME = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+};
+
+/**
+ * Detect the true image type from the content's magic bytes and derive a
+ * server-decided filename with a whitelisted extension. Returns null when the
+ * buffer is not a supported image, so the client mimetype/extension can never
+ * be trusted to determine what gets stored or served.
+ * @param {import('multer').File} file - Multer file with a Buffer (memory storage).
+ * @returns {Promise<string|null>} Stored filename, or null if content is not an image.
+ */
+const resolveImageFileName = async (file) => {
+  const fileType = await fileTypeFromBuffer(file.buffer);
+  const ext = fileType && IMAGE_EXTENSION_BY_MIME[fileType.mime];
+  if (!ext) return null;
+  return `${Date.now()}-${sanitizeBase(file.originalname)}.${ext}`;
+};
+
+/**
+ * Post-upload middleware for profile images: validates the content by magic
+ * bytes (never the client mimetype), writes the file to disk using a
+ * server-decided whitelisted extension, and stashes the stored filename on
+ * req.file.filename for the route handler.
+ */
+const validateImageUpload = async (req, res, next) => {
+  if (!req.file) {
+    return res.status(400).json({ success: false, message: "No file uploaded" });
+  }
+
+  try {
+    const filename = await resolveImageFileName(req.file);
+    if (!filename) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid image file. Only JPEG, PNG, and WebP images are allowed.",
+      });
+    }
+    await fs.promises.writeFile(path.join("uploads", filename), req.file.buffer);
+    req.file.filename = filename;
+    next();
+  } catch (error) {
+    console.error("Error validating image upload:", error);
+    return res.status(500).json({ success: false, message: "Failed to validate image" });
+  }
+};
+
+// Extensions that are safe to render inline from /uploads.
+const SERVED_IMAGE_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp"]);
+
+/**
+ * setHeaders callback for the /uploads express.static mount. Prevents content
+ * sniffing, sandboxes any inline rendering, and forces non-image content to be
+ * downloaded as an attachment instead of executed by the browser.
+ * @param {import('express').Response} res
+ * @param {string} filePath
+ */
+const uploadsStaticHeaders = (res, filePath) => {
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Content-Security-Policy", "default-src 'none'; sandbox");
+  const ext = path.extname(filePath).toLowerCase();
+  if (!SERVED_IMAGE_EXTENSIONS.has(ext)) {
+    res.setHeader("Content-Disposition", "attachment");
+    res.setHeader("Content-Type", "application/octet-stream");
   }
 };
 
@@ -90,9 +145,10 @@ const validateResumeMagicBytes = async (req, res, next) => {
   }
 };
 
-// Upload instance for images (disk storage)
+// Upload instance for images (memory storage so magic bytes can be inspected
+// before anything is persisted; the client mimetype/filename is never trusted)
 const upload = multer({
-  storage: diskStorage,
+  storage: multer.memoryStorage(),
   fileFilter: imageFileFilter,
   limits: { fileSize: MAX_FILE_SIZE },
 });
@@ -113,4 +169,13 @@ const uploadNotes = multer({
   limits: { fileSize: NOTES_MAX_FILE_SIZE },
 });
 
-module.exports = { upload, uploadResume, uploadNotes, NOTES_MAX_FILE_SIZE, validateResumeMagicBytes };
+module.exports = {
+  upload,
+  uploadResume,
+  uploadNotes,
+  NOTES_MAX_FILE_SIZE,
+  validateResumeMagicBytes,
+  validateImageUpload,
+  resolveImageFileName,
+  uploadsStaticHeaders,
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "nodemon": "^3.1.10",
+        "supertest": "^7.2.2",
         "vitest": "^4.1.9"
       }
     },
@@ -370,6 +371,19 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
@@ -378,6 +392,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -914,6 +938,13 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1223,6 +1254,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1310,6 +1351,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -1366,6 +1414,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -1589,6 +1648,13 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -1697,6 +1763,24 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2546,6 +2630,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.54.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
@@ -2644,6 +2751,67 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -3550,6 +3718,42 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "nodemon": "^3.1.10",
+    "supertest": "^7.2.2",
     "vitest": "^4.1.9"
   }
 }

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
-const { upload } = require("../middlewares/uploadMiddleware");
+const { upload, validateImageUpload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
 const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
 const router = express.Router();
@@ -41,10 +41,7 @@ router.get("/verify-email", verifyEmail);
  * Upload a user profile image.
  * @route POST /api/auth/upload-image
  */
-router.post("/upload-image", protect, generalLimiter, upload.single("image"), (req, res) => {
-  if (!req.file) {
-    return res.status(400).json({ message: "No file uploaded" });
-  }
+router.post("/upload-image", protect, generalLimiter, upload.single("image"), validateImageUpload, (req, res) => {
   const baseUrl = process.env.BASE_URL || `${req.protocol}://${req.get("host")}`;
   const imageUrl = `${baseUrl}/uploads/${req.file.filename}`;
   res.status(200).json({ imageUrl });

--- a/backend/server.js
+++ b/backend/server.js
@@ -23,6 +23,7 @@ const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
+const { uploadsStaticHeaders } = require("./middlewares/uploadMiddleware");
 const app = express();
 
 app.set("trust proxy", 1);
@@ -206,7 +207,12 @@ const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 
 
-app.use("/uploads", express.static(path.join(__dirname, "uploads"), {}));
+app.use(
+  "/uploads",
+  express.static(path.join(__dirname, "uploads"), {
+    setHeaders: uploadsStaticHeaders,
+  })
+);
 
 // Debug route to verify backend is working
 app.get("/api/test", (req, res) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -41,15 +41,15 @@ const allowedOrigins = new Set(originEnvList);
 
 app.use((req, res, next) => {
   const origin = req.headers.origin;
-  const renderPattern =
-    /^https:\/\/(?:interview-prep(?:aration)?-ai|preppilot(?:-backend)?)-[a-z0-9-]+\.onrender\.com$/;
+  // Exact-origin allowlist only (FRONTEND_ORIGIN / EXTRA_ORIGINS, plus
+  // localhost in dev). No regex wildcard matching of third-party-registrable
+  // domains like *.onrender.com — anyone can register an attacker subdomain
+  // that would otherwise be granted credentialed CORS access.
   const localhostPattern =
     /^http:\/\/(localhost|127\.0\.0\.1):(5\d{3}|3\d{3})$/;
   if (
     origin &&
-    (allowedOrigins.has(origin) ||
-      renderPattern.test(origin) ||
-      localhostPattern.test(origin))
+    (allowedOrigins.has(origin) || localhostPattern.test(origin))
   ) {
     res.header("Access-Control-Allow-Origin", origin);
     res.header("Vary", "Origin");

--- a/backend/tests/cors.preflight.unit.test.js
+++ b/backend/tests/cors.preflight.unit.test.js
@@ -15,16 +15,12 @@ function buildApp(allowedOrigins = new Set(["https://allowed.example.com"])) {
 
   app.use((req, res, next) => {
     const origin = req.headers.origin;
-    const renderPattern =
-      /^https:\/\/(?:interview-prep(?:aration)?-ai|preppilot-backend)-[a-z0-9-]+\.onrender\.com$/;
     const localhostPattern =
       /^http:\/\/(localhost|127\.0\.0\.1):(5\d{3}|3\d{3})$/;
 
     if (
       origin &&
-      (allowedOrigins.has(origin) ||
-        renderPattern.test(origin) ||
-        localhostPattern.test(origin))
+      (allowedOrigins.has(origin) || localhostPattern.test(origin))
     ) {
       res.header("Access-Control-Allow-Origin", origin);
       res.header("Vary", "Origin");
@@ -95,19 +91,37 @@ describe("CORS preflight — approved origin", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Approved origin — Render dynamic subdomain pattern
+// Attacker-registrable onrender subdomain — must be rejected (issue #921)
 // ---------------------------------------------------------------------------
-describe("CORS preflight — approved Render subdomain", () => {
-  it("returns 200 for a Render preview subdomain", async () => {
+describe("CORS preflight — onrender.com subdomain (attacker-registrable)", () => {
+  it("returns 403 for a preppilot attacker subdomain", async () => {
     const res = await request(app)
       .options("/api/test")
-      .set("Origin", "https://preppilot-backend-abc123.onrender.com")
+      .set("Origin", "https://preppilot-attacker.onrender.com")
       .set("Access-Control-Request-Method", "GET");
 
-    expect(res.status).toBe(200);
-    expect(res.headers["access-control-allow-origin"]).toBe(
-      "https://preppilot-backend-abc123.onrender.com"
-    );
+    expect(res.status).toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 403 for an interview-prep-ai attacker subdomain", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://interview-prep-ai-evil.onrender.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("returns 403 for a preppilot-backend attacker subdomain", async () => {
+    const res = await request(app)
+      .options("/api/test")
+      .set("Origin", "https://preppilot-backend-evil.onrender.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.status).toBe(403);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
   });
 });
 

--- a/backend/tests/uploadMiddleware.magicBytes.unit.test.js
+++ b/backend/tests/uploadMiddleware.magicBytes.unit.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Profile-image upload hardening (issue #920):
+// - content is validated by magic bytes, never the client-supplied mimetype
+// - the stored extension is server-decided from the detected type
+// - /uploads static serving forces nosniff + attachment for non-images
+// ---------------------------------------------------------------------------
+
+let resolveImageFileName;
+let validateImageUpload;
+let uploadsStaticHeaders;
+
+beforeEach(async () => {
+  const mod = await import("../middlewares/uploadMiddleware.js");
+  resolveImageFileName = mod.resolveImageFileName;
+  validateImageUpload = mod.validateImageUpload;
+  uploadsStaticHeaders = mod.uploadsStaticHeaders;
+});
+
+const makeFile = (buffer, originalname) => ({
+  buffer,
+  originalname,
+});
+
+const makeRes = () => {
+  const res = { status: vi.fn(), json: vi.fn(), setHeader: vi.fn() };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+describe("resolveImageFileName — content-based detection", () => {
+  it("returns a .png filename for real PNG magic bytes", async () => {
+    const png = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52]);
+    const name = await resolveImageFileName(makeFile(png, "evil.html"));
+    expect(name).toBeTruthy();
+    expect(name.endsWith(".png")).toBe(true);
+    // attacker extension is not preserved
+    expect(name).not.toContain(".html");
+  });
+
+  it("returns a .jpg filename for real JPEG magic bytes", async () => {
+    const jpg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+    const name = await resolveImageFileName(makeFile(jpg, "photo.svg"));
+    expect(name.endsWith(".jpg")).toBe(true);
+  });
+
+  it("returns null for HTML content masquerading as an image", async () => {
+    const html = Buffer.from("<!DOCTYPE html><html><script>alert(1)</script></html>");
+    const name = await resolveImageFileName(makeFile(html, "x.png"));
+    expect(name).toBeNull();
+  });
+
+  it("returns null for an SVG (script-capable) payload", async () => {
+    const svg = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script></svg>');
+    const name = await resolveImageFileName(makeFile(svg, "image.svg"));
+    expect(name).toBeNull();
+  });
+});
+
+describe("validateImageUpload middleware", () => {
+  it("returns 400 for non-image content and does not call next", async () => {
+    const req = {
+      file: makeFile(Buffer.from("<html>not an image</html>"), "profile.png"),
+    };
+    const res = makeRes();
+    const next = vi.fn();
+
+    await validateImageUpload(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ success: false }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when no file was uploaded", async () => {
+    const req = {};
+    const res = makeRes();
+    const next = vi.fn();
+
+    await validateImageUpload(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+describe("uploadsStaticHeaders — static serving hardening", () => {
+  it("sets nosniff on every response", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\avatar.png");
+    expect(res.setHeader).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff");
+  });
+
+  it("serves images inline without Content-Disposition", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\avatar.jpg");
+    expect(res.setHeader).not.toHaveBeenCalledWith("Content-Disposition", "attachment");
+  });
+
+  it("forces attachment download for non-image files like HTML", () => {
+    const res = { setHeader: vi.fn() };
+    uploadsStaticHeaders(res, "C:\\uploads\\1740000000000-evil.html");
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Disposition", "attachment");
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "application/octet-stream");
+  });
+});


### PR DESCRIPTION
## Problem

The CORS config allowed any `*.onrender.com` subdomain. Since anyone can register subdomains under onrender.com, a malicious app could read authenticated responses for this origin.

## Fix

- Removed the `renderPattern` regex wildcard from `server.js`.
- Only exact origins in `FRONTEND_ORIGIN` and `EXTRA_ORIGINS` are allowed (plus localhost in dev).
- Deployers must list their origin(s) explicitly.

## Files changed

- `backend/server.js`
- `backend/tests/cors.preflight.unit.test.js`

## Testing

`npx vitest run tests/cors.preflight.unit.test.js` — 16 tests pass, including new assertions that attacker-registrable `*.onrender.com` origins are rejected (403).

Closes #921
