### PR TITLE
fix : protect AI generate routes with auth middleware

### DIFF
--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const { protect } = require("../middlewares/authMiddleware");
 const router = express.Router();
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { generateChatWithFallback } = require('../utils/geminiHelper');
@@ -237,12 +238,12 @@ async function generateHandler(req, res) {
 }
 
 // Primary route used by frontend
-router.post('/generate', aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
+router.post('/generate', protect, aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
 // Alias under /ai for consistency if needed later (/api/ai/generate)
-router.post('/ai/generate', aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
+router.post('/ai/generate', protect, aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
 
 // Structured problem-solving route
-router.post('/solve', aiLimiter, sanitizeAiPrompt, validateProblemSolve, solveHandler);
+router.post('/solve', protect, aiLimiter, sanitizeAiPrompt, validateProblemSolve, solveHandler);
 
 // List available models
 /**
@@ -257,7 +258,7 @@ router.post('/solve', aiLimiter, sanitizeAiPrompt, validateProblemSolve, solveHa
  * @example
  * 200 {"availableModels": ["gemini-2.5-flash"], "configured": "models/gemini-2.5-flash", "note": "..."}
  */
-router.get("/models", async (req, res) => {
+router.get("/models", protect, async (req, res) => {
   try {
     const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
     const models = await genAI.listModels();


### PR DESCRIPTION
## Summary of What Has Been Done

In `backend/routes/aiRoutes.js`, added the `protect` auth middleware to all AI-related routes to ensure only authenticated users can access them.

**Changes:**
1. Added `const { protect } = require("../middlewares/authMiddleware");` import.
2. Added `protect` middleware to the following routes:
   - `POST /api/generate` - AI text generation
   - `POST /api/ai/generate` - AI text generation (alias route)
   - `POST /api/solve` - Structured problem solving
   - `GET /api/models` - List available Gemini models

## Changes Made

- Modified `backend/routes/aiRoutes.js`: Added `protect` middleware to all 4 AI routes.

## Impact it Made

- AI generation endpoints are only accessible to authenticated users
- Prevents unauthenticated quota consumption and abuse of the Gemini API
- Consistent security model across all API endpoints

Closes #1188

Note: Please assign this PR to the `tmdeveloper007` account.