### PR TITLE
feat: add health, liveness and readiness endpoints (/api/health)

### DIFF
--- a/backend/routes/healthRoutes.js
+++ b/backend/routes/healthRoutes.js
@@ -1,0 +1,44 @@
+const express = require("express");
+const mongoose = require("mongoose");
+const {
+  attachDbHealthMonitor,
+  buildHealthPayload,
+  getUptimeSeconds,
+  monitor,
+} = require("../utils/healthCheck");
+
+attachDbHealthMonitor(mongoose.connection);
+
+const router = express.Router();
+
+router.get("/", (req, res) => {
+  const payload = buildHealthPayload(mongoose.connection, {
+    version: process.env.npm_package_version,
+  });
+  res.status(200).json(payload);
+});
+
+router.get("/live", (req, res) => {
+  res.status(200).json({
+    status: "ok",
+    uptimeSeconds: getUptimeSeconds(),
+    timestamp: new Date().toISOString(),
+  });
+});
+
+router.get("/ready", (req, res) => {
+  const db = mongoose.connection;
+  const connected = db.readyState === 1;
+  res.status(connected ? 200 : 503).json({
+    status: connected ? "ok" : "unavailable",
+    uptimeSeconds: getUptimeSeconds(),
+    database: {
+      state: db.readyState,
+      connected,
+      lastErrorAt: monitor.lastErrorAt,
+    },
+    timestamp: new Date().toISOString(),
+  });
+});
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -21,6 +21,7 @@ const aiRoutes = require("./routes/aiRoutes");
 const resumeRoutes = require("./routes/resumeRoutes");
 const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
