### PR TITLE
fix : added ObjectId validation in getRoadmapById to prevent CastError

### DIFF
--- a/backend/controllers/roadmapController.js
+++ b/backend/controllers/roadmapController.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const RoadmapProject = require("../models/RoadmapProject");
 
 const MAX_SAVED_ROADMAPS_PER_USER = 30;
@@ -91,6 +92,10 @@ const getRoadmapById = async (req, res) => {
   try {
     const { id } = req.params;
     const userId = req.user._id;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({ success: false, message: "Invalid roadmap ID" });
+    }
 
     const roadmap = await RoadmapProject.findOne({ _id: id, userId });
     if (!roadmap) {


### PR DESCRIPTION
## Summary of What Has Been Done

In `backend/controllers/roadmapController.js`, added ObjectId validation at the start of `getRoadmapById` to return a proper 400 Bad Request instead of letting Mongoose throw a CastError.

**Changes:**
1. Added `const mongoose = require("mongoose");` import at the top of the file.
2. Added validation check before the database query:
   ```js
   if (!mongoose.Types.ObjectId.isValid(id)) {
       return res.status(400).json({ success: false, message: "Invalid roadmap ID" });
   }
   ```

## Changes Made

- Modified `backend/controllers/roadmapController.js`: Added mongoose import and ObjectId validation in `getRoadmapById`.

## Impact it Made

- Returns a proper 400 response for malformed roadmap IDs instead of a 500 Internal Server Error
- Better API error messages for clients
- Prevents unhandled CastError exceptions from leaking into server logs

Closes #1186

Note: Please assign this PR to the `tmdeveloper007` account.