### PR TITLE
fix : added useCallback to fetchBooks in NotesBooks component

### DIFF
--- a/frontend/src/pages/NotesBooks/NotesBooks.jsx
+++ b/frontend/src/pages/NotesBooks/NotesBooks.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   BookMarked,
   BookOpen,
@@ -19,7 +19,7 @@ const NotesBooks = () => {
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
 
-  const fetchBooks = async () => {
+  const fetchBooks = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
@@ -36,11 +36,11 @@ const NotesBooks = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     fetchBooks();
-  }, []);
+  }, [fetchBooks]);
 
   useEffect(() => {
     const handler = setTimeout(() => {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the React Hooks dependency issue in `frontend/src/pages/NotesBooks/NotesBooks.jsx` by wrapping `fetchBooks` in `useCallback` and adding it to the `useEffect` dependency array.

## Changes Made

1. Imported `useCallback` from React
2. Wrapped `fetchBooks` in `useCallback(() => { ... }, [])` to memoize the function
3. Updated the `useEffect` dependency array from `[]` to `[fetchBooks]`

## Impact it Made

- Fixes the ESLint `react-hooks/exhaustive-deps` warning
- Prevents stale closure bugs where the effect captures an outdated version of `fetchBooks`
- Makes the component future-proof for any dependencies that might be added to `fetchBooks`

## Note: Please assign this PR to the `tmdeveloper007` account.