+const healthRoutes = require("./routes/healthRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
 const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
 const app = express();
@@ -207,6 +208,8 @@ app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 
 
 app.use("/uploads", express.static(path.join(__dirname, "uploads"), {}));
+
+app.use("/api/health", healthRoutes);
 
 // Debug route to verify backend is working
 app.get("/api/test", (req, res) => {

--- a/backend/tests/healthCheck.unit.test.js
+++ b/backend/tests/healthCheck.unit.test.js
@@ -1,0 +1,116 @@
+import express from "express";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  buildHealthPayload,
+  formatBytes,
+  formatUptime,
+  getDbState,
+} from "../utils/healthCheck.js";
+import healthRoutes from "../routes/healthRoutes.js";
+
+function buildApp() {
+  const app = express();
+  app.use("/api/health", healthRoutes);
+  return app;
+}
+
+describe("healthCheck utils", () => {
+  it("formats byte counts with human units", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1023)).toBe("1023 B");
+    expect(formatBytes(1024)).toBe("1 KB");
+    expect(formatBytes(5 * 1024 * 1024)).toBe("5 MB");
+    expect(formatBytes(1.5 * 1024 * 1024 * 1024)).toBe("1.5 GB");
+    expect(formatBytes(-4)).toBe("0 B");
+    expect(formatBytes(Number.NaN)).toBe("0 B");
+  });
+
+  it("formats uptime into compact human segments", () => {
+    expect(formatUptime(45)).toBe("45s");
+    expect(formatUptime(125)).toBe("2m 5s");
+    expect(formatUptime(3661)).toBe("1h 1m 1s");
+    expect(formatUptime(90061)).toBe("1d 1h 1m 1s");
+    expect(formatUptime(-10)).toBe("0s");
+  });
+
+  it("maps mongoose readyState to a readable status", () => {
+    expect(getDbState({ readyState: 1 })).toEqual({
+      state: 1,
+      status: "connected",
+      ok: true,
+    });
+    expect(getDbState({ readyState: 0 })).toEqual({
+      state: 0,
+      status: "disconnected",
+      ok: false,
+    });
+    expect(getDbState(null)).toEqual({
+      state: 99,
+      status: "uninitialized",
+      ok: false,
+    });
+  });
+
+  it("builds a health payload with ok=false when the DB is not connected", () => {
+    const payload = buildHealthPayload({ readyState: 0 });
+    expect(payload.ok).toBe(false);
+    expect(payload.status).toBe("degraded");
+    expect(payload.database.status).toBe("disconnected");
+    expect(typeof payload.uptimeSeconds).toBe("number");
+    expect(typeof payload.timestamp).toBe("string");
+    expect(payload.memory).toHaveProperty("heapUsed");
+    expect(payload.runtime.node).toMatch(/^v/);
+  });
+
+  it("builds a health payload with ok=true when the DB is connected", () => {
+    const payload = buildHealthPayload({ readyState: 1, host: "mongodb-test" });
+    expect(payload.ok).toBe(true);
+    expect(payload.status).toBe("ok");
+    expect(payload.database.host).toBe("mongodb-test");
+  });
+});
+
+describe("health routes", () => {
+  let server;
+  let baseUrl;
+
+  beforeAll(async () => {
+    const app = buildApp();
+    server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    if (!server) return;
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it("GET /api/health returns a full health payload with 200", async () => {
+    const response = await fetch(`${baseUrl}/api/health`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveProperty("status");
+    expect(body).toHaveProperty("uptimeSeconds");
+    expect(body).toHaveProperty("memory");
+    expect(body).toHaveProperty("database");
+    expect(body.database).toHaveProperty("state");
+  });
+
+  it("GET /api/health/live returns 200 while the process runs", async () => {
+    const response = await fetch(`${baseUrl}/api/health/live`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.status).toBe("ok");
+    expect(typeof body.uptimeSeconds).toBe("number");
+  });
+
+  it("GET /api/health/ready returns 503 when the DB is not connected", async () => {
+    const response = await fetch(`${baseUrl}/api/health/ready`);
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.status).toBe("unavailable");
+    expect(body.database.connected).toBe(false);
+  });
+});

--- a/backend/utils/healthCheck.js
+++ b/backend/utils/healthCheck.js
@@ -1,0 +1,162 @@
+const os = require("os");
+const mongoose = require("mongoose");
+const pkg = require("../package.json");
+
+const DB_STATES = {
+  0: { code: "disconnected", ok: false },
+  1: { code: "connected", ok: true },
+  2: { code: "connecting", ok: false },
+  3: { code: "disconnecting", ok: false },
+  99: { code: "uninitialized", ok: false },
+};
+
+const monitor = {
+  lastErrorAt: null,
+  lastError: null,
+  lastStateChangeAt: new Date().toISOString(),
+  _attached: false,
+};
+
+function getDbState(connection) {
+  const readyState =
+    connection && typeof connection.readyState === "number"
+      ? connection.readyState
+      : 99;
+  const meta = DB_STATES[readyState] || DB_STATES[99];
+  return {
+    state: readyState,
+    status: meta.code,
+    ok: meta.ok,
+  };
+}
+
+function formatBytes(bytes) {
+  if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes < 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  let value = bytes;
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024;
+    unitIndex += 1;
+  }
+  const fixed = Number.isInteger(value) || value >= 10 ? 0 : 1;
+  return `${value.toFixed(fixed)} ${units[unitIndex]}`;
+}
+
+function formatUptime(totalSeconds) {
+  const seconds = Math.max(0, Math.floor(totalSeconds));
+  const days = Math.floor(seconds / 86400);
+  const hours = Math.floor((seconds % 86400) / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const secs = seconds % 60;
+  const parts = [];
+  if (days) parts.push(`${days}d`);
+  if (hours) parts.push(`${hours}h`);
+  if (minutes) parts.push(`${minutes}m`);
+  parts.push(`${secs}s`);
+  return parts.join(" ");
+}
+
+function getUptimeSeconds() {
+  return Math.floor(process.uptime());
+}
+
+function getMemoryStats() {
+  const { rss, heapUsed, heapTotal } = process.memoryUsage();
+  return {
+    rssBytes: rss,
+    heapUsedBytes: heapUsed,
+    heapTotalBytes: heapTotal,
+    rss: formatBytes(rss),
+    heapUsed: formatBytes(heapUsed),
+    heapTotal: formatBytes(heapTotal),
+    heapUsedPercent:
+      heapTotal > 0
+        ? Number(((heapUsed / heapTotal) * 100).toFixed(2))
+        : 0,
+  };
+}
+
+function getSystemLoad() {
+  return {
+    loadAverage: os
+      .loadavg()
+      .slice(0, 3)
+      .map((n) => Number(n.toFixed(2))),
+    freeMemoryBytes: os.freemem(),
+    totalMemoryBytes: os.totalmem(),
+    cpuCount: os.cpus().length,
+  };
+}
+
+function attachDbHealthMonitor(connection) {
+  if (!connection || monitor._attached) {
+    return monitor;
+  }
+  monitor._attached = true;
+  connection.on("connected", () => {
+    monitor.lastStateChangeAt = new Date().toISOString();
+  });
+  connection.on("disconnected", () => {
+    monitor.lastStateChangeAt = new Date().toISOString();
+  });
+  connection.on("reconnected", () => {
+    monitor.lastStateChangeAt = new Date().toISOString();
+  });
+  connection.on("error", (err) => {
+    monitor.lastErrorAt = new Date().toISOString();
+    monitor.lastError = err.message;
+  });
+  return monitor;
+}
+
+function buildHealthPayload(connection, options = {}) {
+  const db = getDbState(connection);
+  const memory = getMemoryStats();
+  const uptime = getUptimeSeconds();
+  const ok = db.ok;
+  const host =
+    connection && typeof connection.host === "string"
+      ? connection.host
+      : null;
+
+  return {
+    status: ok ? "ok" : "degraded",
+    ok,
+    uptimeSeconds: uptime,
+    uptimeHuman: formatUptime(uptime),
+    timestamp: new Date().toISOString(),
+    version: options.version || pkg.version || "unknown",
+    runtime: {
+      node: process.version,
+      platform: `${os.platform()} (${os.arch()})`,
+      pid: process.pid,
+      cpus: os.cpus().length,
+    },
+    memory,
+    system: getSystemLoad(),
+    database: {
+      state: db.state,
+      status: db.status,
+      ok: db.ok,
+      host,
+      lastErrorAt: monitor.lastErrorAt,
+      lastStateChangeAt: monitor.lastStateChangeAt,
+    },
+  };
+}
+
+module.exports = {
+  DB_STATES,
+  attachDbHealthMonitor,
+  buildHealthPayload,
+  formatBytes,
+  formatUptime,
+  getDbState,
+  getMemoryStats,
+  getSystemLoad,
+  getUptimeSeconds,
+  monitor,
+};


### PR DESCRIPTION
## Summary
Adds a standard **health / liveness / readiness** contract so deployments (Render, Docker, K8s) can tell "process alive" apart from "ready to serve". Previously the only probe was `GET /api/test` which returned a static message and revealed nothing about DB state or resources.

## What changed
- **New** `backend/utils/healthCheck.js`:
  - `formatBytes` / `formatUptime` human-readable helpers
  - `getDbState()` maps `mongoose.connection.readyState` to a status + `ok` flag
  - `getMemoryStats()` (rss / heap / heap %), `getSystemLoad()` (loadavg, free/total memory, cpu count)
  - `buildHealthPayload()` — one consistent JSON shape: `ok`, `status`, uptime, timestamp, app version, runtime, memory, system and database sections
  - `attachDbHealthMonitor()` — records connection state changes and last DB error time on the mongoose connection
- **New** `backend/routes/healthRoutes.js`:
  - `GET /api/health` — full payload (200)
  - `GET /api/health/live` — liveness (200 while the process runs)
  - `GET /api/health/ready` — readiness (200 when DB readyState is 1, 503 otherwise)
- Mounted as `app.use("/api/health", healthRoutes)` in `server.js` ahead of the debug route.
- **New** `backend/tests/healthCheck.unit.test.js` — 8 vitest cases covering the pure helpers and the three routes (integration via the repo's existing `app.listen(0)` + fetch pattern from `booksDownloadRedirect.unit.test.js`).

## Architecture notes
- The `attachDbHealthMonitor` guard (`monitor._attached`) makes the module idempotent when the router is required multiple times (e.g. under test).
- `buildHealthPayload` falls back to `package.json` version and reports DB `host` only when present, keeping the payload JSON-safe on a disconnected connection.
- Readiness is strictly derived from the live `readyState`; historical errors surface as informational `lastErrorAt` fields rather than permanently flapping the endpoint to 503.

## How to test
1. `cd backend && npm test -- tests/healthCheck.unit.test.js` → 8 passing
2. `npm run dev`, then:
   - `curl localhost:5000/api/health` → 200 with `database.status: "connected"`
   - `curl localhost:5000/api/health/live` → 200
   - `curl localhost:5000/api/health/ready` → 200 (or 503 if the DB is unreachable)

## Verification
- New tests pass (8/8). The remaining backend suite failures are the pre-existing outdated assertions tracked in issue #903 — none of them are in the new test file.
- No schema, auth, or workflow changes.
- Fixes #1022 (gssoc26)
