### PR TITLE
fix : used functional setState for score and remaining in GridMemoryGame

### DIFF
--- a/frontend/src/components/GridMemoryGame.jsx
+++ b/frontend/src/components/GridMemoryGame.jsx
@@ -77,12 +77,18 @@ const GridMemoryGame = () => {
     if (cell.clicked) return;
     setGrid((g) => g.map((c, idx) => idx === i ? { ...c, clicked: true, state: c.colored ? "correct" : "wrong" } : c));
     if (cell.colored) {
-      const nr = remaining - 1; const ns = score + 10;
-      setRemaining(nr); setScore(ns);
-      if (nr === 0) { clearTimers(); setPhase("won"); }
+      setScore((s) => s + 10);
+      setRemaining((r) => {
+        const newR = r - 1;
+        if (newR === 0) { clearTimers(); setPhase("won"); }
+        return newR;
+      });
     } else {
-      const nm = mistakes + 1; setMistakes(nm);
-      if (nm >= 3) { clearTimers(); setPhase("lost"); }
+      setMistakes((m) => {
+        const newM = m + 1;
+        if (newM >= 3) { clearTimers(); setPhase("lost"); }
+        return newM;
+      });
     }
   };
 


### PR DESCRIPTION
Closes #1237

## Summary of What Has Been Done

In `frontend/src/components/GridMemoryGame.jsx`, replaced direct state reads in `handleCellClick` with React functional updates. This fixes a stale closure bug where rapid successive cell clicks would read outdated `score` and `remaining` values from the closure instead of the latest React state.

## Changes Made

In `frontend/src/components/GridMemoryGame.jsx`:

```js
// Before (stale closure):
const nr = remaining - 1; const ns = score + 10;
setRemaining(nr); setScore(ns);
if (nr === 0) { clearTimers(); setPhase("won"); }

// After (functional update):
setScore((s) => s + 10);
setRemaining((r) => {
  const newR = r - 1;
  if (newR === 0) { clearTimers(); setPhase("won"); }
  return newR;
});
```

Also fixed the wrong-click branch:
```js
// Before:
const nm = mistakes + 1; setMistakes(nm);

// After:
setMistakes((m) => {
  const newM = m + 1;
  if (newM >= 3) { clearTimers(); setPhase("lost"); }
  return newM;
});
```

## Impact it Made

Score and remaining count are now always computed from the latest state, ensuring correct game logic regardless of click speed.

Note: Please assign this PR to the `tmdeveloper007` account.