### PR TITLE
fix(job-cache): prevent race condition on upserts in refreshJobCache #1249

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -15,23 +15,47 @@ async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
   const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1`;
   const { data } = await axios.get(url, {
     params: {
-      app_id:   ADZUNA_APP_ID,
-      app_key:  ADZUNA_API_KEY,
-      what:     role,
+      app_id:           ADZUNA_APP_ID,
+      app_key:          ADZUNA_API_KEY,
+      what:             role,
       results_per_page: 10,
     },
   });
   return (data.results || []).map((j) => ({
-    id:          j.id,
-    title:       j.title,
-    company:     j.company?.display_name || "Unknown",
-    location:    j.location?.display_name || "Remote",
-    salary_min:  j.salary_min || null,
-    salary_max:  j.salary_max ?? null,
-    description: j.description ?? "",
+    id:           j.id,
+    title:        j.title,
+    company:      j.company?.display_name || "Unknown",
+    location:     j.location?.display_name || "Remote",
+    salary_min:   j.salary_min || null,
+    salary_max:   j.salary_max ?? null,
+    description:  j.description ?? "",
     redirect_url: j.redirect_url,
-    created:     j.created,
+    created:      j.created,
   }));
+}
+
+/**
+ * Handles concurrent upserts safely by catching E11000 duplicate key errors
+ * and falling back to a standard update.
+ */
+async function upsertJobCache(cacheKey, jobs) {
+  const updateData = { jobs, fetchedAt: new Date() };
+  try {
+    return await JobCache.findOneAndUpdate(
+      { cacheKey },
+      updateData,
+      { upsert: true, new: true }
+    );
+  } catch (err) {
+    if (err.code === 11000) {
+      return await JobCache.findOneAndUpdate(
+        { cacheKey },
+        updateData,
+        { new: true }
+      );
+    }
+    throw err;
+  }
 }
 
 exports.getJobs = async (req, res) => {
@@ -63,11 +87,7 @@ exports.getJobs = async (req, res) => {
 
     const jobs = await fetchFromAdzuna(role, country);
 
-    await JobCache.findOneAndUpdate(
-      { cacheKey },
-      { jobs, fetchedAt: new Date() },
-      { upsert: true, new: true }
-    );
+    await upsertJobCache(cacheKey, jobs);
 
     return res.json({ jobs, role, source: "api" });
   } catch (err) {
@@ -84,14 +104,14 @@ exports.refreshJobCache = async () => {
     });
 
     for (const role of roles) {
-      const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
-      const jobs = await fetchFromAdzuna(role);
-      await JobCache.findOneAndUpdate(
-        { cacheKey },
-        { jobs, fetchedAt: new Date() },
-        { upsert: true, new: true }
-      );
-      console.log(`[JobCron] Refreshed cache for: ${role}`);
+      try {
+        const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
+        const jobs = await fetchFromAdzuna(role);
+        await upsertJobCache(cacheKey, jobs);
+        console.log(`[JobCron] Refreshed cache for: ${role}`);
+      } catch (roleErr) {
+        console.error(`[JobCron] Failed to refresh role "${role}":`, roleErr.message);
+      }
     }
   } catch (err) {
     console.error("[JobCron] Refresh failed:", err.message);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1249

### Summary
Fixes a race condition in `JobCache` where concurrent `findOneAndUpdate` calls with `upsert: true` (e.g., background cron job overlapping with incoming `GET /api/jobs` requests for un-cached roles) caused MongoDB `E11000` duplicate key errors. 

Introduced a `upsertJobCache` helper that cleanly catches `E11000` errors on parallel document insertions and falls back to a standard update. Also wrapped individual role refreshes in `refreshJobCache` with isolated `try/catch` blocks to prevent single-role failures from aborting the cron execution.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Simulated concurrent requests to `GET /api/jobs?role=developer` while executing `refreshJobCache()`.
- Verified in server logs that parallel upserts no longer throw `E11000 duplicate key error` or crash the process.
- Verified that cache entries update successfully and subsequent requests hit the cached response as expected.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `upsertJobCache` to handle concurrent cache creation without `E11000` duplicate-key errors.
- Updated request-driven fetching and scheduled refreshes to use the helper.
- Isolated scheduled refresh failures by role so one failure does not stop other roles.
- Logged failed roles during scheduled refreshes.
- Verified concurrent cache updates and successful cache refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->