### PR TITLE
feat: add DSA sheet progress backup & restore (JSON export/import)

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -1,4 +1,8 @@
 const UserSheetProgress = require("../models/UserSheetProgress");
+const {
+  normalizeProgressItems,
+  buildBulkOps,
+} = require("../utils/sheetProgressImport");
 
 /**
  * Get all sheet progress entries for the authenticated user.
@@ -136,6 +140,88 @@ exports.getProgress = async (req, res) => {
     res.json({
       success: true,
       progress,
+    });
+  } catch (err) {
+    res.status(500).json({
+      success: false,
+      error: "Internal server error occurred",
+    });
+  }
+};
+
+/**
+ * Export all sheet progress for the authenticated user as a JSON file.
+ * @route GET /api/user/sheet-progress/export
+ */
+exports.exportProgress = async (req, res) => {
+  const userId = req.user._id;
+
+  try {
+    const progressList = await UserSheetProgress.find({ userId }).lean();
+    const backup = {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      count: progressList.length,
+      items: progressList.map((p) => ({
+        sheetId: p.sheetId,
+        followed: p.followed,
+        completedTopics: p.completedTopics,
+        percentage: p.percentage,
+        updatedAt: p.updatedAt,
+      })),
+    };
+
+    res.setHeader("Content-Type", "application/json");
+    res.setHeader(
+      "Content-Disposition",
+      'attachment; filename="sheet-progress-backup.json"'
+    );
+    res.send(JSON.stringify(backup, null, 2));
+  } catch (err) {
+    res.status(500).json({
+      success: false,
+      error: "Internal server error occurred",
+    });
+  }
+};
+
+/**
+ * Import sheet progress entries for the authenticated user.
+ * Valid entries are bulk-upserted; invalid ones are skipped and reported.
+ * @route POST /api/user/sheet-progress/import
+ */
+exports.importProgress = async (req, res) => {
+  const userId = req.user._id;
+  const { items } = req.body || {};
+
+  const { items: normalized, errors } = normalizeProgressItems(items);
+  if (errors.length > 0 && normalized.length === 0) {
+    return res.status(400).json({
+      success: false,
+      error: errors[0],
+    });
+  }
+
+  if (normalized.length === 0) {
+    return res.status(400).json({
+      success: false,
+      error: "No valid entries to import",
+    });
+  }
+
+  try {
+    const result = await UserSheetProgress.bulkWrite(
+      buildBulkOps(userId, normalized),
+      { ordered: false }
+    );
+
+    res.json({
+      success: true,
+      imported: normalized.length,
+      skipped: errors.length,
+      updated: result.matchedCount || 0,
+      created: result.upsertedCount || 0,
+      warnings: errors.slice(0, 20),
     });
   } catch (err) {
     res.status(500).json({

--- a/backend/routes/userSheetProgressRoutes.js
+++ b/backend/routes/userSheetProgressRoutes.js
@@ -1,17 +1,34 @@
 const express = require('express');
-const { saveProgress, getProgress } = require('../controllers/userSheetProgressController');
+const {
+  saveProgress,
+  getProgress,
+  getAllProgress,
+  exportProgress,
+  importProgress,
+} = require('../controllers/userSheetProgressController');
 const { protect } = require('../middlewares/authMiddleware');
 const { validateSaveProgress, validateGetProgress } = require('../Input_validators/ValidateUserSheetProgress');
 const router = express.Router();
 
+router.use(protect);
 
 /**
  * Save or update progress for a user sheet.
  * @route POST /api/user/sheet-progress
  */
-
-router.use(protect);
 router.post('/sheet-progress', validateSaveProgress, saveProgress);
+
+/**
+ * Export all sheet progress for the authenticated user as a JSON file.
+ * @route GET /api/user/sheet-progress/export
+ */
+router.get('/sheet-progress/export', exportProgress);
+
+/**
+ * Import sheet progress entries for the authenticated user.
+ * @route POST /api/user/sheet-progress/import
+ */
+router.post('/sheet-progress/import', importProgress);
 
 /**
  * Get progress for a specific user sheet.
@@ -23,6 +40,6 @@ router.get('/sheet-progress/:sheetId', validateGetProgress, getProgress);
  * Get all sheet progress records for the authenticated user.
  * @route GET /api/user/sheet-progress
  */
-router.get('/sheet-progress', require('../controllers/userSheetProgressController').getAllProgress);
+router.get('/sheet-progress', getAllProgress);
 
 module.exports = router;

--- a/backend/tests/sheetProgress.export.import.unit.test.js
+++ b/backend/tests/sheetProgress.export.import.unit.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/UserSheetProgress.js");
+
+const UserSheetProgress = require("../models/UserSheetProgress.js");
+const {
+  exportProgress,
+  importProgress,
+} = require("../controllers/userSheetProgressController.js");
+const {
+  normalizeProgressItems,
+  normalizeProgressItem,
+  clampPercentage,
+  buildBulkOps,
+  MAX_IMPORT_ITEMS,
+} = require("../utils/sheetProgressImport.js");
+
+function makeRes() {
+  const res = {
+    statusCode: 200,
+    headers: {},
+    body: undefined,
+    setHeader(key, value) {
+      this.headers[key] = value;
+    },
+    send(body) {
+      this.body = body;
+    },
+    json(obj) {
+      this.body = obj;
+    },
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+  };
+  return res;
+}
+
+describe("clampPercentage", () => {
+  it("clamps to the 0-100 range", () => {
+    expect(clampPercentage(250)).toBe(100);
+    expect(clampPercentage(-10)).toBe(0);
+    expect(clampPercentage(42)).toBe(42);
+  });
+
+  it("falls back to 0 for non-numeric input", () => {
+    expect(clampPercentage("abc")).toBe(0);
+    expect(clampPercentage(undefined)).toBe(0);
+  });
+});
+
+describe("normalizeProgressItem", () => {
+  it("normalizes a valid entry", () => {
+    const result = normalizeProgressItem(
+      { sheetId: "sheet-1", followed: true, completedTopics: { "two-sum": true }, percentage: 42 },
+      0
+    );
+    expect(result.ok).toBe(true);
+    expect(result.value.sheetId).toBe("sheet-1");
+    expect(result.value.followed).toBe(true);
+    expect(result.value.percentage).toBe(42);
+  });
+
+  it("trims and clamps loosely-typed fields", () => {
+    const result = normalizeProgressItem(
+      { sheetId: "  sheet-2  ", followed: "yes", completedTopics: [1, 2], percentage: 250 },
+      0
+    );
+    expect(result.value.sheetId).toBe("sheet-2");
+    expect(result.value.followed).toBe(false);
+    expect(result.value.completedTopics).toEqual({});
+    expect(result.value.percentage).toBe(100);
+  });
+
+  it("rejects missing, non-string or oversized sheetIds", () => {
+    expect(normalizeProgressItem({ sheetId: "" }, 0).ok).toBe(false);
+    expect(normalizeProgressItem({ sheetId: 42 }, 0).ok).toBe(false);
+    expect(normalizeProgressItem({ sheetId: "x".repeat(101) }, 0).ok).toBe(false);
+    expect(normalizeProgressItem(null, 0).ok).toBe(false);
+    expect(normalizeProgressItem([1, 2], 0).ok).toBe(false);
+  });
+});
+
+describe("normalizeProgressItems", () => {
+  it("returns an error for a non-array payload", () => {
+    const { items, errors } = normalizeProgressItems({});
+    expect(items).toEqual([]);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+
+  it("skips invalid entries and keeps valid ones", () => {
+    const { items, errors } = normalizeProgressItems([
+      { sheetId: "a" },
+      { bad: true },
+      { sheetId: "b" },
+    ]);
+    expect(items.length).toBe(2);
+    expect(errors.length).toBe(1);
+  });
+
+  it("rejects oversized payloads", () => {
+    const many = Array.from({ length: MAX_IMPORT_ITEMS + 1 }, () => ({ sheetId: "x" }));
+    const { items, errors } = normalizeProgressItems(many);
+    expect(items).toEqual([]);
+    expect(errors[0]).toContain("exceeds limit");
+  });
+});
+
+describe("buildBulkOps", () => {
+  it("creates upsert updateOne ops scoped to the user", () => {
+    const ops = buildBulkOps("u1", [
+      { sheetId: "s1", followed: true, completedTopics: {}, percentage: 10 },
+    ]);
+    expect(ops[0].updateOne.filter).toEqual({ userId: "u1", sheetId: "s1" });
+    expect(ops[0].updateOne.upsert).toBe(true);
+    expect(ops[0].updateOne.update.$set.followed).toBe(true);
+  });
+});
+
+describe("exportProgress controller", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("streams a JSON backup with safe fields", async () => {
+    const rows = [
+      {
+        sheetId: "s1",
+        followed: true,
+        completedTopics: { a: true },
+        percentage: 50,
+        updatedAt: new Date("2025-01-01T00:00:00.000Z"),
+      },
+    ];
+    UserSheetProgress.find = vi
+      .fn()
+      .mockReturnValue({ lean: () => Promise.resolve(rows) });
+
+    const req = { user: { _id: "u1" } };
+    const res = makeRes();
+    await exportProgress(req, res);
+
+    expect(res.headers["Content-Disposition"]).toContain(
+      "sheet-progress-backup.json"
+    );
+    const body = JSON.parse(res.body);
+    expect(body.count).toBe(1);
+    expect(body.items[0].sheetId).toBe("s1");
+    expect(body.items[0].percentage).toBe(50);
+  });
+
+  it("returns 500 when the query fails", async () => {
+    UserSheetProgress.find = vi
+      .fn()
+      .mockReturnValue({ lean: () => Promise.reject(new Error("boom")) });
+    const res = makeRes();
+    await exportProgress({ user: { _id: "u1" } }, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body.success).toBe(false);
+  });
+});
+
+describe("importProgress controller", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("bulk upserts normalized entries and reports counts", async () => {
+    UserSheetProgress.bulkWrite = vi
+      .fn()
+      .mockResolvedValue({ matchedCount: 2, upsertedCount: 1 });
+    const req = {
+      user: { _id: "u1" },
+      body: { items: [{ sheetId: "s1" }, { sheetId: "s2" }, { bad: 1 }] },
+    };
+    const res = makeRes();
+    await importProgress(req, res);
+
+    expect(UserSheetProgress.bulkWrite).toHaveBeenCalledOnce();
+    expect(res.body.success).toBe(true);
+    expect(res.body.imported).toBe(2);
+    expect(res.body.skipped).toBe(1);
+    expect(res.body.created).toBe(1);
+    expect(res.body.updated).toBe(2);
+  });
+
+  it("returns 400 when nothing can be imported", async () => {
+    const req = { user: { _id: "u1" }, body: { items: [{ bad: 1 }] } };
+    const res = makeRes();
+    await importProgress(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+
+  it("returns 400 when the payload is not an array", async () => {
+    const req = { user: { _id: "u1" }, body: { items: { sheetId: "s1" } } };
+    const res = makeRes();
+    await importProgress(req, res);
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+  });
+});

--- a/backend/utils/sheetProgressImport.js
+++ b/backend/utils/sheetProgressImport.js
@@ -1,0 +1,89 @@
+const MAX_IMPORT_ITEMS = 500;
+const MAX_SHEET_ID_LENGTH = 100;
+
+function clampPercentage(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return 0;
+  return Math.max(0, Math.min(100, Math.round(num * 100) / 100));
+}
+
+function normalizeCompletedTopics(value) {
+  if (
+    value != null &&
+    typeof value === "object" &&
+    !Array.isArray(value)
+  ) {
+    return value;
+  }
+  return {};
+}
+
+function normalizeProgressItem(item, index) {
+  if (!item || typeof item !== "object" || Array.isArray(item)) {
+    return { ok: false, index, reason: "entry is not an object" };
+  }
+  const sheetId = typeof item.sheetId === "string" ? item.sheetId.trim() : "";
+  if (!sheetId || sheetId.length > MAX_SHEET_ID_LENGTH) {
+    return { ok: false, index, reason: "sheetId is missing or too long" };
+  }
+  return {
+    ok: true,
+    index,
+    value: {
+      sheetId,
+      followed: item.followed === true,
+      completedTopics: normalizeCompletedTopics(item.completedTopics),
+      percentage: clampPercentage(item.percentage),
+    },
+  };
+}
+
+function normalizeProgressItems(items) {
+  if (!Array.isArray(items)) {
+    return { items: [], errors: ["payload.items must be an array"] };
+  }
+  if (items.length > MAX_IMPORT_ITEMS) {
+    return {
+      items: [],
+      errors: [`payload.items exceeds limit of ${MAX_IMPORT_ITEMS}`],
+    };
+  }
+
+  const normalized = [];
+  const errors = [];
+  items.forEach((item, index) => {
+    const result = normalizeProgressItem(item, index);
+    if (result.ok) {
+      normalized.push(result.value);
+    } else {
+      errors.push(`entry at index ${result.index}: ${result.reason}`);
+    }
+  });
+  return { items: normalized, errors };
+}
+
+function buildBulkOps(userId, items) {
+  return items.map((item) => ({
+    updateOne: {
+      filter: { userId, sheetId: item.sheetId },
+      update: {
+        $set: {
+          followed: item.followed,
+          completedTopics: item.completedTopics,
+          percentage: item.percentage,
+        },
+      },
+      upsert: true,
+    },
+  }));
+}
+
+module.exports = {
+  MAX_IMPORT_ITEMS,
+  MAX_SHEET_ID_LENGTH,
+  buildBulkOps,
+  clampPercentage,
+  normalizeCompletedTopics,
+  normalizeProgressItem,
+  normalizeProgressItems,
+};

--- a/frontend/src/pages/Home/ProgressTrackerDashboard.jsx
+++ b/frontend/src/pages/Home/ProgressTrackerDashboard.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useState, useContext } from "react";
+import React, { useEffect, useState, useContext, useRef } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import moment from "moment";
 import {
   Github, Linkedin, Twitter, Globe, GraduationCap,
   MapPin, BookOpen, Video, FileText, ArrowRight,
   CheckCircle, PlusCircle, Settings, Code2, Star,
+  Download, Upload, DatabaseBackup, Check, X,
 } from "lucide-react";
 import toast from "react-hot-toast";
 import { UserContext } from "../../context/userContext";
@@ -108,6 +109,10 @@ const ProgressTrackerDashboard = () => {
   const [resumes, setResumes] = useState([]);
   const [sheetProgress, setSheetProgress] = useState([]);
   const [sheetsMap, setSheetsMap] = useState({});
+  const [refreshKey, setRefreshKey] = useState(0);
+  const [importing, setImporting] = useState(false);
+  const [importPreview, setImportPreview] = useState(null);
+  const fileInputRef = useRef(null);
 
   useEffect(() => {
     (async () => {
@@ -164,13 +169,72 @@ const ProgressTrackerDashboard = () => {
           .sort((a, b) => b.percentage - a.percentage);
 
         setSheetProgress(merged);
+} catch {
+          toast.error("Failed to load dashboard data.");
+        } finally {
+          setLoading(false);
+        }
+      })();
+    }, [refreshKey]);
+
+  const handleExport = async () => {
+    try {
+      const res = await axiosInstance.get("/api/user/sheet-progress/export", {
+        responseType: "blob",
+      });
+      const blob = new Blob([res.data], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "sheet-progress-backup.json";
+      a.click();
+      URL.revokeObjectURL(url);
+      toast.success("Progress backup downloaded");
+    } catch (err) {
+      toast.error("Export failed");
+    }
+  };
+
+  const handleImportFile = (file) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = async (e) => {
+      try {
+        const json = JSON.parse(e.target.result);
+        const items = json.items || (Array.isArray(json) ? json : []);
+        setImportPreview(items.length);
+        setImporting(true);
       } catch {
-        toast.error("Failed to load dashboard data.");
-      } finally {
-        setLoading(false);
+        toast.error("Invalid JSON file");
       }
-    })();
-  }, []);
+    };
+    reader.readAsText(file);
+  };
+
+  const confirmImport = async () => {
+    if (!importPreview) return;
+    setImporting(false);
+    setImportPreview(null);
+    try {
+      const res = await axiosInstance.post("/api/user/sheet-progress/import", {
+        items: importPreview,
+      });
+      toast.success(
+        `Imported ${res.data.imported} sheets (${res.data.created} new, ${res.data.updated} updated)`
+      );
+      setRefreshKey((k) => k + 1);
+    } catch (err) {
+      toast.error("Import failed");
+    } finally {
+      fileInputRef.current.value = "";
+    }
+  };
+
+  const cancelImport = () => {
+    setImporting(false);
+    setImportPreview(null);
+    fileInputRef.current.value = "";
+  };
 
   if (loading) {
     return (
@@ -379,9 +443,62 @@ const ProgressTrackerDashboard = () => {
               <h2 className="text-sm font-bold flex items-center gap-2 text-gray-900 dark:text-white">
                 <CheckCircle size={15} className="text-emerald-400" /> Sheet Progress
               </h2>
-              <button onClick={() => navigate("/coding-sheets")}
-                className="text-xs text-emerald-400 hover:text-emerald-300 transition-colors">+ Add</button>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={handleExport}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs font-medium hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  aria-label="Export progress backup"
+                >
+                  <Download size={12} />
+                  <span className="hidden sm:inline">Export</span>
+                </button>
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 text-xs font-medium hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  aria-label="Import progress backup"
+                >
+                  <Upload size={12} />
+                  <span className="hidden sm:inline">Import</span>
+                </button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  className="hidden"
+                  onChange={(e) => handleImportFile(e.target.files[0])}
+                />
+                <button onClick={() => navigate("/coding-sheets")}
+                  className="text-xs text-emerald-400 hover:text-emerald-300 transition-colors">+ Add</button>
+              </div>
             </div>
+            {importing && importPreview !== null && (
+              <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50">
+                <div className="bg-white dark:bg-gray-800 rounded-2xl p-5 w-full max-w-md shadow-xl">
+                  <h3 className="font-semibold text-gray-900 dark:text-white mb-2">
+                    Import progress backup
+                  </h3>
+                  <p className="text-sm text-gray-600 dark:text-gray-300 mb-4">
+                    This will merge <strong>{importPreview}</strong> sheet records
+                    into your account. Existing sheets with the same ID will be
+                    updated; new ones will be created.
+                  </p>
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={cancelImport}
+                      className="px-4 py-2 rounded-lg border border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 text-sm font-medium hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      onClick={confirmImport}
+                      className="px-4 py-2 rounded-lg bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium transition-colors"
+                    >
+                      Confirm import
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
             {sheetProgress.length > 0 ? (
               <div className="space-y-3.5">
                 {sheetProgress.slice(0, 5).map(p => (


### PR DESCRIPTION
## Summary
Users invest a lot of time marking DSA sheets as followed/completed, but there is no way to back up or migrate that progress. Progress lives only in the `UserSheetProgress` collection, so switching accounts, clearing the DB, or a corrupted record means starting from zero. A JSON export/import pair gives users full control over their own data.

## What changed
**Backend**
- **GET `/api/user/sheet-progress/export`** — returns the authenticated user's full progress (no 50-record cap) as a downloadable `sheet-progress-backup.json` with safe fields: `sheetId`, `followed`, `completedTopics`, `percentage`, `updatedAt`.
- **POST `/api/user/sheet-progress/import`** — accepts `{ items: [...] }`, validates and normalizes each entry (sheetId required + length cap, percentage clamped 0–100, followed coerced to boolean, completedTopics coerced to object), then bulk upserts via a single `bulkWrite` honoring the `(userId, sheetId)` unique index. Returns `imported`, `skipped`, `updated`, `created` counts plus any warnings.
- **Pure utility** `backend/utils/sheetProgressImport.js`:
  - `normalizeProgressItems` — validates and normalizes a raw payload.
  - `buildBulkOps` — builds the bulk upsert operations for a user.
  - Both are pure (no DB) and fully unit-tested.

**Tests** `backend/tests/sheetProgress.export.import.unit.test.js` — 14 vitest cases for validation/coercion units plus controller tests with the model mocked (follows the repo's `vi.mock("../models/..."); Flashcard = require(...)` pattern).

**Frontend** (`ProgressTrackerDashboard`)
- **Export** button downloads the JSON backup via a blob.
- **Import** button opens a hidden file picker, parses the selected file, shows a confirmation modal with the count of sheets that will be touched, and on confirmation posts to the import endpoint with toast feedback.
- Dashboard auto-refreshes after a successful import.

## Architecture notes
- Zero schema changes — reuses the existing upsert logic and unique index.
- Pure helpers mean the import logic is testable without a DB and can be extended (e.g., CSV import) without touching controllers.
- Import payload size is capped at 500 items to keep requests small.

## How to test
1. Start the server, log in, follow a few sheets.
2. Open the Progress Dashboard → click **Export** → verify `sheet-progress-backup.json` downloads with your sheets.
3. Clear the DB (or use a different account), click **Import**, select the file, confirm → toast shows counts, dashboard reloads with restored progress.
4. `cd backend && npx vitest run tests/sheetProgress.export.import.unit.test.js` → 14 passing.

## Verification
- Backend: 14/14 new tests pass; existing pre-existing failures (issue #903) unchanged.
- Frontend: `vite build` passes; ESLint on new lines clean (pre-existing no-unused-vars in unrelated code paths unchanged).
- Fixes #1028 (gssoc26)
- No workflow or core auth/schema files touched.