### PR TITLE
[Bug]: Debug console.log statements in sendEmail.js

### DIFF
--- a/backend/utils/sendEmail.js
+++ b/backend/utils/sendEmail.js
@@ -59,7 +59,7 @@ const transporter = createTransporter();
  * @param {string} verificationUrl - Full URL with token for email verification.
  */
 const sendVerificationEmail = async (toEmail, verificationUrl) => {
-    console.log("Attempting SMTP connection...");
+
     await transporter.sendMail({
         from: `"PrepPilot" <${process.env.EMAIL_USER}>`,
         to: toEmail,
@@ -80,7 +80,7 @@ const sendVerificationEmail = async (toEmail, verificationUrl) => {
             </div>
         `,
     });
-    console.log("SMTP verified");
+
 };
 
 module.exports = { sendVerificationEmail };


### PR DESCRIPTION
**Problem**
Hardcoded `console.log` statements in the email utility expose SMTP connection details to standard output, which clutters production logs and risks exposing server configuration.

**Fix**
`backend/utils/sendEmail.js`:
Removed all debug `console.log` statements from the email transporter service.

**Files changed**
`backend/utils/sendEmail.js`

**Testing**
Verified that the file parses correctly and the logging is removed.

Closes #1124
