### PR TITLE
Security: Add Helmet Middleware and Secure CSRF Secret

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -1,6 +1,7 @@
 const requiredEnvVars = Object.freeze([
   "MONGO_URI",
   "JWT_SECRET",
+  "CSRF_SESSION_SECRET",
   "GEMINI_API_KEY",
 ]);
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -2646,6 +2646,67 @@
         "url": "https://opencollective.com/mongoose"
       }
     },
+    "node_modules/mongoose/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/mongoose/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/mongoose/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/mongoose/node_modules/mongodb": {
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",

--- a/backend/server.js
+++ b/backend/server.js
@@ -22,11 +22,25 @@ const resumeRoutes = require("./routes/resumeRoutes");
 const aptitudeQuestionsRoutes = require("./routes/AptitudeQuestions.js");
 const jobRoutes = require("./routes/jobRoutes");
 const { generalLimiter, aiLimiter } = require("./middlewares/rateLimiter");
-const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
+const { sensitiveRouteHeaders } = require("./middlewares/securityHeaders");
+const helmet = require("helmet");
 const app = express();
 
 app.set("trust proxy", 1);
-app.use(generalHeaders); 
+app.use(helmet({
+  contentSecurityPolicy: {
+    directives: {
+      defaultSrc: ["'self'"],
+      scriptSrc: ["'self'"],
+      styleSrc: ["'self'", "'unsafe-inline'"],
+      imgSrc: ["'self'", "data:", "https:"],
+      connectSrc: ["'self'"],
+      fontSrc: ["'self'"],
+      objectSrc: ["'none'"],
+      frameSrc: ["'none'"]
+    }
+  }
+})); 
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [
   process.env.FRONTEND_ORIGIN,
@@ -95,7 +109,7 @@ app.use(cookieParser());
 app.use(
   cookieSession({
     name: "csrfSession",
-    keys: [process.env.CSRF_SESSION_SECRET || process.env.JWT_SECRET],
+    keys: [process.env.CSRF_SESSION_SECRET],
     maxAge: 24 * 60 * 60 * 1000, // 24h
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",

--- a/backend/utils/responseHandler.js
+++ b/backend/utils/responseHandler.js
@@ -1,0 +1,27 @@
+const sendError = (res, statusCode, message, details = null) => {
+  const response = {
+    success: false,
+    message: message || "An unexpected error occurred",
+  };
+  
+  if (details) {
+    response.details = details;
+  }
+  
+  return res.status(statusCode).json(response);
+};
+
+const sendSuccess = (res, statusCode, data = {}, message = null) => {
+  const response = {
+    success: true,
+    ...data,
+  };
+  
+  if (message) {
+    response.message = message;
+  }
+  
+  return res.status(statusCode).json(response);
+};
+
+module.exports = { sendError, sendSuccess };


### PR DESCRIPTION
Resolves #1002
Resolves #1003

Description
This PR adds \helmet\ middleware to secure HTTP headers instead of manual header setup, fixing #1002.
It also ensures \CSRF_SESSION_SECRET\ is required and does not fall back to \JWT_SECRET\, preventing potential JWT secret reuse for CSRF sessions, fixing #1003.