### PR TITLE
fix: send createSession 201 only after the transaction commits

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -28,42 +28,50 @@ const MAX_EXPERIENCE = 50;
  */
 
 exports.createSession = async (req, res) => {
-    const mongoSession = await mongoose.startSession();
-
+    let mongoSession;
     try {
-        await mongoSession.withTransaction(async () => {
-            const userId = req.user._id;
-            const { role, experience, topicsToFocus, description } = req.body;
-            const experienceNumber = Number(experience);
- 
-            if (!role || role.trim() === "") {
-                return res.status(400).json({
-                    success: false,
-                    message: "Role is required.",
-                });
-            }
+        const userId = req.user._id;
+        const { role, experience, topicsToFocus, description } = req.body;
+        const experienceNumber = Number(experience);
 
-            if (Number.isNaN(experienceNumber)) {
-              return res.status(400).json({
-                    success: false,
-                    message: "Years of experience must be a valid number.",
-           });
-         }
+        // Validate before opening the transaction so 4xx responses are sent
+        // from the outer handler, never from inside the transaction callback
+        // (returning inside withTransaction resolves it and commits).
+        if (!role || role.trim() === "") {
+            return res.status(400).json({
+                success: false,
+                message: "Role is required.",
+            });
+        }
 
-          if (experienceNumber < 0 || experienceNumber > MAX_EXPERIENCE) {
-             return res.status(400).json({
-                   success: false,
-                   message: `Years of experience must be between 0 and ${MAX_EXPERIENCE}.`,
-             });
-            }
-            const sessionCount = await Session.countDocuments({
-                user: userId,
-            }).session(mongoSession);
+        if (Number.isNaN(experienceNumber)) {
+            return res.status(400).json({
+                success: false,
+                message: "Years of experience must be a valid number.",
+            });
+        }
 
-            if (sessionCount >= MAX_SESSIONS) {
-                throw new Error("SESSION_LIMIT_REACHED");
-            }
+        if (experienceNumber < 0 || experienceNumber > MAX_EXPERIENCE) {
+            return res.status(400).json({
+                success: false,
+                message: `Years of experience must be between 0 and ${MAX_EXPERIENCE}.`,
+            });
+        }
 
+        const sessionCount = await Session.countDocuments({
+            user: userId,
+        });
+
+        if (sessionCount >= MAX_SESSIONS) {
+            return res.status(400).json({
+                success: false,
+                message: `Maximum of ${MAX_SESSIONS} sessions reached.`,
+            });
+        }
+
+        mongoSession = await mongoose.startSession();
+
+        const created = await mongoSession.withTransaction(async () => {
             const createdSession = await Session.create(
                 [
                     {
@@ -92,26 +100,24 @@ await createdSession[0].save({
   session: mongoSession,
 });
 
-            res.status(201).json({
-                success: true,
-                session: createdSession[0],
-            });
+            return createdSession[0];
+        });
+
+        // Respond only after the transaction has committed.
+        res.status(201).json({
+            success: true,
+            session: created,
         });
     } catch (err) {
-        if (err.message === "SESSION_LIMIT_REACHED") {
-            return res.status(400).json({
-                success: false,
-                message: `Maximum of ${MAX_SESSIONS} sessions reached.`,
-            });
-        }
-
         console.error("Create session error:", err);
         return res.status(500).json({
             success: false,
             message: "Internal server error occurred",
         });
     } finally {
-        await mongoSession.endSession();
+        if (mongoSession) {
+            await mongoSession.endSession();
+        }
     }
 };
 

--- a/backend/tests/sessionController.create.transaction.unit.test.js
+++ b/backend/tests/sessionController.create.transaction.unit.test.js
@@ -1,0 +1,147 @@
+import { Module } from "node:module";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// createSession transaction fix (issue #1142): the 201 response must be sent
+// only after the transaction commits, and validation failures must return 4xx
+// from the outer handler instead of `return res...` inside the withTransaction
+// callback (which would resolve it and commit).
+//
+// sessionController.js is CommonJS, so we shim Node's module loader (same
+// pattern as registerEnumeration.unit.test.js).
+// ---------------------------------------------------------------------------
+
+const sessionMock = vi.hoisted(() => ({
+  countDocuments: vi.fn(),
+  create: vi.fn(),
+}));
+const questionMock = vi.hoisted(() => ({ insertMany: vi.fn() }));
+const mongooseMock = vi.hoisted(() => ({ startSession: vi.fn() }));
+
+const testDoubles = new Map();
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (testDoubles.has(request)) {
+    return testDoubles.get(request);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const clearRequireCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (
+      key.includes("controllers\\sessionController") ||
+      key.includes("controllers/sessionController")
+    ) {
+      delete require.cache[key];
+    }
+  });
+};
+
+let createSession;
+let currentSession;
+
+const makeSessionObj = () => ({
+  withTransaction: vi.fn(async (cb) => cb()),
+  endSession: vi.fn(async () => {}),
+});
+
+beforeAll(async () => {
+  clearRequireCache();
+  testDoubles.set("mongoose", mongooseMock);
+  testDoubles.set("../models/Session", sessionMock);
+  testDoubles.set("../models/Question", questionMock);
+
+  const mod = await import("../controllers/sessionController.js");
+  createSession = mod.createSession;
+});
+
+beforeEach(() => {
+  sessionMock.countDocuments.mockReset();
+  sessionMock.create.mockReset();
+  questionMock.insertMany.mockReset();
+  mongooseMock.startSession.mockReset();
+  currentSession = makeSessionObj();
+  mongooseMock.startSession.mockImplementation(async () => currentSession);
+});
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: null };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+};
+
+const req = (overrides = {}) => ({
+  user: { _id: "user-1" },
+  body: { role: "Backend Engineer", experience: "3", topicsToFocus: [], description: "" },
+  ...overrides,
+});
+
+describe("createSession — transaction boundary", () => {
+  it("returns 400 for a missing role without starting a transaction", async () => {
+    const res = mockRes();
+    await createSession(req({ body: { role: "   ", experience: "3" } }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mongooseMock.startSession).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for a non-numeric experience", async () => {
+    const res = mockRes();
+    await createSession(req({ body: { role: "Engineer", experience: "abc" } }), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mongooseMock.startSession).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the session limit is reached without starting a transaction", async () => {
+    sessionMock.countDocuments.mockResolvedValue(50);
+
+    const res = mockRes();
+    await createSession(req(), res);
+
+    expect(res.statusCode).toBe(400);
+    expect(mongooseMock.startSession).not.toHaveBeenCalled();
+  });
+
+  it("does not emit 201 when the transaction commit fails", async () => {
+    sessionMock.countDocuments.mockResolvedValue(0);
+    currentSession.withTransaction.mockRejectedValueOnce(new Error("commit failed"));
+
+    const res = mockRes();
+    await createSession(req(), res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.statusCode).not.toBe(201);
+    expect(currentSession.endSession).toHaveBeenCalled();
+  });
+
+  it("emits 201 with the created session only after the transaction commits", async () => {
+    sessionMock.countDocuments.mockResolvedValue(0);
+    const createdSession = {
+      _id: "s1",
+      role: "Backend Engineer",
+      questions: [],
+      save: vi.fn(async function () {
+        return this;
+      }),
+    };
+    sessionMock.create.mockResolvedValue([createdSession]);
+    questionMock.insertMany.mockResolvedValue([]);
+
+    const res = mockRes();
+    await createSession(req(), res);
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.success).toBe(true);
+    expect(res.body.session).toBe(createdSession);
+    expect(currentSession.endSession).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem

`createSession` in `backend/controllers/sessionController.js` sent the HTTP 201 response **inside** the `withTransaction` callback — before the transaction commits. If the commit subsequently failed, the client had already received a 201 with a full session object that was never persisted (phantom success). Additionally, the validation-error paths did `return res.status(400).json(...)` inside the callback, which resolves the transaction promise as a **commit** rather than an abort — the opposite of the code's obvious intent.

## Fix

- Moved the `role`/`experience`/`MAX_SESSIONS` validation ahead of the transaction, so `4xx` responses are sent from the outer handler and never from inside the callback.
- The callback now returns the created session; `res.status(201).json(...)` is sent only after `withTransaction` resolves (i.e. after the commit succeeds).
- Validation paths no longer call `res.*` inside the callback at all, so there is no accidental commit on a validation failure.
- `endSession()` is kept in `finally` and guarded so it only runs when a session was actually started.

## Files changed

- `backend/controllers/sessionController.js`
- `backend/tests/sessionController.create.transaction.unit.test.js` (new)

## Testing

- Added unit tests covering: missing role → 400 without starting a transaction; non-numeric experience → 400; session limit reached → 400; a simulated commit failure → no 201 emitted (500 + session ended); successful commit → 201 with the created session.
- `npx vitest run tests/sessionController.create.transaction.unit.test.js` — 5/5 passing.

Closes #1142
