### PR TITLE
fix : trim category field in createFlashcard controller

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -64,6 +64,7 @@ const createFlashcard = async (req, res) => {
   try {
     const { question, answer, category, sourceId } = req.body;
     const userId = req.user._id;
+    const trimmedCategory = (category || "General").trim();
 
     // Check if card with exact sourceId already exists for this user
     if (sourceId) {
@@ -81,7 +82,7 @@ const createFlashcard = async (req, res) => {
       userId,
       question,
       answer,
-      category: category || "General",
+      category: trimmedCategory || "General",
       sourceId: sourceId || null,
       dueDate: new Date(),
     });


### PR DESCRIPTION
## Summary of What Has Been Done

In `backend/controllers/flashcardController.js`, the `createFlashcard` function was modified to trim whitespace from the `category` field before using it.

**Changes:**
1. Extracted `trimmedCategory = (category || "General").trim()` from `req.body` destructuring.
2. Used `trimmedCategory` in `Flashcard.create()` call.

## Changes Made

- Modified `backend/controllers/flashcardController.js`: Trim category before saving.

## Impact it Made

- Consistent category values stored regardless of input whitespace
- Prevents duplicate categories like "General" and "  General  "
- Better data quality for flashcard organization

Closes #1189

Note: Please assign this PR to the `tmdeveloper007` account.