### PR TITLE
fix: stop leaking password hash and secrets in user JSON

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -77,6 +77,21 @@ UserSchema.methods.isValidPassword = async function(candidatePassword) {
   // Compare candidate password with the stored hash
   return await bcrypt.compare(candidatePassword, this.password);
 };   
-   
+
+// Never serialize secrets when a User document is sent over the wire (e.g.
+// res.json(user) in GET /api/auth/profile). These fields remain readable in
+// code where they are explicitly needed (login comparison, refresh rotation),
+// but are stripped from every JSON output.
+UserSchema.set("toJSON", {
+  transform: (doc, ret) => {
+    delete ret.password;
+    delete ret.refreshTokenHash;
+    delete ret.refreshTokenExpiresAt;
+    delete ret.emailVerificationToken;
+    delete ret.emailVerificationExpires;
+    delete ret.tokenVersion;
+    return ret;
+  },
+});
 
 module.exports = mongoose.model("User", UserSchema);

--- a/backend/tests/userToJSON.unit.test.js
+++ b/backend/tests/userToJSON.unit.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/profile secret redaction (issue #923): the User schema's
+// toJSON transform must never serialize password / refresh-token / email
+// verification secrets, which were previously leaked by res.json(user).
+// ---------------------------------------------------------------------------
+
+let User;
+
+beforeAll(async () => {
+  const mod = await import("../models/User.js");
+  User = mod.default ?? mod;
+});
+
+const buildUser = () =>
+  new User({
+    name: "Test User",
+    email: "test@example.com",
+    password: "hashed-super-secret",
+    profileImageUrl: "https://example.com/avatar.png",
+    refreshTokenHash: "refresh-hash",
+    refreshTokenExpiresAt: new Date(),
+    tokenVersion: 3,
+    firstName: "Test",
+    lastName: "User",
+    bio: "hello",
+    visibility: "Public",
+    prepPilotId: "testpilot123",
+    emailVerificationToken: "verification-token",
+    emailVerificationExpires: new Date(),
+    isEmailVerified: true,
+  });
+
+describe("User toJSON transform", () => {
+  it("drops every secret field from toJSON()", () => {
+    const json = buildUser().toJSON();
+
+    expect(json.password).toBeUndefined();
+    expect(json.refreshTokenHash).toBeUndefined();
+    expect(json.refreshTokenExpiresAt).toBeUndefined();
+    expect(json.emailVerificationToken).toBeUndefined();
+    expect(json.emailVerificationExpires).toBeUndefined();
+    expect(json.tokenVersion).toBeUndefined();
+  });
+
+  it("keeps the public profile fields", () => {
+    const json = buildUser().toJSON();
+
+    expect(json.name).toBe("Test User");
+    expect(json.email).toBe("test@example.com");
+    expect(json.profileImageUrl).toBe("https://example.com/avatar.png");
+    expect(json.firstName).toBe("Test");
+    expect(json.bio).toBe("hello");
+    expect(json.visibility).toBe("Public");
+    expect(json.prepPilotId).toBe("testpilot123");
+  });
+
+  it("JSON.stringify (the res.json path) also strips secrets", () => {
+    const str = JSON.stringify(buildUser());
+    expect(str).not.toContain("refreshTokenHash");
+    expect(str).not.toContain("emailVerificationToken");
+    expect(str).not.toContain("hashed-super-secret");
+  });
+});


### PR DESCRIPTION
## Problem

`GET /api/auth/profile` (and any `res.json(user)`) serialized the Mongoose user document including `password` (bcrypt hash), `refreshTokenHash`, `refreshTokenExpiresAt`, `emailVerificationToken`, `emailVerificationExpires`, and `tokenVersion`.

## Fix

- Added a schema-level `toJSON` transform on `User` that strips all secret/token fields from every JSON serialization, so no route can leak them.

## Files changed

- `backend/models/User.js`
- `backend/tests/userToJSON.unit.test.js`

## Testing

`npx vitest run tests/userToJSON.unit.test.js` — 3 tests pass (secrets absent from `toJSON`, non-secrets retained).

Closes #923
