### PR TITLE
fix: make register responses indistinguishable for fresh and existing emails

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -18,6 +18,9 @@ const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "30d";
 const REFRESH_TOKEN_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
 const REFRESH_TOKEN_SALT_ROUNDS = 10;
+// Single generic message used by BOTH registration branches so the response
+// body can never reveal whether an email is already registered.
+const REGISTRATION_GENERIC_MESSAGE = "If this email is not already registered, your account has been created.";
 const getRefreshCookieOptions = () => ({
     httpOnly: true,
     secure: process.env.NODE_ENV === "production",
@@ -75,7 +78,7 @@ const registerUser = async (req, res) => {
             // so the endpoint cannot be used for account enumeration.
             return res.status(201).json({
                 success: true,
-                message: "If this email is not already registered, your account has been created.",
+                message: REGISTRATION_GENERIC_MESSAGE,
             });
         }
 
@@ -108,22 +111,18 @@ const registerUser = async (req, res) => {
             isEmailVerified: true, // skip email verification until SMTP is configured
         });
 
-        const accessToken = generateAccessToken(user._id, user.tokenVersion);
         const refreshToken = generateRefreshToken(user._id);
 
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
-        res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
+
+        // Identical generic shape for fresh and already-registered emails (no
+        // accessToken, no user fields, no auth cookie) so the response cannot
+        // be used to enumerate accounts. Tokens are issued at login/refresh.
         return res.status(201).json({
             success: true,
-            message: "Account created successfully. You can now log in.",
-            accessToken,
-            
-            _id: user._id,
-            name: user.name,
-            email: user.email,
-            profileImageUrl: user.profileImageUrl,
+            message: REGISTRATION_GENERIC_MESSAGE,
         });
     } catch (error) {
         console.error("Register error:", error);

--- a/backend/tests/registerEnumeration.unit.test.js
+++ b/backend/tests/registerEnumeration.unit.test.js
@@ -75,7 +75,7 @@ const mockRes = () => {
     res.body = body;
     return res;
   };
-  res.cookie = () => res;
+  res.cookie = vi.fn(() => res);
   return res;
 };
 
@@ -85,6 +85,8 @@ const req = (overrides = {}) => ({
 });
 
 describe("registerUser — account enumeration", () => {
+  const REGISTRATION_MESSAGE = "If this email is not already registered, your account has been created.";
+
   it("returns a generic 201 for an already-registered email (no tokens, no user data)", async () => {
     userMock.findOne.mockResolvedValue({ _id: "existing-id" });
 
@@ -92,14 +94,11 @@ describe("registerUser — account enumeration", () => {
     await registerUser(req(), res);
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.success).toBe(true);
-    expect(res.body.message).toContain("already registered");
-    expect(res.body.accessToken).toBeUndefined();
-    expect(res.body._id).toBeUndefined();
+    expect(res.body).toEqual({ success: true, message: REGISTRATION_MESSAGE });
     expect(userMock.create).not.toHaveBeenCalled();
   });
 
-  it("returns 201 with tokens for a brand-new email", async () => {
+  it("returns the identical generic 201 for a brand-new email (no tokens, no user data, no cookie)", async () => {
     userMock.findOne.mockResolvedValue(null);
     const fakeUser = {
       _id: "new-id",
@@ -119,7 +118,40 @@ describe("registerUser — account enumeration", () => {
     await registerUser(req(), res);
 
     expect(res.statusCode).toBe(201);
-    expect(res.body.success).toBe(true);
-    expect(res.body.accessToken).toBeTruthy();
+    expect(res.body).toEqual({ success: true, message: REGISTRATION_MESSAGE });
+    expect(res.cookie).not.toHaveBeenCalled();
+  });
+
+  it("produces responses indistinguishable in shape for fresh vs already-registered emails", async () => {
+    // Fresh email path
+    userMock.findOne.mockResolvedValue(null);
+    const fakeUser = {
+      _id: "new-id",
+      tokenVersion: 0,
+      name: "Test User",
+      email: "new@example.com",
+      profileImageUrl: null,
+      refreshTokenHash: null,
+      refreshTokenExpiresAt: null,
+      save: vi.fn(async function () {
+        return this;
+      }),
+    };
+    userMock.create.mockResolvedValue(fakeUser);
+
+    const freshRes = mockRes();
+    await registerUser(req(), freshRes);
+
+    // Already-registered email path
+    userMock.create.mockClear();
+    userMock.findOne.mockResolvedValue({ _id: "existing-id" });
+
+    const existingRes = mockRes();
+    await registerUser(req(), existingRes);
+
+    expect(freshRes.statusCode).toBe(201);
+    expect(existingRes.statusCode).toBe(201);
+    expect(Object.keys(freshRes.body).sort()).toEqual(Object.keys(existingRes.body).sort());
+    expect(freshRes.body).toEqual(existingRes.body);
   });
 });


### PR DESCRIPTION
## Problem

`registerUser` in `backend/controllers/authController.js` still enumerated accounts. Both branches returned `201`, but the response bodies differed by shape:

- **Already-registered email** → `{ success, message }` only.
- **Brand-new email** → `{ success, message, accessToken, _id, name, email, profileImageUrl }` (plus a `refreshToken` cookie).

An attacker probing with an email list could trivially distinguish the two by the presence/absence of `accessToken` and user fields — the exact leak the inline comment claimed to prevent.

## Fix

- `backend/controllers/authController.js`:
  - Added a single `REGISTRATION_GENERIC_MESSAGE` constant used by **both** branches.
  - The brand-new-email branch now returns the identical `{ success: true, message }` shape — no `accessToken`, no user fields, and no `refreshToken` cookie — so the response body (and headers) are indistinguishable from the already-registered branch.
  - The refresh token is still generated, hashed, and stored on the user document so login/refresh continue to work; tokens are issued at login, not during registration.

## Files changed

- `backend/controllers/authController.js`
- `backend/tests/registerEnumeration.unit.test.js`

## Testing

- Updated `registerEnumeration.unit.test.js`:
  - Already-registered email → `201 { success: true, message: REGISTRATION_GENERIC_MESSAGE }`, `User.create` not called.
  - Brand-new email → identical `201` body, no cookie set.
  - Fresh vs. already-registered responses have **exactly the same keys and values** (`Object.keys` + `toEqual`).
- `npx vitest run tests/registerEnumeration.unit.test.js` — 3/3 passing.

Closes #1146
