### PR TITLE
fix : removed duplicate setLoading call in userContext

### DIFF
--- a/frontend/src/context/userContext.jsx
+++ b/frontend/src/context/userContext.jsx
@@ -49,7 +49,6 @@ export const UserProvider = ({ children }) => {
         if (status === 401 || status === 403) {
             clearUser();
         }
-        setLoading(false);
         return;
     } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the duplicate `setLoading(false)` call from the `catch` block in `frontend/src/context/userContext.jsx`. The `finally` block already handles `setLoading(false)`, making the catch block's call unreachable redundant code.

## Changes Made

- Removed `setLoading(false);` from the `catch` block of the `fetchUser` function in `frontend/src/context/userContext.jsx`.

## Impact it Made

- Cleaner code without unreachable statements
- Consistent loading state management
- Note: Please assign this PR to the `tmdeveloper007` account.