### PR TITLE
fix: remove contradictory process.exit unhandledRejection handler

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -195,9 +195,3 @@ process.on("uncaughtException", (err) => {
   console.error("Uncaught Exception:", err);
   process.exit(1);
 });
-
-// Handle unhandled promise rejections
-process.on("unhandledRejection", (reason, promise) => {
-  console.error("Unhandled Rejection at:", promise, "reason:", reason);
-  process.exit(1);
-});

--- a/backend/tests/unhandledRejection.policy.unit.test.js
+++ b/backend/tests/unhandledRejection.policy.unit.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// unhandledRejection policy fix (issue #1138): two contradictory global
+// listeners existed — the first logs and continues, the second called
+// process.exit(1), so any unhandled rejection killed the whole server.
+// Exactly one log-and-continue policy must remain.
+// ---------------------------------------------------------------------------
+
+const serverSource = readFileSync(resolve(__dirname, "../server.js"), "utf8");
+
+describe("server.js unhandledRejection policy", () => {
+  it("registers exactly one unhandledRejection listener", () => {
+    const matches = serverSource.match(/process\.on\(\s*["']unhandledRejection["']/g) || [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("does not exit the process from the unhandledRejection handler", () => {
+    const listenerBlock = serverSource.slice(
+      serverSource.indexOf('"unhandledRejection"'),
+      serverSource.indexOf("unhandledRejection") + 300
+    );
+    expect(listenerBlock).not.toMatch(/process\.exit/);
+  });
+});


### PR DESCRIPTION
## Problem

`backend/server.js` registered **two** global `unhandledRejection` listeners with opposite intents: the first (top of file) logs and lets the server keep running, while the second (bottom of file) calls `process.exit(1)`. Node invokes all registered listeners, so any single unhandled rejection hard-terminated the process — a site-wide outage for every user caused by one stray rejected promise. The log-and-continue handler was dead, misleading code.

## Fix

- Removed the second `unhandledRejection` handler that called `process.exit(1)`, keeping the single log-and-continue listener so rejections are logged without taking down the server.
- `uncaughtException` handling is left unchanged (fail-fast crash-and-restart is still in place for true exceptions).

## Files changed

- `backend/server.js`
- `backend/tests/unhandledRejection.policy.unit.test.js` (new)

## Testing

- Added a regression test asserting exactly one `unhandledRejection` listener is registered and that it does not call `process.exit`.
- `npx vitest run tests/unhandledRejection.policy.unit.test.js` — 2/2 passing.
- `node --check backend/server.js` — syntax OK.

Closes #1138
