### PR TITLE
fix : added max length validation to topicsToFocus array in session creation

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -5,7 +5,7 @@ const { handleValidationError } = require("./ValidateQuestions");
 const createSessionSchema = z.object({
   role: z.string().min(1, "Role is required"),
   experience: z.string().min(1, "Experience is required"),
-  topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
+  topicsToFocus: z.array(z.string()).min(1, "At least one topic is required").max(20, "Maximum of 20 topics allowed per session"),
   description: z.string().optional(),
   question: z.array(
     z.object({


### PR DESCRIPTION
## Summary of What Has Been Done

Added a .max(20) constraint to the topicsToFocus array schema in backend/Input_validators/ValidateSession.js.

## Changes Made

Updated the Zod schema for session creation to enforce a maximum of 20 topics per session:

Before:
topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),

After:
topicsToFocus: z.array(z.string()).min(1, "At least one topic is required").max(20, "Maximum of 20 topics allowed per session"),

## Impact it Made

- Prevents users from submitting sessions with excessive topic arrays
- Keeps database records lean and query performance optimal
- Provides a clear, user-friendly error message when the limit is exceeded

## Note: Please assign this PR to the `tmdeveloper007` account.
