### PR TITLE
fix: catch validation error in generateConceptExplanation (#753)

### DIFF
--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -136,7 +136,14 @@ const generateConceptExplanation = async (req, res) => {
   try {
     const { question } = req.body;
 
-    const prompt = conceptExplainPrompt(question);
+    let prompt;
+    try {
+      prompt = conceptExplainPrompt(question);
+    } catch (validationError) {
+      return res.status(400).json({
+        message: validationError.message,
+      });
+    }
 
     const { result, usedModel } = await generateWithFallback(
       process.env.GEMINI_API_KEY,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #753

### Summary
Added a targeted `try/catch` block around `conceptExplainPrompt(question)` inside `generateConceptExplanation`. If `question` is missing or fails prompt creation validation, the endpoint now catches the error early and returns an HTTP `400 Bad Request` with a clear message, matching the behavior of `generateInterviewQuestions` and `generateInterviewTips` instead of unhandling the exception and throwing a `500 Internal Server Error`.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
- Sent a POST request to `/api/ai/generate-explanation` with a missing `question` field (`{}`) and verified it returns `400 Bad Request`.
- Sent a POST request with a valid `question` payload and verified it completes successfully with a `200 OK` response.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors