### PR TITLE
fix(auth): implement cascade deletion for user account cleanup

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -197,7 +197,14 @@ Errors:
 - `DELETE /api/auth/delete-account`
 - Private
 
-Permanently deletes the authenticated user's account. This action is irreversible.
+Permanently deletes the authenticated user's account and all associated data. This action is irreversible and performs cascade deletion of:
+
+- Interview sessions and their associated questions
+- Flashcards (SRS deck)
+- Resumes
+- Notes summaries
+- Roadmap projects
+- DSA sheet progress records
 
 Headers:
 ```
@@ -207,7 +214,7 @@ Response `200`:
 ```json
 {
   "success": true,
-  "message": "Account deleted successfully"
+  "message": "Account and all associated data deleted successfully"
 }
 ```
 Errors:

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -5,6 +5,15 @@ const crypto = require("crypto");
 const { sendVerificationEmail } = require("../utils/sendEmail");
 const { validatePassword } = require('../utils/passwordPolicy');
 
+// Models for cascade deletion on account delete
+const Session = require("../models/Session");
+const Question = require("../models/Question");
+const Flashcard = require("../models/Flashcard");
+const Resume = require("../models/Resume");
+const NotesSummary = require("../models/NotesSummary");
+const RoadmapProject = require("../models/RoadmapProject");
+const UserSheetProgress = require("../models/UserSheetProgress");
+
 const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "30d";
 const REFRESH_TOKEN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
@@ -501,7 +510,8 @@ const changePassword = async (req, res) => {
 };
 
 /**
- * Permanently delete user account.
+ * Permanently delete user account and all associated data.
+ * Implements cascade deletion to clean up orphaned documents.
  * @route DELETE /api/auth/delete-account
  */
 const deleteUserAccount = async (req, res) => {
@@ -512,8 +522,71 @@ const deleteUserAccount = async (req, res) => {
             return res.status(404).json({ success: false, message: "User not found" });
         }
 
+        // Cascade delete: remove all user-related data
+        const deletePromises = [];
+
+        // Delete user's sessions and their associated questions
+        const sessions = await Session.find({ user: userId });
+        const sessionIds = sessions.map(s => s._id);
+        if (sessionIds.length > 0) {
+            deletePromises.push(
+                Question.deleteMany({ session: { $in: sessionIds } }).then(() => {
+                    console.log(`Deleted ${sessionIds.length} sessions and their questions for user ${userId}`);
+                })
+            );
+        }
+        deletePromises.push(Session.deleteMany({ user: userId }));
+
+        // Delete user's flashcards
+        deletePromises.push(
+            Flashcard.deleteMany({ userId: userId }).then(result => {
+                console.log(`Deleted ${result.deletedCount} flashcards for user ${userId}`);
+            })
+        );
+
+        // Delete user's resumes
+        deletePromises.push(
+            Resume.deleteMany({ user: userId }).then(result => {
+                console.log(`Deleted ${result.deletedCount} resumes for user ${userId}`);
+            })
+        );
+
+        // Delete user's notes summaries
+        deletePromises.push(
+            NotesSummary.deleteMany({ user: userId }).then(result => {
+                console.log(`Deleted ${result.deletedCount} notes summaries for user ${userId}`);
+            })
+        );
+
+        // Delete user's roadmap projects
+        deletePromises.push(
+            RoadmapProject.deleteMany({ userId: userId }).then(result => {
+                console.log(`Deleted ${result.deletedCount} roadmap projects for user ${userId}`);
+            })
+        );
+
+        // Delete user's sheet progress
+        deletePromises.push(
+            UserSheetProgress.deleteMany({ userId: userId }).then(result => {
+                console.log(`Deleted ${result.deletedCount} sheet progress records for user ${userId}`);
+            })
+        );
+
+        // Wait for all deletions to complete
+        await Promise.all(deletePromises);
+
+        // Finally, delete the user account
         await User.findByIdAndDelete(userId);
-        res.json({ success: true, message: "Account deleted successfully" });
+        
+        // Clear auth cookies
+        res.clearCookie("refreshToken", {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: process.env.NODE_ENV === "production" ? "None" : "Lax",
+            path: "/api/auth"
+        });
+
+        res.json({ success: true, message: "Account and all associated data deleted successfully" });
     } catch (error) {
         console.error("Delete account error:", error);
         res.status(500).json({ success: false, message: "Internal server error occurred" });

--- a/backend/tests/authController.deleteAccount.cascade.unit.test.js
+++ b/backend/tests/authController.deleteAccount.cascade.unit.test.js
@@ -1,0 +1,257 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ─── Module Mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("../models/User.js", () => ({
+  findById: vi.fn(),
+  findByIdAndDelete: vi.fn(),
+}));
+
+vi.mock("../models/Session.js", () => ({
+  find: vi.fn(),
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/Question.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/Flashcard.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/Resume.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/NotesSummary.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/RoadmapProject.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+vi.mock("../models/UserSheetProgress.js", () => ({
+  deleteMany: vi.fn(),
+}));
+
+// ─── Test Variables ───────────────────────────────────────────────────────────
+
+let deleteUserAccount;
+let User;
+let Session;
+let Question;
+let Flashcard;
+let Resume;
+let NotesSummary;
+let RoadmapProject;
+let UserSheetProgress;
+
+// ─── Setup ───────────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  process.env.JWT_SECRET = "test-secret";
+  process.env.NODE_ENV = "test";
+
+  const ctrl = await import("../controllers/authController.js");
+  deleteUserAccount = ctrl.deleteUserAccount ?? ctrl.default?.deleteUserAccount;
+
+  const UserModule = await import("../models/User.js");
+  User = UserModule.default ?? UserModule;
+
+  const SessionModule = await import("../models/Session.js");
+  Session = SessionModule.default ?? SessionModule;
+
+  const QuestionModule = await import("../models/Question.js");
+  Question = QuestionModule.default ?? QuestionModule;
+
+  const FlashcardModule = await import("../models/Flashcard.js");
+  Flashcard = FlashcardModule.default ?? FlashcardModule;
+
+  const ResumeModule = await import("../models/Resume.js");
+  Resume = ResumeModule.default ?? ResumeModule;
+
+  const NotesSummaryModule = await import("../models/NotesSummary.js");
+  NotesSummary = NotesSummaryModule.default ?? NotesSummaryModule;
+
+  const RoadmapProjectModule = await import("../models/RoadmapProject.js");
+  RoadmapProject = RoadmapProjectModule.default ?? RoadmapProjectModule;
+
+  const UserSheetProgressModule = await import("../models/UserSheetProgress.js");
+  UserSheetProgress = UserSheetProgressModule.default ?? UserSheetProgressModule;
+});
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+/** Build a minimal Express-style res mock with chainable .status() */
+const makeRes = () => {
+  const res = {
+    status: vi.fn(),
+    json: vi.fn(),
+    clearCookie: vi.fn(),
+  };
+  res.status.mockReturnValue(res);
+  return res;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// deleteUserAccount
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("deleteUserAccount", () => {
+  it("returns 404 when user is not found", async () => {
+    User.findById.mockResolvedValueOnce(null);
+
+    const req = { user: { _id: "non-existent-user-id" } };
+    const res = makeRes();
+
+    await deleteUserAccount(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "User not found",
+      })
+    );
+  });
+
+  it("deletes user and all associated data when account is deleted", async () => {
+    const userId = "user-to-delete-id";
+    const mockUser = {
+      _id: userId,
+      name: "Test User",
+      email: "test@example.com",
+    };
+
+    User.findById.mockResolvedValueOnce(mockUser);
+    User.findByIdAndDelete.mockResolvedValueOnce(mockUser);
+
+    // Mock sessions with questions
+    const mockSessions = [
+      { _id: "session-1" },
+      { _id: "session-2" },
+    ];
+    Session.find.mockResolvedValueOnce(mockSessions);
+    Session.deleteMany.mockResolvedValueOnce({ deletedCount: 2 });
+    Question.deleteMany.mockResolvedValueOnce({ deletedCount: 5 });
+
+    // Mock other collections
+    Flashcard.deleteMany.mockResolvedValueOnce({ deletedCount: 3 });
+    Resume.deleteMany.mockResolvedValueOnce({ deletedCount: 2 });
+    NotesSummary.deleteMany.mockResolvedValueOnce({ deletedCount: 1 });
+    RoadmapProject.deleteMany.mockResolvedValueOnce({ deletedCount: 4 });
+    UserSheetProgress.deleteMany.mockResolvedValueOnce({ deletedCount: 6 });
+
+    const req = { user: { _id: userId } };
+    const res = makeRes();
+
+    await deleteUserAccount(req, res);
+
+    // Verify cascade deletions were called
+    expect(Session.find).toHaveBeenCalledWith({ user: userId });
+    expect(Question.deleteMany).toHaveBeenCalledWith({
+      session: { $in: ["session-1", "session-2"] },
+    });
+    expect(Session.deleteMany).toHaveBeenCalledWith({ user: userId });
+    expect(Flashcard.deleteMany).toHaveBeenCalledWith({ userId: userId });
+    expect(Resume.deleteMany).toHaveBeenCalledWith({ user: userId });
+    expect(NotesSummary.deleteMany).toHaveBeenCalledWith({ user: userId });
+    expect(RoadmapProject.deleteMany).toHaveBeenCalledWith({ userId: userId });
+    expect(UserSheetProgress.deleteMany).toHaveBeenCalledWith({ userId: userId });
+
+    // Verify user account deletion
+    expect(User.findByIdAndDelete).toHaveBeenCalledWith(userId);
+
+    // Verify cookie clearing
+    expect(res.clearCookie).toHaveBeenCalledWith(
+      "refreshToken",
+      expect.objectContaining({
+        httpOnly: true,
+        path: "/api/auth",
+      })
+    );
+
+    // Verify success response
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: "Account and all associated data deleted successfully",
+      })
+    );
+  });
+
+  it("handles deletion when user has no associated data", async () => {
+    const userId = "user-with-no-data-id";
+    const mockUser = {
+      _id: userId,
+      name: "New User",
+      email: "new@example.com",
+    };
+
+    User.findById.mockResolvedValueOnce(mockUser);
+    User.findByIdAndDelete.mockResolvedValueOnce(mockUser);
+
+    // User has no sessions
+    Session.find.mockResolvedValueOnce([]);
+    // No other data exists
+    Flashcard.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    Resume.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    NotesSummary.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    RoadmapProject.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    UserSheetProgress.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+
+    const req = { user: { _id: userId } };
+    const res = makeRes();
+
+    await deleteUserAccount(req, res);
+
+    // Verify user account was still deleted
+    expect(User.findByIdAndDelete).toHaveBeenCalledWith(userId);
+
+    // Verify success response
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        message: "Account and all associated data deleted successfully",
+      })
+    );
+  });
+
+  it("returns 500 when database error occurs during deletion", async () => {
+    const userId = "user-id";
+    const mockUser = {
+      _id: userId,
+      name: "Test User",
+      email: "test@example.com",
+    };
+
+    User.findById.mockResolvedValueOnce(mockUser);
+    User.findByIdAndDelete.mockRejectedValueOnce(new Error("Database connection lost"));
+
+    // Mock cascade deletions
+    Session.find.mockResolvedValueOnce([]);
+    Flashcard.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    Resume.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    NotesSummary.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    RoadmapProject.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+    UserSheetProgress.deleteMany.mockResolvedValueOnce({ deletedCount: 0 });
+
+    const req = { user: { _id: userId } };
+    const res = makeRes();
+
+    await deleteUserAccount(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "Internal server error occurred",
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Problem Description

When a user deletes their account via `DELETE /api/auth/delete-account`, only the User document is removed. All associated user data remains in the database as orphaned documents.

## Affected Collections

| Collection | Model File | Reference Field |
|------------|------------|----------------|
| sessions | `backend/models/Session.js` | `user: ObjectId` |
| questions | `backend/models/Question.js` | `session: ObjectId` |
| flashcards | `backend/models/Flashcard.js` | `userId: ObjectId` |
| resumes | `backend/models/Resume.js` | `user: ObjectId` |
| notes_summaries | `backend/models/NotesSummary.js` | `user: ObjectId` |
| roadmap_projects | `backend/models/RoadmapProject.js` | `userId: ObjectId` |
| user_sheet_progress | `backend/models/UserSheetProgress.js` | `userId: ObjectId` |

## Impact

1. **Database Bloat**: Orphaned documents accumulate over time
2. **Data Inconsistency**: References to deleted users remain
3. **Query Performance**: Queries include irrelevant orphaned data
4. **Privacy Concern**: User-generated content remains after deletion

## Solution

Implemented cascade deletion in `deleteUserAccount` function to:

1. Fetch all sessions belonging to the user
2. Delete all questions associated with those sessions
3. Delete sessions, flashcards, resumes, notes, roadmaps, progress
4. Delete the user account
5. Clear refreshToken cookie

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)

## How Has This Been Tested?

- [x] Added comprehensive unit tests with 4 test cases

## Files Changed

1. `backend/controllers/authController.js` - Cascade deletion logic
2. `API_DOCUMENTATION.md` - Updated documentation
3. `backend/tests/authController.deleteAccount.cascade.unit.test.js` - New tests

## Related Issue

Closes #1097