### PR TITLE
fix : added typeof string guard in validateEnv before calling trim

### DIFF
--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -14,7 +14,7 @@ const validateEnv = () => {
   requiredEnvVars.forEach((envVar) => {
     const value = process.env[envVar];
 
-    if (!value || value.trim() === "") {
+    if (!value || typeof value !== "string" || value.trim() === "") {
       missingVars.push(envVar);
     }
   });


### PR DESCRIPTION
Closes #1236

## Summary of What Has Been Done

In `backend/config/validateEnv.js`, added a `typeof value !== "string"` guard before calling `value.trim()`. This prevents an unhandled `TypeError` crash when environment variables are set as non-string types (numbers, booleans, or objects) in certain runner environments or during automated testing.

## Changes Made

In `backend/config/validateEnv.js`:
```js
// Before:
if (!value || value.trim() === "") {

// After:
if (!value || typeof value !== "string" || value.trim() === "") {
```

## Impact it Made

Prevents server crashes at startup when environment variables contain non-string values. The validation now safely handles all value types.

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a type guard in `validateEnv` to reject non-string environment variable values before calling `.trim()`. This prevents startup crashes caused by invalid environment variable types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->