### PR TITLE
fix : normalized topicsToFocus to always be an array in createSession

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -33,7 +33,11 @@ exports.createSession = async (req, res) => {
     try {
         await mongoSession.withTransaction(async () => {
             const userId = req.user._id;
-            const { role, experience, topicsToFocus, description } = req.body;
+            const { role, experience, description } = req.body;
+            // Normalize topicsToFocus to always be an array to prevent type errors downstream
+            const topicsToFocus = Array.isArray(req.body.topicsToFocus)
+                ? req.body.topicsToFocus
+                : [];
             const experienceNumber = Number(experience);
  
             if (!role || role.trim() === "") {


### PR DESCRIPTION
## Summary of What Has Been Done

Added defensive normalization for `topicsToFocus` in the `createSession` controller to ensure it is always stored as an array in MongoDB. Previously, if a client sent a non-array value (number, string, null, object), it would be stored directly, causing potential crashes in downstream code that iterates over it expecting an array.

## Changes Made

- `backend/controllers/sessionController.js`: Added `const topicsToFocus = Array.isArray(req.body.topicsToFocus) ? req.body.topicsToFocus : [];` before the session creation, replacing the direct destructured assignment.

## Impact it Made

- Prevents storing non-array `topicsToFocus` values in the database
- Ensures downstream code (e.g., Gemini prompt building) never crashes from iterating over a non-array
- Improves data integrity in MongoDB
- Makes the API more robust against malformed client requests

Closes #1161.

## Note: please assign this PR to the `tmdeveloper007` account.