### PR TITLE
fix : added case-insensitive Bearer token check in auth middleware

### DIFF
--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -8,7 +8,7 @@ const protect = async (req, res, next) => {
   try {
     let token = req.headers.authorization;
 
-    if (token && token.startsWith("Bearer")) {
+    if (token && token.toLowerCase().startsWith("bearer")) {
       // Extract token from "Bearer <token>"
       token = token.split(" ")[1];
 


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the issue described in #1109.

## Changes Made

- Changed `token.startsWith("Bearer")` to `token.toLowerCase().startsWith("bearer")` in `backend/middlewares/authMiddleware.js` for case-insensitive header matching.

## Impact it Made

- Ensures authentication works regardless of header casing (Bearer vs bearer)
- Prevents false "not authorized" rejections
- Note: Please assign this PR to the `tmdeveloper007` account.