### PR TITLE
fix(ai): strip nested markdown code fences before parsing Gemini JSON (#752)

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -9,6 +9,20 @@ const Question = require("../models/Question");
 const { generateWithFallback } = require("../utils/geminiHelper");
 
 /**
+ * Safely strips single or nested markdown code block fences (```json, ```)
+ * and leading/trailing whitespace from Gemini AI responses.
+ * @param {string} rawText
+ * @returns {string}
+ */
+const cleanGeminiResponse = (rawText) => {
+  if (!rawText) return "";
+  return rawText
+    .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
+    .replace(/(\s*```\s*)+$/i, "")
+    .trim();
+};
+
+/**
  * Generate interview questions and answers using the Gemini AI service.
  * @route POST /api/ai/generate-questions
  * @param {import('express').Request} req
@@ -74,10 +88,7 @@ const generateInterviewQuestions = async (req, res) => {
     );
 
     const rawText = await result.response.text();
-    let cleanedText = rawText
-      .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
-      .replace(/(\s*```\s*)+$/i, "")
-      .trim();
+    const cleanedText = cleanGeminiResponse(rawText);
 
     try {
       const data = JSON.parse(cleanedText);
@@ -144,12 +155,7 @@ const generateConceptExplanation = async (req, res) => {
     );
 
     const rawText = await result.response.text();
-    // Clean: remove all leading/trailing code block markers (```json, ```), even if repeated, and trim
-    let cleanedText = rawText
-      .replace(/^\s*```json\s*/i, "")
-      .replace(/^\s*```\s*/i, "")
-      .replace(/(\s*```\s*)+$/i, "")
-      .trim();
+    const cleanedText = cleanGeminiResponse(rawText);
 
     try {
       const data = JSON.parse(cleanedText);
@@ -166,6 +172,7 @@ const generateConceptExplanation = async (req, res) => {
 
       res.status(200).json({ model: usedModel, ...data });
     } catch (err) {
+      console.error("Gemini returned invalid JSON:", cleanedText);
       res.status(500).json({
         message: "Gemini returned invalid JSON",
       });
@@ -217,10 +224,7 @@ const generateInterviewTips = async (req, res) => {
     );
 
     const rawText = await result.response.text();
-    let cleanedText = rawText
-      .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
-      .replace(/(\s*```\s*)+$/i, "")
-      .trim();
+    const cleanedText = cleanGeminiResponse(rawText);
 
     try {
       const data = JSON.parse(cleanedText);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #752

### Summary
Fixes a crash during response parsing in `generateConceptExplanation` caused by extra or double-wrapped markdown code fences (e.g. ` ```json `) returned by Gemini. 

Replaced the non-repeating single-pass regex in `generateConceptExplanation` with a centralized `cleanGeminiResponse` utility function. This standardizes response cleaning across `generateInterviewQuestions`, `generateConceptExplanation`, and `generateInterviewTips` to cleanly strip all leading/trailing backticks before executing `JSON.parse()`.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [x] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Verified `generateConceptExplanation` successfully parses Gemini responses wrapped in single or multiple nested markdown code blocks without throwing `SyntaxError`.
- Tested existing `generateInterviewQuestions` and `generateInterviewTips` endpoints to ensure no regression.
- Verified that invalid JSON non-parseable responses still return proper `500` status codes with informative logging.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors