### PR TITLE
fix : added ObjectId validation in getSessionById to prevent CastError

### DIFF
--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -156,6 +156,10 @@ exports.getMySessions = async (req, res) => {
  */
 exports.getSessionById = async (req, res) => {
     try {
+  if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+    return res.status(400).json({ success: false, message: "Invalid session ID" });
+  }
+
   const session = await Session.findById(req.params.id)
   .populate({
     path: "questions",


### PR DESCRIPTION
## Summary of What Has Been Done

In `backend/controllers/sessionController.js`, added ObjectId validation at the start of `getSessionById` to return a proper 400 Bad Request instead of letting Mongoose throw a CastError for invalid session IDs.

**Changes:**
Added validation check before the database query:
```js
if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
  return res.status(400).json({ success: false, message: "Invalid session ID" });
}
```

## Changes Made

- Modified `backend/controllers/sessionController.js`: Added ObjectId validation in `getSessionById`.

## Impact it Made

- Returns a proper 400 response for malformed session IDs instead of a 500 Internal Server Error
- Better API error messages for clients
- Prevents unhandled CastError exceptions from leaking into server logs

Closes #1187

Note: Please assign this PR to the `tmdeveloper007` account.