### PR TITLE
fix : added typeof string guard in validateEnv to prevent TypeError

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -14,7 +14,7 @@ const validateEnv = () => {
   requiredEnvVars.forEach((envVar) => {
     const value = process.env[envVar];
 
-    if (!value || value.trim() === "") {
+    if (!value || typeof value !== "string" || value.trim() === "") {
       missingVars.push(envVar);
     }
   });


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `typeof value !== "string"` guard in `backend/config/validateEnv.js` before calling `value.trim()`. This prevents a `TypeError` crash if a non-string value ever ends up as an environment variable value (e.g., from test mocks or unconventional env-loading libraries).

## Changes Made

- `backend/config/validateEnv.js`: Changed `if (!value || value.trim() === "")` to `if (!value || typeof value !== "string" || value.trim() === "")`

## Impact it Made

- Prevents hard crashes when non-string env values are encountered
- Makes env validation more defensive and robust
- Improves reliability in test environments

Closes #1157.

## Note: please assign this PR to the `tmdeveloper007` account.