### PR TITLE
fix(env): log non-blocking warnings for missing optional environment variables (#732)

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -4,13 +4,18 @@ const requiredEnvVars = Object.freeze([
   "GEMINI_API_KEY",
 ]);
 
-// Optional integrations — the server boots fine without these, but the
-// dependent feature is disabled until they are provided.
-// ADZUNA_APP_ID / ADZUNA_API_KEY → "Jobs for You" (see controllers/jobController.js)
+// Optional integrations mapping missing keys to dependent features
+const optionalEnvGroups = Object.freeze([
+  {
+    feature: "Jobs for You",
+    keys: ["ADZUNA_APP_ID", "ADZUNA_API_KEY"],
+  },
+]);
 
 const validateEnv = () => {
   const missingVars = [];
 
+  // 1. Check required environment variables
   requiredEnvVars.forEach((envVar) => {
     const value = process.env[envVar];
 
@@ -27,13 +32,27 @@ const validateEnv = () => {
     });
 
     console.error(
-      "\n⚠️ Please add the missing environment variables to your .env file.\n",
+      "\n Please add the missing environment variables to your .env file.\n",
     );
 
     process.exit(1);
   }
 
-  console.log("✅ Environment variables validated successfully\n");
+  // 2. Check optional environment variables and warn if missing
+  optionalEnvGroups.forEach(({ feature, keys }) => {
+    const missingKeys = keys.filter((key) => {
+      const val = process.env[key];
+      return !val || val.trim() === "";
+    });
+
+    if (missingKeys.length > 0) {
+      console.warn(
+        `⚠️  [Optional Config] Missing: ${missingKeys.join(", ")} -> "${feature}" feature will be disabled.`
+      );
+    }
+  });
+
+  console.log(" Environment variables validated successfully\n");
 };
 
 module.exports = validateEnv;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #732

### Summary
Updated `validateEnv()` to log non-blocking warnings (`console.warn`) when optional environment variables (such as `ADZUNA_APP_ID` and `ADZUNA_API_KEY`) are missing. This informs developers during local startup which dependent application features (e.g., "Jobs for You") will be disabled, preventing silent feature failures without breaking application execution.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- [x] Verified startup with all required variables present and optional Adzuna variables omitted: observed yellow warning logs identifying disabled "Jobs for You" feature followed by successful validation output.
- [x] Verified missing required environment variables (`MONGO_URI`, `JWT_SECRET`, etc.) still correctly log an error and exit application process (`process.exit(1)`).

---

### Screenshots (if applicable)
*N/A — console output verification*

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors