### PR TITLE
fix : added trim on note field in updateQuestionNote

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -239,7 +239,7 @@ const updateQuestionNote = async (req, res) => {
       });
     }
 
-    question.note = note || "";
+    question.note = (note || "").trim();
     await question.save();
 
     res.status(200).json({ success: true, question });


### PR DESCRIPTION
## Summary of What Has Been Done

In `backend/controllers/questionController.js`, the `updateQuestionNote` function was modified to trim whitespace from the `note` field before saving it to the database.

**Before:**
```js
question.note = note || "";
```

**After:**
```js
question.note = (note || "").trim();
```

## Changes Made

- Modified `backend/controllers/questionController.js`: Changed the note assignment to use `.trim()` so that whitespace-only notes are normalized to empty strings.

## Impact it Made

- Prevents saving whitespace-only notes which are meaningless and waste storage
- Consistent behavior with how other text fields are handled
- Minor improvement in data quality

Closes #1185

Note: Please assign this PR to the `tmdeveloper007` account.