### PR TITLE
fix : used functional update for high score in PatternMatrixGame hook

### DIFF
--- a/frontend/src/components/GridMemoryGame.jsx
+++ b/frontend/src/components/GridMemoryGame.jsx
@@ -77,12 +77,18 @@ const GridMemoryGame = () => {
     if (cell.clicked) return;
     setGrid((g) => g.map((c, idx) => idx === i ? { ...c, clicked: true, state: c.colored ? "correct" : "wrong" } : c));
     if (cell.colored) {
-      const nr = remaining - 1; const ns = score + 10;
-      setRemaining(nr); setScore(ns);
-      if (nr === 0) { clearTimers(); setPhase("won"); }
+      setScore((s) => s + 10);
+      setRemaining((r) => {
+        const newR = r - 1;
+        if (newR === 0) { clearTimers(); setPhase("won"); }
+        return newR;
+      });
     } else {
-      const nm = mistakes + 1; setMistakes(nm);
-      if (nm >= 3) { clearTimers(); setPhase("lost"); }
+      setMistakes((m) => {
+        const newM = m + 1;
+        if (newM >= 3) { clearTimers(); setPhase("lost"); }
+        return newM;
+      });
     }
   };
 

--- a/frontend/src/hooks/usePatternMatrix.js
+++ b/frontend/src/hooks/usePatternMatrix.js
@@ -81,6 +81,9 @@ export const usePatternMatrix = () => {
   const [correctClicks, setCorrectClicks] = useState(0);
   const [timeElapsed, setTimeElapsed] = useState(0);
 
+  // Score ref to avoid stale closure reads in setHighScore callback
+  const scoreRef = useRef(0);
+
   // Timer reference stores
   const displayTimerRef = useRef(null);
   const countdownIntervalRef = useRef(null);
@@ -243,7 +246,7 @@ export const usePatternMatrix = () => {
     
     setDifficulty(selectedDiff);
     setPaused(false);
-    setScore(0);
+    scoreRef.current = 0; setScore(0);
     setLevel(1);
     setStreak(0);
     setMaxStreak(0);
@@ -281,7 +284,7 @@ export const usePatternMatrix = () => {
         // Success calculations
         const diffMultiplier = DIFFICULTY_CONFIGS[difficulty].multiplier;
         const ptsEarned = Math.round((50 * level * diffMultiplier) + (10 * targets.size));
-        setScore((s) => s + ptsEarned);
+        setScore((s) => { const ns = s + ptsEarned; scoreRef.current = ns; return ns; });
         
         const nextStreak = streak + 1;
         setStreak(nextStreak);
@@ -327,9 +330,10 @@ export const usePatternMatrix = () => {
         transitionTimeoutRef.current = setTimeout(() => {
           setPhase("gameover");
           setHighScore((prevHigh) => {
-            if (score > prevHigh) {
-              localStorage.setItem("matrix_high_score", score.toString());
-              return score;
+            const finalScore = scoreRef.current;
+            if (finalScore > prevHigh) {
+              localStorage.setItem("matrix_high_score", finalScore.toString());
+              return finalScore;
             }
             return prevHigh;
           });
@@ -342,7 +346,7 @@ export const usePatternMatrix = () => {
         }, 1500);
       }
     }
-  }, [phase, paused, selected, wrongClicks, targets, gridSize, difficulty, level, streak, lives, score, startCountdown]);
+  }, [phase, paused, selected, wrongClicks, targets, gridSize, difficulty, level, streak, lives, scoreRef, startCountdown]);
 
   // ─── Pause & Resume Utilities ────────────────────────────────────────────────
   const pauseGame = useCallback(() => {


### PR DESCRIPTION
Closes #1238

## Summary of What Has Been Done

In `frontend/src/hooks/usePatternMatrix.js`, introduced a `scoreRef` to track the current score value. The ref is kept up-to-date alongside every `setScore` call, ensuring the game-over `setHighScore` callback always reads the true final score instead of a stale closure-captured value.

## Changes Made

1. Added `const scoreRef = useRef(0);` to track the current score.
2. Updated `setScore` calls to also update `scoreRef.current`.
3. In the game-over `setHighScore` callback, read from `scoreRef.current` instead of the closure-captured `score` variable.
4. Removed `score` from the `useCallback` dependency array (now reads via ref).

```js
// Before (stale closure):
setHighScore((prevHigh) => {
  if (score > prevHigh) {
    localStorage.setItem("matrix_high_score", score.toString());
    return score;
  }
  return prevHigh;
});

// After (ref-based):
setHighScore((prevHigh) => {
  const finalScore = scoreRef.current;
  if (finalScore > prevHigh) {
    localStorage.setItem("matrix_high_score", finalScore.toString());
    return finalScore;
  }
  return prevHigh;
});
```

## Impact it Made

High scores are now always computed from the true final score state, preventing incorrect high score records and ensuring the persisted localStorage value is accurate.

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Use functional state updates in `GridMemoryGame`.
- Use `scoreRef` in `usePatternMatrix` to calculate and persist the accurate final high score.
- Prevent stale score values in asynchronous game-over callbacks.

Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->