### PR TITLE
fix: scope sheet uploads and reads to the owning user

### DIFF
--- a/backend/models/Sheet.js
+++ b/backend/models/Sheet.js
@@ -37,14 +37,29 @@ const SectionSchema = new mongoose.Schema({
 
 // Sheet Schema
 const SheetSchema = new mongoose.Schema({
-  id: { type: String, required: true, unique: true },
+  // Sheets are scoped to the user who uploaded them. The id field alone is no
+  // longer unique so that different users may each have their own copy of a
+  // shared sheet id; ownership is enforced via the compound index below.
+  id: { type: String, required: true },
   title: { type: String, required: true },
   description: { type: String, default: "" },
   followers: { type: Number, default: 0 },
   questions: { type: Number, default: 0 },
   category: { type: String, default: "general" },
   sections: [SectionSchema],
+  owner: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+    index: true,
+    required: true,
+  },
   uploadedAt: { type: Date, default: Date.now }
 });
 
-module.exports = mongoose.model('Sheet', SheetSchema);
+// Each user may own at most one sheet per id; a user can never overwrite (or
+// read) another user's sheet.
+SheetSchema.index({ id: 1, owner: 1 }, { unique: true });
+
+// Guard against recompiling when the same model is loaded through both CJS and
+// ESM module graphs in the test runner.
+module.exports = mongoose.models.Sheet || mongoose.model('Sheet', SheetSchema);

--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -26,10 +26,12 @@ router.post('/upload', protect, async (req, res) => {
         continue;
       }
 
-      // Insert or update sheet by id
+      // Insert or update the sheet scoped to the authenticated owner. The
+      // filter uses { id, owner }, so a user can never overwrite another
+      // user's sheet even when ids collide.
       const sheet = await Sheet.findOneAndUpdate(
-        { id: sheetObj.id },
-        sheetObj,
+        { id: sheetObj.id, owner: req.user._id },
+        { ...sheetObj, owner: req.user._id },
         { upsert: true, new: true, setDefaultsOnInsert: true }
       );
 
@@ -38,6 +40,11 @@ router.post('/upload', protect, async (req, res) => {
 
     res.status(201).json({ uploaded: results.length, results });
   } catch (err) {
+    if (err.code === 11000) {
+      // The compound { id, owner } index rejected the upsert — e.g. a legacy
+      // sheet without an owner already holds this id. Surface it clearly.
+      return res.status(409).json({ error: 'A sheet with this id already exists.' });
+    }
     console.error('Error saving to MongoDB:', err);
     res.status(500).json({ error: 'Failed to save sheet to database.' });
   }
@@ -45,10 +52,10 @@ router.post('/upload', protect, async (req, res) => {
 
 
 
-// GET / - fetch all sheets (for /api/sheets)
-router.get('/', async (req, res) => {
+// GET / - fetch the authenticated user's sheets
+router.get('/', protect, async (req, res) => {
   try {
-    const sheets = await Sheet.find({});
+    const sheets = await Sheet.find({ owner: req.user._id });
     res.json({ sheets });
   } catch (err) {
     console.error('Error fetching sheets:', err);
@@ -57,11 +64,11 @@ router.get('/', async (req, res) => {
 });
 
 
-// GET /:id - fetch single sheet by id (for /api/sheets/:id)
-router.get('/:id', async (req, res) => {
+// GET /:id - fetch a single sheet owned by the authenticated user
+router.get('/:id', protect, async (req, res) => {
   try {
-    // Always find by custom id field (string)
-    const sheet = await Sheet.findOne({ id: req.params.id });
+    // Always find by custom id field (string) scoped to the owner
+    const sheet = await Sheet.findOne({ id: req.params.id, owner: req.user._id });
     if (!sheet) {
       return res.status(404).json({ error: 'Sheet not found.' });
     }

--- a/backend/tests/sheetJsonUpload.unit.test.js
+++ b/backend/tests/sheetJsonUpload.unit.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Sheet upload scoping (issue #926):
+// - sheets are upserted with { id, owner } so users can't overwrite each other
+// - reads require authentication and are scoped to the owner
+// - the model has a compound unique index on { id, owner } (not id alone)
+// ---------------------------------------------------------------------------
+
+let router;
+let Sheet;
+
+beforeAll(async () => {
+  const mod = await import("../routes/sheetJsonUpload.js");
+  router = mod.default ?? mod;
+  const sheetMod = await import("../models/Sheet.js");
+  Sheet = sheetMod.default ?? sheetMod;
+});
+
+describe("Sheet model ownership", () => {
+  it("has an owner field", () => {
+    expect(Sheet.schema.paths.owner).toBeTruthy();
+  });
+
+  it("uses a compound unique index on { id, owner }", () => {
+    const indexes = Sheet.schema.indexes().map(([keys, options]) => ({
+      keys: JSON.stringify(keys),
+      unique: !!options.unique,
+    }));
+    expect(indexes).toContainEqual({
+      keys: JSON.stringify({ id: 1, owner: 1 }),
+      unique: true,
+    });
+  });
+});
+
+describe("sheet routes require authentication", () => {
+  const chainLength = (path, method) => {
+    const layer = router.stack.find(
+      (l) => l.route && l.route.path === path && l.route.methods[method]
+    );
+    expect(layer, `no route ${method.toUpperCase()} ${path}`).toBeTruthy();
+    return layer.route.stack.length;
+  };
+
+  it("POST /upload has protect plus handler", () => {
+    expect(chainLength("/upload", "post")).toBeGreaterThanOrEqual(2);
+  });
+
+  it("GET / has protect plus handler", () => {
+    expect(chainLength("/", "get")).toBeGreaterThanOrEqual(2);
+  });
+
+  it("GET /:id has protect plus handler", () => {
+    expect(chainLength("/:id", "get")).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## Problem

Sheet uploads upserted globally by `id` (any user could overwrite another user's sheet), and `GET /api/sheets` / `GET /api/sheets/:id` were unauthenticated, exposing all sheets.

## Fix

- Added `owner` to `Sheet` and a compound unique index on `{ id, owner }`.
- Upserts use `{ id, owner: req.user._id }`.
- Reads now require `protect` and are scoped to `req.user._id`.
- Duplicate-key (11000) conflicts return a clean 409 instead of 500.

## Files changed

- `backend/models/Sheet.js`
- `backend/routes/sheetJsonUpload.js`
- `backend/tests/sheetJsonUpload.unit.test.js`

## Testing

`npx vitest run tests/sheetJsonUpload.unit.test.js` — 5 tests pass (owner field, compound unique index, all routes protected).

Closes #926
