### PR TITLE
fix: reject placeholder JWT_SECRET in env validation

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -4,36 +4,78 @@ const requiredEnvVars = Object.freeze([
   "GEMINI_API_KEY",
 ]);
 
-// Optional integrations — the server boots fine without these, but the
-// dependent feature is disabled until they are provided.
-// ADZUNA_APP_ID / ADZUNA_API_KEY → "Jobs for You" (see controllers/jobController.js)
+// Documented placeholder values that must never pass validation — copying
+// .env.example straight to .env would otherwise ship weak, guessable secrets.
+// Values are compared case-insensitively after trimming.
+const placeholderValues = Object.freeze({
+  JWT_SECRET: ["your_jwt_secret_key_here_change_me", "change_me", "changeme", "secret"],
+  GEMINI_API_KEY: ["your_gemini_api_key_here", "your_api_key_here"],
+});
 
-const validateEnv = () => {
-  const missingVars = [];
+const isPlaceholder = (envVar, value) => {
+  const normalized = String(value).trim().toLowerCase();
+  const list = placeholderValues[envVar] || [];
+  return list.includes(normalized);
+};
+
+// Pure check — reads process.env, returns a report. The server entrypoint
+// turns an invalid report into process.exit(1) via validateEnv().
+const checkEnv = () => {
+  const missing = [];
+  const placeholders = [];
 
   requiredEnvVars.forEach((envVar) => {
     const value = process.env[envVar];
 
     if (!value || value.trim() === "") {
-      missingVars.push(envVar);
+      missing.push(envVar);
+    } else if (isPlaceholder(envVar, value)) {
+      placeholders.push(envVar);
     }
   });
 
-  if (missingVars.length > 0) {
+  return {
+    valid: missing.length === 0 && placeholders.length === 0,
+    missing,
+    placeholders,
+  };
+};
+
+const validateEnv = () => {
+  const { valid, missing, placeholders } = checkEnv();
+
+  if (valid) {
+    console.log("✅ Environment variables validated successfully\n");
+    return;
+  }
+
+  if (missing.length > 0) {
     console.error("\n❌ Missing required environment variables:\n");
 
-    missingVars.forEach((envVar) => {
+    missing.forEach((envVar) => {
       console.error(`   • ${envVar}`);
     });
 
     console.error(
       "\n⚠️ Please add the missing environment variables to your .env file.\n",
     );
-
-    process.exit(1);
   }
 
-  console.log("✅ Environment variables validated successfully\n");
+  if (placeholders.length > 0) {
+    console.error("\n❌ Placeholder (weak/guessable) environment values:\n");
+
+    placeholders.forEach((envVar) => {
+      console.error(`   • ${envVar} must be replaced with a real value`);
+    });
+
+    console.error(
+      "\n⚠️ The .env.example defaults are not secrets — replace them with strong, unique values.\n",
+    );
+  }
+
+  process.exit(1);
 };
 
 module.exports = validateEnv;
+module.exports.checkEnv = checkEnv;
+module.exports.placeholderValues = placeholderValues;

--- a/backend/tests/validateEnv.unit.test.js
+++ b/backend/tests/validateEnv.unit.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// validateEnv placeholder rejection (issue #927):
+// the documented .env.example JWT_SECRET placeholder must fail validation
+// instead of being accepted as a usable secret.
+// ---------------------------------------------------------------------------
+
+let checkEnv;
+
+beforeAll(async () => {
+  const mod = await import("../config/validateEnv.js");
+  checkEnv = mod.checkEnv;
+});
+
+beforeEach(() => {
+  vi.stubEnv("MONGO_URI", "mongodb://localhost:27017/interview_prep_ai");
+  vi.stubEnv("JWT_SECRET", "a_real_random_secret_value_32_chars_minimum_xyz");
+  vi.stubEnv("GEMINI_API_KEY", "AIzaSy-real-key");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+const report = () => checkEnv();
+
+describe("checkEnv — placeholder rejection", () => {
+  it("rejects the documented .env.example JWT_SECRET placeholder", () => {
+    vi.stubEnv("JWT_SECRET", "your_jwt_secret_key_here_change_me");
+    const r = report();
+    expect(r.valid).toBe(false);
+    expect(r.placeholders).toContain("JWT_SECRET");
+  });
+
+  it("rejects the documented GEMINI_API_KEY placeholder", () => {
+    vi.stubEnv("GEMINI_API_KEY", "your_gemini_api_key_here");
+    const r = report();
+    expect(r.valid).toBe(false);
+    expect(r.placeholders).toContain("GEMINI_API_KEY");
+  });
+
+  it("rejects a plain 'secret' value", () => {
+    vi.stubEnv("JWT_SECRET", "secret");
+    const r = report();
+    expect(r.placeholders).toContain("JWT_SECRET");
+  });
+
+  it("is case/whitespace-insensitive when detecting placeholders", () => {
+    vi.stubEnv("JWT_SECRET", "  YOUR_JWT_SECRET_KEY_HERE_CHANGE_ME  ");
+    const r = report();
+    expect(r.placeholders).toContain("JWT_SECRET");
+  });
+});
+
+describe("checkEnv — happy path and missing vars", () => {
+  it("is valid when all required vars are real", () => {
+    expect(report().valid).toBe(true);
+  });
+
+  it("reports missing vars", () => {
+    vi.stubEnv("JWT_SECRET", "");
+    const r = report();
+    expect(r.valid).toBe(false);
+    expect(r.missing).toContain("JWT_SECRET");
+    expect(r.placeholders).not.toContain("JWT_SECRET");
+  });
+});


### PR DESCRIPTION
## Problem

`validateEnv` accepted the documented `.env.example` placeholder `your_jwt_secret_key_here_change_me`, shipping weak, guessable secrets.

## Fix

- `checkEnv` detects placeholder values for `JWT_SECRET` (and `GEMINI_API_KEY`) and fails startup with a clear message; real values pass.

## Files changed

- `backend/config/validateEnv.js`
- `backend/tests/validateEnv.unit.test.js`

## Testing

`npx vitest run tests/validateEnv.unit.test.js` — 6 tests pass (placeholder rejected case-insensitively, missing vars reported, happy path valid).

Closes #927
