### PR TITLE
[Performance]: Fix Unnecessary Dependency in usePatternMatrix Hook

### DIFF
--- a/frontend/src/hooks/usePatternMatrix.js
+++ b/frontend/src/hooks/usePatternMatrix.js
@@ -342,7 +342,7 @@ export const usePatternMatrix = () => {
         }, 1500);
       }
     }
-  }, [phase, paused, selected, wrongClicks, targets, gridSize, difficulty, level, streak, lives, score, startCountdown, clearTimers]);
+  }, [phase, paused, selected, wrongClicks, targets, gridSize, difficulty, level, streak, lives, score, startCountdown]);
 
   // ─── Pause & Resume Utilities ────────────────────────────────────────────────
   const pauseGame = useCallback(() => {


### PR DESCRIPTION
Resolves #981

Description
This pull request resolves an ESLint warning in usePatternMatrix by removing the unnecessary \clearTimers\ dependency from the useCallback hook, avoiding potential unnecessary re-renders or function recreations.