### PR TITLE
feat: DSA sheet CRUD with shared JSON validation helper

### DIFF
--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -2,6 +2,10 @@ const express = require('express');
 const router = express.Router();
 const Sheet = require('../models/Sheet');
 const { protect } = require('../middlewares/authMiddleware');
+const {
+  normalizeSheet,
+  computeSheetStats,
+} = require('../utils/sheetValidation');
 
 // POST /api/sheets/upload
 // Body: { filename: "file.json", data: {...sheet data...} }
@@ -21,15 +25,20 @@ router.post('/upload', protect, async (req, res) => {
     const results = [];
 
     for (const sheetObj of sheetsArr) {
-      if (!sheetObj || !sheetObj.id || !sheetObj.title) {
-        results.push({ error: 'Invalid sheet data. Each sheet needs id & title.', sheet: sheetObj });
+      const normalized = normalizeSheet(sheetObj);
+      if (!normalized.ok) {
+        results.push({
+          error: 'Invalid sheet data.',
+          details: normalized.errors,
+          sheet: sheetObj,
+        });
         continue;
       }
 
       // Insert or update sheet by id
       const sheet = await Sheet.findOneAndUpdate(
-        { id: sheetObj.id },
-        sheetObj,
+        { id: normalized.value.id },
+        normalized.value,
         { upsert: true, new: true, setDefaultsOnInsert: true }
       );
 
@@ -40,6 +49,103 @@ router.post('/upload', protect, async (req, res) => {
   } catch (err) {
     console.error('Error saving to MongoDB:', err);
     res.status(500).json({ error: 'Failed to save sheet to database.' });
+  }
+});
+
+// POST /api/sheets/validate
+// Body: { data: {...sheet data...} }
+// Dry-run: returns stats + errors without writing to the DB.
+router.post('/validate', protect, async (req, res) => {
+  const { data } = req.body;
+
+  if (!data) {
+    return res.status(400).json({ error: 'Sheet data is required.' });
+  }
+
+  const sheetsArr = Array.isArray(data.sheets) ? data.sheets : [data];
+  const results = [];
+
+  for (const sheetObj of sheetsArr) {
+    const normalized = normalizeSheet(sheetObj);
+    if (!normalized.ok) {
+      results.push({
+        id: sheetObj && sheetObj.id ? sheetObj.id : null,
+        ok: false,
+        errors: normalized.errors,
+      });
+      continue;
+    }
+    results.push({
+      id: normalized.value.id,
+      title: normalized.value.title,
+      ok: true,
+      stats: computeSheetStats(normalized.value),
+    });
+  }
+
+  const invalidCount = results.filter((r) => !r.ok).length;
+  res.json({
+    valid: results.length - invalidCount,
+    invalid: invalidCount,
+    total: results.length,
+    results,
+  });
+});
+
+// PUT /api/sheets/:id
+// Update a single sheet after validation.
+router.put('/:id', protect, async (req, res) => {
+  const { id } = req.params;
+  const body = req.body && req.body.sheet ? req.body.sheet : req.body;
+
+  const normalized = normalizeSheet(body);
+  if (!normalized.ok) {
+    return res.status(400).json({ error: 'Invalid sheet data.', details: normalized.errors });
+  }
+
+  if (normalized.value.id && normalized.value.id !== id) {
+    return res.status(400).json({ error: 'Sheet id in body does not match URL id.' });
+  }
+
+  try {
+    const sheet = await Sheet.findOneAndUpdate(
+      { id },
+      normalized.value,
+      { new: true, setDefaultsOnInsert: true }
+    );
+
+    if (!sheet) {
+      return res.status(404).json({ error: 'Sheet not found.' });
+    }
+
+    res.json({ message: 'Sheet updated.', sheet });
+  } catch (err) {
+    console.error('Error updating sheet:', err);
+    res.status(500).json({ error: 'Failed to update sheet.' });
+  }
+});
+
+// DELETE /api/sheets/:id
+// Requires confirmId matching :id to prevent accidental deletion.
+router.delete('/:id', protect, async (req, res) => {
+  const { id } = req.params;
+  const { confirmId } = req.body || {};
+
+  if (confirmId !== id) {
+    return res.status(400).json({ error: 'confirmId must match the sheet id.' });
+  }
+
+  try {
+    const sheet = await Sheet.findOneAndDelete({ id });
+
+    if (!sheet) {
+      return res.status(404).json({ error: 'Sheet not found.' });
+    }
+
+    res.json({ message: 'Sheet deleted.', id });
+  } catch (err) {
+    console.error('Error deleting sheet:', err);
+    res.status(500).json({ error: 'Failed to delete sheet.' });
   }
 });
 
@@ -60,7 +166,7 @@ router.get('/', async (req, res) => {
 // GET /:id - fetch single sheet by id (for /api/sheets/:id)
 router.get('/:id', async (req, res) => {
   try {
-    // Always find by custom id field (string)
+    // Always find by cust
     const sheet = await Sheet.findOne({ id: req.params.id });
     if (!sheet) {
       return res.status(404).json({ error: 'Sheet not found.' });

--- a/backend/tests/sheetValidation.unit.test.js
+++ b/backend/tests/sheetValidation.unit.test.js
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+
+const {
+  normalizeSheet,
+  normalizeSection,
+  normalizeSubtopic,
+  computeSheetStats,
+} = require("../utils/sheetValidation.js");
+
+function validSheet(overrides = {}) {
+  return {
+    id: "striver-sde",
+    title: "Striver SDE Sheet",
+    description: "The best sheet",
+    category: "dsa",
+    questions: 455,
+    followers: 1200,
+    sections: [
+      {
+        title: "Arrays",
+        topics: [
+          {
+            title: "1D Arrays",
+            subtopics: [
+              { title: "Two Sum", difficulty: "Easy", status: "completed", links: { leetcode: "https://..." } },
+              { title: "Max Subarray", difficulty: "Medium" },
+            ],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("normalizeSheet", () => {
+  it("normalizes a valid sheet and drops unknown fields", () => {
+    const { ok, errors, value } = normalizeSheet(
+      validSheet({ junk: "field", questions: "455.7", followers: -5 })
+    );
+    expect(ok).toBe(true);
+    expect(errors).toHaveLength(0);
+    expect(value.id).toBe("striver-sde");
+    expect(value.questions).toBe(456);
+    expect(value.followers).toBe(0);
+    expect(value.junk).toBeUndefined();
+  });
+
+  it("rejects a missing id", () => {
+    const { ok, errors } = normalizeSheet(validSheet({ id: "" }));
+    expect(ok).toBe(false);
+    expect(errors.some((e) => e.includes("id is required"))).toBe(true);
+  });
+
+  it("rejects an id with invalid characters", () => {
+    const { ok, errors } = normalizeSheet(validSheet({ id: "my sheet!" }));
+    expect(ok).toBe(false);
+    expect(errors.some((e) => e.includes("letters, digits"))).toBe(true);
+  });
+
+  it("rejects a missing title", () => {
+    const { ok, errors } = normalizeSheet(validSheet({ title: "" }));
+    expect(ok).toBe(false);
+    expect(errors.some((e) => e.includes("title is required"))).toBe(true);
+  });
+
+  it("rejects an unknown category", () => {
+    const { ok, errors } = normalizeSheet(validSheet({ category: "cat-herding" }));
+    expect(ok).toBe(false);
+    expect(errors.some((e) => e.includes("category"))).toBe(true);
+  });
+
+  it("falls back to 'general' for an empty category", () => {
+    const { ok, value } = normalizeSheet(validSheet({ category: "" }));
+    expect(ok).toBe(true);
+    expect(value.category).toBe("general");
+  });
+
+  it("rejects non-object payloads", () => {
+    expect(normalizeSheet(null).ok).toBe(false);
+    expect(normalizeSheet("nope").ok).toBe(false);
+    expect(normalizeSheet([1, 2]).ok).toBe(false);
+  });
+});
+
+describe("nested normalization", () => {
+  it("drops subtopics without a title", () => {
+    const sub = normalizeSubtopic({ difficulty: "Easy" });
+    expect(sub).toBeNull();
+  });
+
+  it("coerces difficulty and status to valid enums", () => {
+    const sub = normalizeSubtopic({
+      title: "Two Sum",
+      difficulty: "Impossible",
+      status: "maybe",
+    });
+    expect(sub.difficulty).toBe("Medium");
+    expect(sub.status).toBe("not-started");
+  });
+
+  it("drops invalid sections and topics", () => {
+    const section = normalizeSection({ title: "Arrays", completed: "bad", topics: [null, { title: "Valid" }] });
+    expect(section.completed).toBe(0);
+    expect(section.topics).toHaveLength(1);
+    expect(section.topics[0].title).toBe("Valid");
+  });
+});
+
+describe("computeSheetStats", () => {
+  it("counts questions, sections and breaks down by difficulty/status", () => {
+    const { ok, value } = normalizeSheet(validSheet());
+    expect(ok).toBe(true);
+    const stats = computeSheetStats(value);
+    expect(stats.sections).toBe(1);
+    expect(stats.questions).toBe(2);
+    expect(stats.byDifficulty).toEqual({ Easy: 1, Medium: 1, Hard: 0 });
+    expect(stats.byStatus).toEqual({ "not-started": 1, "in-progress": 0, completed: 1 });
+  });
+});
+
+describe("sheet CRUD routes", () => {
+  let router;
+
+  beforeAll(async () => {
+    const mod = await import("../routes/sheetJsonUpload.js");
+    router = mod.default ?? mod;
+  });
+
+  function getLayerStack(method, path) {
+    const layer = router.stack.find(
+      (l) => l.route && l.route.path === path && l.route.methods[method.toLowerCase()]
+    );
+    if (!layer) return null;
+    return layer.route.stack.map((s) => s.handle);
+  }
+
+  function isProtect(handler) {
+    return typeof handler === "function" && handler.name === "protect";
+  }
+
+  it("registers POST /validate behind protect", () => {
+    const stack = getLayerStack("POST", "/validate");
+    expect(stack).toBeTruthy();
+    expect(stack.some(isProtect)).toBe(true);
+  });
+
+  it("registers PUT /:id behind protect", () => {
+    const stack = getLayerStack("PUT", "/:id");
+    expect(stack).toBeTruthy();
+    expect(stack.some(isProtect)).toBe(true);
+  });
+
+  it("registers DELETE /:id behind protect", () => {
+    const stack = getLayerStack("DELETE", "/:id");
+    expect(stack).toBeTruthy();
+    expect(stack.some(isProtect)).toBe(true);
+  });
+
+  it("registers POST /upload behind protect", () => {
+    const stack = getLayerStack("POST", "/upload");
+    expect(stack).toBeTruthy();
+    expect(stack.some(isProtect)).toBe(true);
+  });
+
+  it("keeps GET / and GET /:id public", () => {
+    expect(getLayerStack("GET", "/").some(isProtect)).toBe(false);
+    expect(getLayerStack("GET", "/:id").some(isProtect)).toBe(false);
+  });
+
+  it("places protect before the handler on PUT /:id", () => {
+    const stack = getLayerStack("PUT", "/:id");
+    const protectIndex = stack.findIndex(isProtect);
+    expect(protectIndex).toBeGreaterThanOrEqual(0);
+    expect(protectIndex).toBeLessThan(stack.length - 1);
+  });
+});

--- a/backend/utils/sheetValidation.js
+++ b/backend/utils/sheetValidation.js
@@ -1,0 +1,158 @@
+const SHEET_ID_PATTERN = /^[a-zA-Z0-9-_]+$/;
+const DIFFICULTIES = ["Easy", "Medium", "Hard"];
+const STATUSES = ["not-started", "in-progress", "completed"];
+const CATEGORIES = ["general", "dsa", "aptitude", "system-design"];
+
+function clampNonNegativeInt(value, fallback = 0) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return fallback;
+  return Math.max(0, Math.round(num));
+}
+
+function asString(value, maxLength = 500) {
+  if (typeof value !== "string") return "";
+  return value.trim().slice(0, maxLength);
+}
+
+function normalizeSubtopic(subtopic) {
+  if (!subtopic || typeof subtopic !== "object" || Array.isArray(subtopic)) {
+    return null;
+  }
+  const title = asString(subtopic.title, 200);
+  if (!title) return null;
+
+  let difficulty = asString(subtopic.difficulty, 20) || "Medium";
+  if (!DIFFICULTIES.includes(difficulty)) difficulty = "Medium";
+
+  let status = asString(subtopic.status, 20) || "not-started";
+  if (!STATUSES.includes(status)) status = "not-started";
+
+  const links = subtopic.links && typeof subtopic.links === "object"
+    ? {
+        gfg: asString(subtopic.links.gfg, 1000),
+        leetcode: asString(subtopic.links.leetcode, 1000),
+        youtube: asString(subtopic.links.youtube, 1000),
+      }
+    : {};
+
+  return { title, difficulty, status, links };
+}
+
+function normalizeTopic(topic) {
+  if (!topic || typeof topic !== "object" || Array.isArray(topic)) {
+    return null;
+  }
+  const title = asString(topic.title, 200);
+  if (!title) return null;
+
+  const subtopics = Array.isArray(topic.subtopics)
+    ? topic.subtopics.map(normalizeSubtopic).filter(Boolean)
+    : [];
+
+  return {
+    title,
+    completed: clampNonNegativeInt(topic.completed),
+    total: clampNonNegativeInt(topic.total),
+    subtopics,
+  };
+}
+
+function normalizeSection(section) {
+  if (!section || typeof section !== "object" || Array.isArray(section)) {
+    return null;
+  }
+  const title = asString(section.title, 200);
+  if (!title) return null;
+
+  const topics = Array.isArray(section.topics)
+    ? section.topics.map(normalizeTopic).filter(Boolean)
+    : [];
+
+  return {
+    title,
+    completed: clampNonNegativeInt(section.completed),
+    total: clampNonNegativeInt(section.total),
+    topics,
+  };
+}
+
+function normalizeSheet(raw) {
+  const errors = [];
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return { ok: false, errors: ["sheet payload must be an object"] };
+  }
+
+  const id = asString(raw.id, 100);
+  if (!id) errors.push("id is required");
+  else if (!SHEET_ID_PATTERN.test(id)) {
+    errors.push("id may only contain letters, digits, dashes and underscores");
+  }
+
+  const title = asString(raw.title, 300);
+  if (!title) errors.push("title is required");
+
+  let category = asString(raw.category, 50);
+  if (category && !CATEGORIES.includes(category)) {
+    errors.push(`category must be one of: ${CATEGORIES.join(", ")}`);
+    category = "";
+  }
+
+  const sections = Array.isArray(raw.sections)
+    ? raw.sections.map(normalizeSection).filter(Boolean)
+    : [];
+
+  return {
+    ok: errors.length === 0,
+    errors,
+    value: {
+      id,
+      title,
+      description: asString(raw.description, 2000),
+      followers: clampNonNegativeInt(raw.followers),
+      questions: clampNonNegativeInt(raw.questions),
+      category: category || "general",
+      sections,
+    },
+  };
+}
+
+function computeSheetStats(sheet) {
+  let questions = 0;
+  let subtopicCount = 0;
+  const byDifficulty = { Easy: 0, Medium: 0, Hard: 0 };
+  const byStatus = { "not-started": 0, "in-progress": 0, completed: 0 };
+
+  for (const section of sheet.sections || []) {
+    for (const topic of section.topics || []) {
+      for (const subtopic of topic.subtopics || []) {
+        subtopicCount += 1;
+        if (DIFFICULTIES.includes(subtopic.difficulty)) {
+          byDifficulty[subtopic.difficulty] += 1;
+        }
+        if (STATUSES.includes(subtopic.status)) {
+          byStatus[subtopic.status] += 1;
+        }
+      }
+    }
+  }
+
+  questions = subtopicCount;
+  return {
+    questions,
+    sections: (sheet.sections || []).length,
+    byDifficulty,
+    byStatus,
+  };
+}
+
+module.exports = {
+  CATEGORIES,
+  DIFFICULTIES,
+  STATUSES,
+  SHEET_ID_PATTERN,
+  computeSheetStats,
+  normalizeSection,
+  normalizeSheet,
+  normalizeSubtopic,
+  normalizeTopic,
+};


### PR DESCRIPTION
## Summary
DSA sheets are maintained as JSON files uploaded via `POST /api/sheets/upload`, but the API had no way to validate a payload before saving, update a single sheet, or remove one. Maintainers either re-uploaded the whole file or deleted directly in MongoDB. This PR adds validated CRUD and a shared, pure validation helper.

## What changed
**New helper** `backend/utils/sheetValidation.js` (pure, no DB):
- `normalizeSheet(sheet)` — validates/normalizes a payload: required `id` (alphanumeric/`-`/`_` only, ≤100) and `title`; `category` whitelist (`general/dsa/aptitude/system-design`); `questions`/`followers`/counters coerced to non-negative numbers; nested `sections → topics → subtopics` validated, with `difficulty` enum (`Easy/Medium/Hard`) and `status` enum (`not-started/in-progress/completed`); unknown fields dropped.
- `computeSheetStats(sheet)` — per-section/difficulty/status question counts.

**New endpoints** (`backend/routes/sheetJsonUpload.js`, all behind `protect` like the existing upload):
- `POST /api/sheets/validate` — dry-run: returns `{ valid, invalid, total, results[] }` with per-sheet stats or validation errors, **no DB writes**.
- `PUT /api/sheets/:id` — update a single sheet; rejects a body whose id ≠ URL id; 400 with `details` on invalid payloads; 404 for missing sheets.
- `DELETE /api/sheets/:id` — delete a sheet; requires `confirmId` in the body matching `:id` (prevents accidental deletion); 404 if missing.
- Existing `POST /upload` refactored onto `normalizeSheet` so upload and CRUD share one validated path (invalid entries now report the specific validation errors).

**Tests** `backend/tests/sheetValidation.unit.test.js` — 17 vitest cases: normalization/enums/counts, and route-wiring checks (protected vs public routes, handler ordering) via the same router-stack introspection pattern the repo already uses.

## Architecture notes
- One validated ingestion path for upload/validate/update — no schema changes.
- Helper is pure and fully unit-testable without a DB.
- Scope intentionally excludes the separate "Missing Pagination in User Sheet Progress Query" performance issue.

## How to test
1. `cd backend && npm run dev`.
2. `POST /api/sheets/validate` with a valid/invalid sheet payload → stats or errors, DB untouched.
3. `PUT /api/sheets/:id` updates only that sheet; a bad payload returns its errors.
4. `DELETE /api/sheets/:id` with `{ confirmId }` deletes; wrong confirmId → 400; unknown id → 404.
5. `cd backend && npx vitest run tests/sheetValidation.unit.test.js` → 17 passing.

## Verification
- `npx vitest run tests/sheetValidation.unit.test.js` → 17/17 pass.
- `node -e "require('./utils/sheetValidation'); require('./routes/sheetJsonUpload')"` loads cleanly.
- Fixes #1071 (gssoc26)
- No workflow or auth/schema files touched.