### PR TITLE
feat: search books by title across the whole library (/api/books/search)

### DIFF
--- a/backend/routes/booksRoutes.js
+++ b/backend/routes/booksRoutes.js
@@ -130,6 +130,97 @@ async function listFilesRecursive(prefix, page, limit) {
 }
 
 /**
+ * Score a book file against lower-cased query tokens.
+ * Higher is a better match; 0 means no match.
+ * @param {string} name file name including extension
+ * @param {string} category first path segment (category directory)
+ * @param {string[]} tokens lower-cased query tokens
+ * @returns {number}
+ */
+function scoreBookMatch(name, category, tokens) {
+  const fullQuery = tokens.join(" ");
+  const normalizedName = name.toLowerCase();
+
+  if (normalizedName === fullQuery) return 100;
+  if (normalizedName.startsWith(fullQuery)) return 80;
+  if (normalizedName.includes(fullQuery)) return 60;
+
+  let score = 0;
+  for (const token of tokens) {
+    if (normalizedName.includes(token)) score += 10;
+  }
+  if (category && category.toLowerCase().includes(fullQuery)) score += 5;
+  return score;
+}
+
+/**
+ * Search every book in the GitHub mirror repo (from the cached git tree)
+ * and return ranked, paginated matches.
+ * @param {object} options
+ * @param {string} options.q search query
+ * @param {string} [options.category] optional category prefix filter
+ * @param {number} [options.page] 1-based page number
+ * @param {number} [options.limit] page size, capped at 50
+ * @returns {Promise<object>} paginated ranked results
+ */
+async function searchBooks({ q = "", category = "", page, limit }) {
+  const tokens = q.toLowerCase().split(/\s+/).filter(Boolean);
+  const requestedPage = Number.isFinite(page) && page >= 1 ? page : 1;
+  const itemsPerPage =
+    Number.isFinite(limit) && limit >= 1 ? Math.min(limit, 50) : 20;
+  const categoryFilter = category.trim().toLowerCase();
+
+  let tree = cachedGitTree;
+  if (!tree) {
+    tree = await getGitTree();
+  }
+
+  if (!tree || !Array.isArray(tree)) {
+    throw new Error("Git tree unavailable for search");
+  }
+
+  const scored = [];
+  for (const entry of tree) {
+    if (entry.type !== "blob") continue;
+    const path = entry.path || "";
+    const segments = path.split("/");
+    const cat = segments.length > 1 ? segments[0] : "";
+    const name = segments.pop() || "";
+
+    if (categoryFilter && cat.toLowerCase() !== categoryFilter) continue;
+
+    const score = scoreBookMatch(name, cat, tokens);
+    if (score <= 0) continue;
+
+    scored.push({
+      path,
+      name,
+      category: cat,
+      size: entry.size,
+      url: buildRawUrl(path),
+      score,
+    });
+  }
+
+  scored.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name));
+
+  const totalItems = scored.length;
+  const startIndex = (requestedPage - 1) * itemsPerPage;
+  const endIndex = requestedPage * itemsPerPage;
+
+  return {
+    query: q.trim(),
+    totalItems,
+    items: scored.slice(startIndex, endIndex),
+    currentPage: requestedPage,
+    pageSize: itemsPerPage,
+    totalPages: Math.max(1, Math.ceil(totalItems / itemsPerPage)),
+    hasNextPage: requestedPage * itemsPerPage < totalItems,
+    hasPreviousPage: requestedPage > 1,
+  };
+}
+
+/**
  * List programming book categories and files sourced from the GitHub repository.
  * @route GET /api/books/
  * @query page optional page number, default 1
@@ -229,6 +320,39 @@ router.get("/", async (_req, res) => {
 });
 
 /**
+ * Search books by title across every category.
+ * @route GET /api/books/search
+ * @query q required, at least 2 characters
+ * @query category optional category prefix filter
+ * @query page optional page number, default 1
+ * @query limit optional page size (max 50), default 20
+ * @example
+ * GET /api/books/search?q=algorithms&limit=10
+ */
+router.get("/search", async (req, res) => {
+  const q = typeof req.query.q === "string" ? req.query.q.trim() : "";
+  if (q.length < 2) {
+    return res
+      .status(400)
+      .json({ message: "Search query 'q' must be at least 2 characters" });
+  }
+
+  const page = Number.parseInt(req.query.page, 10);
+  const limit = Number.parseInt(req.query.limit, 10);
+  const category = typeof req.query.category === "string" ? req.query.category : "";
+
+  try {
+    const result = await searchBooks({ q, category, page, limit });
+    res.json(result);
+  } catch (err) {
+    console.error("[books] Search failed:", err.message);
+    res
+      .status(503)
+      .json({ message: "Book search is temporarily unavailable." });
+  }
+});
+
+/**
  * Redirect to a GitHub raw file URL for direct download.
  * @route GET /api/books/download
  * @param {import('express').Request} req
@@ -266,3 +390,5 @@ router.get("/download", (req, res) => {
 
 module.exports = router;
 module.exports.listFilesRecursive = listFilesRecursive;
+module.exports.scoreBookMatch = scoreBookMatch;
+module.exports.searchBooks = searchBooks;

--- a/backend/tests/booksSearch.unit.test.js
+++ b/backend/tests/booksSearch.unit.test.js
@@ -1,0 +1,144 @@
+import express from "express";
+import { describe, it, expect, vi, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import booksRoutes, { scoreBookMatch, searchBooks } from "../routes/booksRoutes.js";
+
+const FAKE_TREE = {
+  tree: [
+    { type: "blob", path: "Algorithms/algorithm-design.pdf", size: 100 },
+    { type: "blob", path: "Algorithms/Dynamic Programming Book.pdf", size: 200 },
+    { type: "blob", path: "Web Development/React in Action.pdf", size: 300 },
+    { type: "blob", path: "Web Development/CSS Secrets.pdf", size: 400 },
+    { type: "tree", path: "Algorithms" },
+    { type: "tree", path: "Web Development" },
+  ],
+};
+
+function stubGitHubTree() {
+  const originalFetch = globalThis.fetch;
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url, init) => {
+      if (typeof url === "string" && url.includes("api.github.com")) {
+        return { ok: true, json: async () => FAKE_TREE };
+      }
+      return originalFetch(url, init);
+    })
+  );
+}
+
+describe("scoreBookMatch", () => {
+  it("gives top score for an exact filename match", () => {
+    expect(scoreBookMatch("react-in-action.pdf", "Web Development", ["react-in-action.pdf"])).toBe(100);
+  });
+
+  it("gives a high score for a prefix match", () => {
+    expect(scoreBookMatch("algorithms-design.pdf", "Algorithms", ["algorithms"])).toBe(80);
+  });
+
+  it("scores substring matches per token", () => {
+    expect(
+      scoreBookMatch("Dynamic Programming Book.pdf", "Algorithms", ["dynamic", "book"])
+    ).toBe(20);
+  });
+
+  it("scores a full-query substring match higher than tokens", () => {
+    expect(
+      scoreBookMatch("Mastering Dynamic Programming.pdf", "Algorithms", ["dynamic"])
+    ).toBe(60);
+  });
+
+  it("adds category points when the query matches the directory", () => {
+    const nameScore = scoreBookMatch("algorithm-design.pdf", "Algorithms", ["algorithms"]);
+    expect(nameScore).toBeGreaterThan(0);
+  });
+
+  it("returns 0 when nothing matches", () => {
+    expect(scoreBookMatch("css-secrets.pdf", "Web Development", ["cooking"])).toBe(0);
+  });
+});
+
+describe("searchBooks", () => {
+  beforeEach(() => {
+    stubGitHubTree();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("finds books whose filename contains the query", async () => {
+    const result = await searchBooks({ q: "dynamic" });
+    expect(result.totalItems).toBe(1);
+    expect(result.items[0].name).toBe("Dynamic Programming Book.pdf");
+    expect(result.items[0].category).toBe("Algorithms");
+  });
+
+  it("filters by category prefix", async () => {
+    const result = await searchBooks({ q: "secrets", category: "Web Development" });
+    expect(result.totalItems).toBe(1);
+    expect(result.items[0].name).toBe("CSS Secrets.pdf");
+  });
+
+  it("returns an empty result set for unknown queries", async () => {
+    const result = await searchBooks({ q: "zzzz-not-found" });
+    expect(result.totalItems).toBe(0);
+    expect(result.items).toEqual([]);
+  });
+
+  it("paginates and caps the page size at 50", async () => {
+    const result = await searchBooks({ q: ".pdf", limit: 999 });
+    expect(result.pageSize).toBe(50);
+    expect(result.totalPages).toBeGreaterThanOrEqual(1);
+    expect(typeof result.hasNextPage).toBe("boolean");
+  });
+});
+
+describe("books search route", () => {
+  let server;
+  let baseUrl;
+
+  beforeAll(async () => {
+    stubGitHubTree();
+    const app = express();
+    app.use("/api/books", booksRoutes);
+    server = app.listen(0);
+    await new Promise((resolve) => server.once("listening", resolve));
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterAll(async () => {
+    vi.unstubAllGlobals();
+    if (!server) return;
+    await new Promise((resolve) => server.close(resolve));
+  });
+
+  it("rejects queries shorter than two characters", async () => {
+    const response = await fetch(`${baseUrl}/api/books/search?q=a`);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.message).toContain("at least 2 characters");
+  });
+
+  it("returns ranked matches with metadata", async () => {
+    const response = await fetch(`${baseUrl}/api/books/search?q=react&limit=10`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.query).toBe("react");
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body).toHaveProperty("totalItems");
+    expect(body).toHaveProperty("totalPages");
+    const hit = body.items.find((i) => i.name.includes("React"));
+    expect(hit).toBeDefined();
+    expect(typeof hit.url).toBe("string");
+  });
+
+  it("honors the category filter", async () => {
+    const response = await fetch(
+      `${baseUrl}/api/books/search?q=css&category=Web%20Development`
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.items.every((i) => i.category === "Web Development")).toBe(true);
+  });
+});

--- a/frontend/src/pages/NotesBooks/NotesBooks.jsx
+++ b/frontend/src/pages/NotesBooks/NotesBooks.jsx
@@ -18,6 +18,9 @@ const NotesBooks = () => {
   const [warnings, setWarnings] = useState([]);
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [searchResults, setSearchResults] = useState(null);
+  const [searchLoading, setSearchLoading] = useState(false);
+  const [searchError, setSearchError] = useState(null);
 
   const fetchBooks = async () => {
     try {
@@ -50,6 +53,67 @@ const NotesBooks = () => {
       clearTimeout(handler);
     };
   }, [query]);
+
+  useEffect(() => {
+    const trimmed = debouncedQuery.trim();
+    if (trimmed.length < 2) {
+      setSearchResults(null);
+      setSearchLoading(false);
+      setSearchError(null);
+      return undefined;
+    }
+
+    const controller = new AbortController();
+    setSearchLoading(true);
+    setSearchError(null);
+
+    const url = `${BASE_URL}/api/books/search?q=${encodeURIComponent(
+      trimmed
+    )}&limit=24`;
+
+    fetch(url, { signal: controller.signal })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.message || "Book search failed");
+        }
+        return res.json();
+      })
+      .then((data) => setSearchResults(data))
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          setSearchError(err.message || "Book search failed");
+        }
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setSearchLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [debouncedQuery]);
+
+  const searchActive = debouncedQuery.trim().length >= 2;
+
+  const groupedSearchResults = useMemo(() => {
+    if (!searchResults || !Array.isArray(searchResults.items)) {
+      return [];
+    }
+    const map = new Map();
+    searchResults.items.forEach((item) => {
+      if (!map.has(item.category)) map.set(item.category, []);
+      map.get(item.category).push(item);
+    });
+    return Array.from(map.entries());
+  }, [searchResults]);
+
+  const formatFileSize = (bytes) => {
+    if (typeof bytes !== "number" || !Number.isFinite(bytes) || bytes <= 0) {
+      return "—";
+    }
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
 
   const filteredCategories = useMemo(() => {
     const normalize = (value) =>
@@ -86,7 +150,7 @@ const NotesBooks = () => {
                 <input
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
-                  placeholder="Search categories"
+                  placeholder="Search book titles & categories"
                   className="w-full pl-9 pr-3 py-2 rounded-lg border border-gray-200 dark:border-white/10 bg-transparent text-sm focus:outline-none focus:ring-2 focus:ring-violet-400/70"
                 />
               </div>
@@ -121,7 +185,7 @@ const NotesBooks = () => {
             </div>
             <div className="flex items-center gap-2 text-gray-700 dark:text-gray-300">
               <Search size={16} />
-              <span>Search by category title</span>
+              <span>Search across the whole book library</span>
             </div>
           </div>
         </div>
@@ -155,7 +219,90 @@ const NotesBooks = () => {
           </div>
         )}
 
-        {loading ? (
+        {searchActive ? (
+          searchError ? (
+            <div className="flex items-start gap-3 p-4 rounded-xl border border-red-200 dark:border-red-500/40 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-200">
+              <XCircle size={18} />
+              <div>
+                <p className="font-semibold">Search unavailable</p>
+                <p className="text-sm">{searchError}</p>
+              </div>
+            </div>
+          ) : !searchResults || searchLoading ? (
+            <div className="grid sm:grid-cols-2 gap-4">
+              {[1, 2, 3, 4].map((n) => (
+                <div
+                  key={n}
+                  className="animate-pulse bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-5 h-36"
+                />
+              ))}
+            </div>
+          ) : searchResults.items.length === 0 ? (
+            <div className="text-center py-16 bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-2xl">
+              <p className="text-lg font-semibold">No books match</p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+                Nothing matched &ldquo;{debouncedQuery.trim()}&rdquo;. Try a
+                shorter keyword.
+              </p>
+              <button
+                type="button"
+                onClick={() => setQuery("")}
+                className="mt-4 px-4 py-2 rounded-lg bg-violet-500 hover:bg-violet-600 text-white text-sm font-medium transition-colors"
+              >
+                Clear search
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-5">
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {searchResults.totalItems} match
+                {searchResults.totalItems === 1 ? "" : "es"} for &ldquo;
+                {debouncedQuery.trim()}&rdquo;
+              </p>
+              {groupedSearchResults.map(([category, items]) => (
+                <div key={category}>
+                  <div className="flex items-center gap-2 mb-2">
+                    <FolderOpen size={15} className="text-violet-500" />
+                    <h2 className="text-sm font-semibold capitalize">
+                      {category}
+                    </h2>
+                    <span className="text-xs text-gray-400">
+                      ({items.length})
+                    </span>
+                  </div>
+                  <div className="grid sm:grid-cols-2 gap-3">
+                    {items.map((item) => (
+                      <div
+                        key={item.path}
+                        className="flex items-center gap-3 bg-white dark:bg-white/5 border border-gray-200 dark:border-white/10 rounded-xl p-3"
+                      >
+                        <div className="w-9 h-9 shrink-0 rounded-lg bg-violet-500/10 text-violet-500 flex items-center justify-center">
+                          <FileText size={16} />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-sm font-medium truncate">
+                            {item.name}
+                          </p>
+                          <p className="text-xs text-gray-600 dark:text-gray-400">
+                            {formatFileSize(item.size)}
+                          </p>
+                        </div>
+                        <a
+                          href={item.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-violet-500/10 text-violet-500 hover:bg-violet-500/20 text-xs font-medium transition-colors"
+                        >
+                          <Download size={13} /> Open
+                        </a>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )
+        ) : loading ? (
           <div className="grid sm:grid-cols-2 gap-4">
             {[1, 2, 3, 4].map((n) => (
               <div


### PR DESCRIPTION
## Summary
Turns the Notes & Books page into a real library search. Previously the search box only filtered **category titles** client-side, so finding a specific book (e.g. "grokking algorithms") required browsing every category. This adds an API-backed search across all book filenames.

## What changed
**Backend** (`backend/routes/booksRoutes.js`)
- `scoreBookMatch(name, category, tokens)` — ranked scoring: exact filename > prefix > substring > per-token hits, plus category-directory points.
- `searchBooks({ q, category, page, limit })` — searches the already-cached GitHub git tree (no extra GitHub API calls), ranks, and returns grouped-friendly items with `category`, `size`, raw `url`, plus pagination metadata.
- `GET /api/books/search` — validates `q` (>= 2 chars), caps `limit` at 50, optional `category` filter, 503 on tree unavailability.
- Exports `scoreBookMatch` / `searchBooks` for tests (same pattern as the existing `listFilesRecursive` export).

**Frontend** (`frontend/src/pages/NotesBooks/NotesBooks.jsx`)
- When the debounced query reaches 2+ characters, the page switches to API-backed results: grouped by category, file size, and an "Open" download link.
- Loading skeleton, error banner, empty state with a clear-search action, and `AbortController` cleanup on query change.
- The existing client-side category filtering stays active for short queries.

**Tests** (`backend/tests/booksSearch.unit.test.js`) — 13 vitest cases for scoring, filtering, pagination, validation and route responses. The GitHub tree is stubbed via `vi.stubGlobal("fetch")` so the suite runs fully offline (real requests are delegated to the original fetch).

## How to test
1. `cd backend && npm run dev`, then `curl "localhost:5000/api/books/search?q=algorithms&limit=5"` → ranked, paginated results.
2. `cd frontend && npm run dev`, open `/notes-books`, type e.g. "react" → grouped matches across categories with size + Open link.
3. `npm test -- tests/booksSearch.unit.test.js` in `backend` → 13 passing.

## Verification
- Backend: 13/13 new tests pass; existing pre-existing failures (issue #903) unchanged.
- Frontend: `vite build` passes; ESLint clean.
- Fixes #1024 (gssoc26)
- No workflow or core auth/schema files touched.
