### PR TITLE
feat: add complete Jake's Resume template

### DIFF
--- a/frontend/src/pages/ResumeBuilder/ResumeEditor.jsx
+++ b/frontend/src/pages/ResumeBuilder/ResumeEditor.jsx
@@ -12,7 +12,15 @@ import { API_PATHS } from "../../utils/apiPaths";
 const TEMPLATES = {
   "jakes-resume": {
     name: "Jake's Resume",
-    code: `\\documentclass[letterpaper,11pt]{article}
+    code: `%-------------------------
+% Resume in Latex
+% Author : Jake Gutierrez
+% Based off of: https://github.com/sb2nov/resume
+% License : MIT
+%------------------------
+
+\\documentclass[letterpaper,11pt]{article}
+
 \\usepackage{latexsym}
 \\usepackage[empty]{fullpage}
 \\usepackage{titlesec}
@@ -26,12 +34,26 @@ const TEMPLATES = {
 \\usepackage{tabularx}
 \\input{glyphtounicode}
 
+
+%----------FONT OPTIONS----------
+% sans-serif
+% \\usepackage[sfdefault]{FiraSans}
+% \\usepackage[sfdefault]{roboto}
+% \\usepackage[sfdefault]{noto-sans}
+% \\usepackage[default]{sourcesanspro}
+
+% serif
+% \\usepackage{CormorantGaramond}
+% \\usepackage{charter}
+
+
 \\pagestyle{fancy}
-\\fancyhf{}
+\\fancyhf{} % clear all header and footer fields
 \\fancyfoot{}
 \\renewcommand{\\headrulewidth}{0pt}
 \\renewcommand{\\footrulewidth}{0pt}
 
+% Adjust margins
 \\addtolength{\\oddsidemargin}{-0.5in}
 \\addtolength{\\evensidemargin}{-0.5in}
 \\addtolength{\\textwidth}{1in}
@@ -43,36 +65,169 @@ const TEMPLATES = {
 \\raggedright
 \\setlength{\\tabcolsep}{0in}
 
+% Sections formatting
 \\titleformat{\\section}{
   \\vspace{-4pt}\\scshape\\raggedright\\large
 }{}{0em}{}[\\color{black}\\titlerule \\vspace{-5pt}]
 
+% Ensure that generate pdf is machine readable/ATS parsable
+\\pdfgentounicode=1
+
+%-------------------------
+% Custom commands
+\\newcommand{\\resumeItem}[1]{
+  \\item\\small{
+    {#1 \\vspace{-2pt}}
+  }
+}
+
+\\newcommand{\\resumeSubheading}[4]{
+  \\vspace{-2pt}\\item
+    \\begin{tabular*}{0.97\\textwidth}[t]{l@{\\extracolsep{\\fill}}r}
+      \\textbf{#1} & #2 \\\\
+      \\textit{\\small#3} & \\textit{\\small #4} \\\\
+    \\end{tabular*}\\vspace{-7pt}
+}
+
+\\newcommand{\\resumeSubSubheading}[2]{
+    \\item
+    \\begin{tabular*}{0.97\\textwidth}{l@{\\extracolsep{\\fill}}r}
+      \\textit{\\small#1} & \\textit{\\small #2} \\\\
+    \\end{tabular*}\\vspace{-7pt}
+}
+
+\\newcommand{\\resumeProjectHeading}[2]{
+    \\item
+    \\begin{tabular*}{0.97\\textwidth}{l@{\\extracolsep{\\fill}}r}
+      \\small#1 & #2 \\\\
+    \\end{tabular*}\\vspace{-7pt}
+}
+
+\\newcommand{\\resumeSubItem}[1]{\\resumeItem{#1}\\vspace{-4pt}}
+
+\\renewcommand\\labelitemii{$\\vcenter{\\hbox{\\tiny$\\bullet$}}$}
+
+\\newcommand{\\resumeSubHeadingListStart}{\\begin{itemize}[leftmargin=0.15in, label={}]}
+\\newcommand{\\resumeSubHeadingListEnd}{\\end{itemize}}
+\\newcommand{\\resumeItemListStart}{\\begin{itemize}}
+\\newcommand{\\resumeItemListEnd}{\\end{itemize}\\vspace{-5pt}}
+
+%-------------------------------------------
+%%%%%%  RESUME STARTS HERE  %%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+
 \\begin{document}
 
+%----------HEADING----------
+% \\begin{tabular*}{\\textwidth}{l@{\\extracolsep{\\fill}}r}
+%   \\textbf{\\href{http://sourabhbajaj.com/}{\\Large Sourabh Bajaj}} & Email : \\href{mailto:sourabh@sourabhbajaj.com}{sourabh@sourabhbajaj.com}\\\\
+%   \\href{http://sourabhbajaj.com/}{http://www.sourabhbajaj.com} & Mobile : +1-123-456-7890 \\\\
+% \\end{tabular*}
+
 \\begin{center}
-    \\textbf{\\Huge \\scshape Jake Gutierrez} \\\\ \\vspace{1pt}
-    \\small 123-456-7890 $|$ \\href{mailto:jake@jake.com}{\\underline{jake@jake.com}} $|$ 
-    \\href{https://linkedin.com/in/jake}{\\underline{linkedin.com/in/jake}} $|$
-    \\href{https://github.com/jake}{\\underline{github.com/jake}}
+    \\textbf{\\Huge \\scshape Jake Ryan} \\\\ \\vspace{1pt}
+    \\small 123-456-7890 $|$ \\href{mailto:x@x.com}{\\underline{jake@su.edu}} $|$
+    \\href{https://linkedin.com/in/...}{\\underline{linkedin.com/in/jake}} $|$
+    \\href{https://github.com/...}{\\underline{github.com/jake}}
 \\end{center}
 
+
+%-----------EDUCATION-----------
 \\section{Education}
-    \\begin{tabularx}{\\textwidth}{X r}
-      \\textbf{Southwestern University} & Georgetown, TX \\\\
-      Bachelor of Arts in Computer Science, Minor in Business & Aug. 2018 -- May 2021 \\\\
-    \\end{tabularx}
+  \\resumeSubHeadingListStart
+    \\resumeSubheading
+      {Southwestern University}{Georgetown, TX}
+      {Bachelor of Arts in Computer Science, Minor in Business}{Aug. 2018 -- May 2021}
+    \\resumeSubheading
+      {Blinn College}{Bryan, TX}
+      {Associate's in Liberal Arts}{Aug. 2014 -- May 2018}
+  \\resumeSubHeadingListEnd
 
+
+%-----------EXPERIENCE-----------
 \\section{Experience}
-    \\begin{tabularx}{\\textwidth}{X r}
-      \\textbf{Research Assistant} $|$ \\emph{Texas A\\&M University} & June 2020 -- Present \\\\
-    \\end{tabularx}
-    \\vspace{-1.5em}
-    \\begin{itemize}[leftmargin=0.15in, label={--}]
-        \\small
-        \\item Developed a REST API using FastAPI and PostgreSQL
-        \\item Built a full-stack app using Flask, React, PostgreSQL and Docker
-    \\end{itemize}
+  \\resumeSubHeadingListStart
 
+    \\resumeSubheading
+      {Undergraduate Research Assistant}{June 2020 -- Present}
+      {Texas A\\&M University}{College Station, TX}
+      \\resumeItemListStart
+        \\resumeItem{Developed a REST API using FastAPI and PostgreSQL to store data from learning management systems}
+        \\resumeItem{Developed a full-stack web application using Flask, React, PostgreSQL and Docker to analyze GitHub data}
+        \\resumeItem{Explored ways to visualize GitHub collaboration in a classroom setting}
+      \\resumeItemListEnd
+
+% -----------Multiple Positions Heading-----------
+%    \\resumeSubSubheading
+%     {Software Engineer I}{Oct 2014 - Sep 2016}
+%     \\resumeItemListStart
+%        \\resumeItem{Apache Beam}
+%          {Apache Beam is a unified model for defining both batch and streaming data-parallel processing pipelines}
+%     \\resumeItemListEnd
+%    \\resumeSubHeadingListEnd
+%-------------------------------------------
+
+    \\resumeSubheading
+      {Information Technology Support Specialist}{Sep. 2018 -- Present}
+      {Southwestern University}{Georgetown, TX}
+      \\resumeItemListStart
+        \\resumeItem{Communicate with managers to set up campus computers used on campus}
+        \\resumeItem{Assess and troubleshoot computer problems brought by students, faculty and staff}
+        \\resumeItem{Maintain upkeep of computers, classroom equipment, and 200 printers across campus}
+    \\resumeItemListEnd
+
+    \\resumeSubheading
+      {Artificial Intelligence Research Assistant}{May 2019 -- July 2019}
+      {Southwestern University}{Georgetown, TX}
+      \\resumeItemListStart
+        \\resumeItem{Explored methods to generate video game dungeons based off of \\emph{The Legend of Zelda}}
+        \\resumeItem{Developed a game in Java to test the generated dungeons}
+        \\resumeItem{Contributed 50K+ lines of code to an established codebase via Git}
+        \\resumeItem{Conducted  a human subject study to determine which video game dungeon generation technique is enjoyable}
+        \\resumeItem{Wrote an 8-page paper and gave multiple presentations on-campus}
+        \\resumeItem{Presented virtually to the World Conference on Computational Intelligence}
+      \\resumeItemListEnd
+
+  \\resumeSubHeadingListEnd
+
+
+%-----------PROJECTS-----------
+\\section{Projects}
+    \\resumeSubHeadingListStart
+      \\resumeProjectHeading
+          {\\textbf{Gitlytics} $|$ \\emph{Python, Flask, React, PostgreSQL, Docker}}{June 2020 -- Present}
+          \\resumeItemListStart
+            \\resumeItem{Developed a full-stack web application using with Flask serving a REST API with React as the frontend}
+            \\resumeItem{Implemented GitHub OAuth to get data from user's repositories}
+            \\resumeItem{Visualized GitHub data to show collaboration}
+            \\resumeItem{Used Celery and Redis for asynchronous tasks}
+          \\resumeItemListEnd
+      \\resumeProjectHeading
+          {\\textbf{Simple Paintball} $|$ \\emph{Spigot API, Java, Maven, TravisCI, Git}}{May 2018 -- May 2020}
+          \\resumeItemListStart
+            \\resumeItem{Developed a Minecraft server plugin to entertain kids during free time for a previous job}
+            \\resumeItem{Published plugin to websites gaining 2K+ downloads and an average 4.5/5-star review}
+            \\resumeItem{Implemented continuous delivery using TravisCI to build the plugin upon new a release}
+            \\resumeItem{Collaborated with Minecraft server administrators to suggest features and get feedback about the plugin}
+          \\resumeItemListEnd
+    \\resumeSubHeadingListEnd
+
+
+
+%
+%-----------PROGRAMMING SKILLS-----------
+\\section{Technical Skills}
+ \\begin{itemize}[leftmargin=0.15in, label={}]
+    \\small{\\item{
+     \\textbf{Languages}{: Java, Python, C/C++, SQL (Postgres), JavaScript, HTML/CSS, R} \\\\
+     \\textbf{Frameworks}{: React, Node.js, Flask, JUnit, WordPress, Material-UI, FastAPI} \\\\
+     \\textbf{Developer Tools}{: Git, Docker, TravisCI, Google Cloud Platform, VS Code, Visual Studio, PyCharm, IntelliJ, Eclipse} \\\\
+     \\textbf{Libraries}{: pandas, NumPy, Matplotlib}
+    }}
+ \\end{itemize}
+
+
+%-------------------------------------------
 \\end{document}`,
   },
   "deedy-cv": {


### PR DESCRIPTION
## Summary
- Replaces the placeholder `jakes-resume` LaTeX template with the complete Jake's Resume implementation requested in #637
- Preserves the original MIT license and attribution header from the source template
- Adds the full Contact, Education, Experience, Projects, and Technical Skills sections in `ResumeEditor.jsx`

## Testing
- `npm run test` - passed (1 test file, 4 tests)
- `npm run build` - passed
- `git diff --check` - passed

## Notes
- `npm run lint` currently fails on pre-existing unrelated files with unused variables / an existing JSX parse issue outside this PR's touched file.
- A local TeX engine (`pdflatex`, `xelatex`, or `tectonic`) is not installed in this environment, so I could not compile the template locally outside the app. The source is the MIT-licensed Jake's Resume template requested in the issue.

Closes #637
