### PR TITLE
fix: JSX syntax error in BehavioralCoach prevents dev server

### DIFF
--- a/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
+++ b/frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx
@@ -348,7 +348,7 @@ const BehavioralCoach = () => {
 
       </div> {/* End max-w-6xl */}
 
-    </div> {/* End Page */}
+    </div> /* End Page */
 
   );
 };


### PR DESCRIPTION
## Problem

Vite's dependency scan failed with `Expected ")" but found "{"` at `src/pages/BehavioralCoach/BehavioralCoach.jsx:351`. The `{/* End Page */}` JSX comment appeared after the root `</div>` closed, i.e. outside any JSX element, which is invalid JSX.

## Fix

- Moved the trailing marker comment outside JSX to a plain JS comment: `</div> /* End Page */`. Verified with `esbuild` (the same parser Vite's dep scan uses) — the file now parses cleanly.

## Files changed

- `frontend/src/pages/BehavioralCoach/BehavioralCoach.jsx`

## Testing

`npx esbuild --loader:.jsx=jsx src/pages/BehavioralCoach/BehavioralCoach.jsx` completes without errors. (Frontend `node_modules` not installed here, so a full `vite build` was not run; the failing step — esbuild dep scan — passes.)

Closes #929
