### PR TITLE
fix : added typeof string guard in saveAchievements achievement validation

### DIFF
--- a/backend/controllers/achievementController.js
+++ b/backend/controllers/achievementController.js
@@ -22,12 +22,12 @@ exports.saveAchievements = async (req, res) => {
     }
 
     // Reject any ID not in the server-side allowlist
-    const unknown = unlockedAchievements.filter((id) => !VALID_ACHIEVEMENTS.has(id));
+    const unknown = unlockedAchievements.filter((id) => typeof id !== 'string' || !VALID_ACHIEVEMENTS.has(id));
 
     if (unknown.length > 0) {
         return res.status(400).json({
             success: false,
-            error: `Unknown achievement ID(s): ${unknown.join(', ')}`,
+            error: `Invalid achievement ID(s): ${unknown.join(', ')}. Each ID must be a string.`,
         });
     }
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added an explicit `typeof id !== 'string'` guard in `backend/controllers/achievementController.js` before calling `VALID_ACHIEVEMENTS.has(id)`. Also improved the error message to clarify that each achievement ID must be a string.

## Changes Made

- `backend/controllers/achievementController.js`: Changed filter to `unlockedAchievements.filter((id) => typeof id !== 'string' || !VALID_ACHIEVEMENTS.has(id))`
- Updated error message from "Unknown achievement ID(s)" to "Invalid achievement ID(s): ... Each ID must be a string."

## Impact it Made

- Provides clear validation feedback when non-string types are submitted
- Makes the security boundary explicit rather than relying on Set behavior alone
- Improves developer experience with better error messages

Closes #1158.

## Note: please assign this PR to the `tmdeveloper007` account.