### PR TITLE
fix: verify SMTP TLS certificates

### DIFF
--- a/backend/tests/sendEmail.unit.test.js
+++ b/backend/tests/sendEmail.unit.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// SMTP TLS verification (issue #928):
+// the custom SMTP transporter must not disable certificate verification
+// (rejectUnauthorized: false removed).
+// ---------------------------------------------------------------------------
+
+let createTransporter;
+
+beforeAll(async () => {
+  const mod = await import("../utils/sendEmail.js");
+  createTransporter = mod.createTransporter;
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
+
+const customSmtpEnv = () => {
+  vi.stubEnv("EMAIL_SERVICE", "smtp");
+  vi.stubEnv("EMAIL_HOST", "smtp.example.com");
+  vi.stubEnv("EMAIL_PORT", "587");
+  vi.stubEnv("EMAIL_SECURE", "false");
+  vi.stubEnv("EMAIL_USER", "user@example.com");
+  vi.stubEnv("EMAIL_PASS", "pass");
+};
+
+describe("createTransporter — custom SMTP", () => {
+  it("does not disable TLS certificate verification", () => {
+    customSmtpEnv();
+    const transporter = createTransporter();
+    // rejectUnauthorized must be undefined (nodemailer default = verify) or
+    // explicitly true — never false.
+    expect(transporter.options.tls?.rejectUnauthorized).not.toBe(false);
+  });
+});

--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -5,8 +5,6 @@ const nodemailer = require("nodemailer");
  * Supports "gmail", "ethereal", or any custom SMTP provider.
  * Set EMAIL_SERVICE in .env to switch between providers.
  */
-console.log("EMAIL_SERVICE:", process.env.EMAIL_SERVICE);
-
 const createTransporter = () => {
     const service = process.env.EMAIL_SERVICE?.toLowerCase();
 
@@ -36,7 +34,10 @@ const createTransporter = () => {
         });
     }
 
-    // Custom SMTP — provider sets EMAIL_HOST, EMAIL_PORT themselves
+    // Custom SMTP — provider sets EMAIL_HOST, EMAIL_PORT themselves.
+    // TLS certificates are verified (nodemailer default); disabling
+    // rejectUnauthorized would allow man-in-the-middle interception of
+    // verification links and credentials.
     return nodemailer.createTransport({
         host: process.env.EMAIL_HOST,
         port: parseInt(process.env.EMAIL_PORT, 10) || 587,
@@ -44,9 +45,6 @@ const createTransporter = () => {
         auth: {
             user: process.env.EMAIL_USER,
             pass: process.env.EMAIL_PASS,
-        },
-        tls: {
-            rejectUnauthorized: false,
         },
     });
 };
@@ -83,4 +81,4 @@ const sendVerificationEmail = async (toEmail, verificationUrl) => {
     console.log("SMTP verified");
 };
 
-module.exports = { sendVerificationEmail };
+module.exports = { sendVerificationEmail, createTransporter };


### PR DESCRIPTION
## Problem

The custom SMTP transporter set `tls.rejectUnauthorized: false`, disabling certificate verification and enabling MITM interception of email credentials and verification links.

## Fix

- Removed the `tls.rejectUnauthorized: false` option so nodemailer's default (verification on) applies.
- Removed a stray `console.log` of `EMAIL_SERVICE`.

## Files changed

- `backend/utils/sendEmail.js`
- `backend/tests/sendEmail.unit.test.js`

## Testing

`npx vitest run tests/sendEmail.unit.test.js` — 1 test passes (custom SMTP transporter does not disable TLS verification).

Closes #928
