### PR TITLE
fix(jobs): validate country query parameter against supported Adzuna codes (#1251)

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -4,11 +4,15 @@ const JobCache = require("../models/JobCache");
 
 const ADZUNA_APP_ID  = process.env.ADZUNA_APP_ID;
 const ADZUNA_API_KEY = process.env.ADZUNA_API_KEY;
-const ADZUNA_COUNTRY = process.env.ADZUNA_COUNTRY || "in";
+const ADZUNA_COUNTRY = (process.env.ADZUNA_COUNTRY || "in").toLowerCase();
 const CACHE_TTL_MS   = 24 * 60 * 60 * 1000;
 
-// The Jobs feature is optional: without Adzuna credentials it stays dormant
-// instead of crashing the server or spamming failed API calls.
+// Supported Adzuna country codes
+const SUPPORTED_COUNTRIES = new Set([
+  "gb", "us", "in", "ca", "au", "de", "fr", "br", "za", 
+  "at", "be", "ch", "es", "it", "nl", "nz", "pl", "ru", "sg"
+]);
+
 const isAdzunaConfigured = () => Boolean(ADZUNA_APP_ID && ADZUNA_API_KEY);
 
 async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
@@ -70,6 +74,14 @@ exports.getJobs = async (req, res) => {
       });
     }
 
+    // Validate country parameter if explicitly provided
+    let country = req.query.country ? String(req.query.country).toLowerCase() : ADZUNA_COUNTRY;
+    if (!SUPPORTED_COUNTRIES.has(country)) {
+      return res.status(400).json({
+        message: `Invalid or unsupported country code: "${req.query.country}". Supported codes are: ${Array.from(SUPPORTED_COUNTRIES).join(", ")}`,
+      });
+    }
+
     const userId = req.user._id;
 
     const latestSession = await Session.findOne({ user: userId })
@@ -77,7 +89,6 @@ exports.getJobs = async (req, res) => {
       .select("role");
 
     const role    = req.query.role || latestSession?.role || "software engineer";
-    const country = req.query.country   || ADZUNA_COUNTRY;
     const cacheKey = `${role.toLowerCase()}|${country}`;
 
     const cached = await JobCache.findOne({ cacheKey });
@@ -98,6 +109,9 @@ exports.getJobs = async (req, res) => {
 
 exports.refreshJobCache = async () => {
   if (!isAdzunaConfigured()) return;
+
+  const targetCountry = SUPPORTED_COUNTRIES.has(ADZUNA_COUNTRY) ? ADZUNA_COUNTRY : "in";
+
   try {
     const roles = await Session.distinct("role", {
       createdAt: { $gte: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) },
@@ -105,8 +119,8 @@ exports.refreshJobCache = async () => {
 
     for (const role of roles) {
       try {
-        const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
-        const jobs = await fetchFromAdzuna(role);
+        const cacheKey = `${role.toLowerCase()}|${targetCountry}`;
+        const jobs = await fetchFromAdzuna(role, targetCountry);
         await upsertJobCache(cacheKey, jobs);
         console.log(`[JobCron] Refreshed cache for: ${role}`);
       } catch (roleErr) {

--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -15,23 +15,47 @@ async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
   const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1`;
   const { data } = await axios.get(url, {
     params: {
-      app_id:   ADZUNA_APP_ID,
-      app_key:  ADZUNA_API_KEY,
-      what:     role,
+      app_id:           ADZUNA_APP_ID,
+      app_key:          ADZUNA_API_KEY,
+      what:             role,
       results_per_page: 10,
     },
   });
   return (data.results || []).map((j) => ({
-    id:          j.id,
-    title:       j.title,
-    company:     j.company?.display_name || "Unknown",
-    location:    j.location?.display_name || "Remote",
-    salary_min:  j.salary_min || null,
-    salary_max:  j.salary_max ?? null,
-    description: j.description ?? "",
+    id:           j.id,
+    title:        j.title,
+    company:      j.company?.display_name || "Unknown",
+    location:     j.location?.display_name || "Remote",
+    salary_min:   j.salary_min || null,
+    salary_max:   j.salary_max ?? null,
+    description:  j.description ?? "",
     redirect_url: j.redirect_url,
-    created:     j.created,
+    created:      j.created,
   }));
+}
+
+/**
+ * Handles concurrent upserts safely by catching E11000 duplicate key errors
+ * and falling back to a standard update.
+ */
+async function upsertJobCache(cacheKey, jobs) {
+  const updateData = { jobs, fetchedAt: new Date() };
+  try {
+    return await JobCache.findOneAndUpdate(
+      { cacheKey },
+      updateData,
+      { upsert: true, new: true }
+    );
+  } catch (err) {
+    if (err.code === 11000) {
+      return await JobCache.findOneAndUpdate(
+        { cacheKey },
+        updateData,
+        { new: true }
+      );
+    }
+    throw err;
+  }
 }
 
 exports.getJobs = async (req, res) => {
@@ -63,11 +87,7 @@ exports.getJobs = async (req, res) => {
 
     const jobs = await fetchFromAdzuna(role, country);
 
-    await JobCache.findOneAndUpdate(
-      { cacheKey },
-      { jobs, fetchedAt: new Date() },
-      { upsert: true, new: true }
-    );
+    await upsertJobCache(cacheKey, jobs);
 
     return res.json({ jobs, role, source: "api" });
   } catch (err) {
@@ -84,14 +104,14 @@ exports.refreshJobCache = async () => {
     });
 
     for (const role of roles) {
-      const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
-      const jobs = await fetchFromAdzuna(role);
-      await JobCache.findOneAndUpdate(
-        { cacheKey },
-        { jobs, fetchedAt: new Date() },
-        { upsert: true, new: true }
-      );
-      console.log(`[JobCron] Refreshed cache for: ${role}`);
+      try {
+        const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
+        const jobs = await fetchFromAdzuna(role);
+        await upsertJobCache(cacheKey, jobs);
+        console.log(`[JobCron] Refreshed cache for: ${role}`);
+      } catch (roleErr) {
+        console.error(`[JobCron] Failed to refresh role "${role}":`, roleErr.message);
+      }
     }
   } catch (err) {
     console.error("[JobCron] Refresh failed:", err.message);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1251

### Summary
Added validation for the `country` query parameter in `GET /api/jobs`. Unsupported or invalid country codes (e.g., `?country=xyz`) are now intercepted immediately and return a `400 Bad Request` with an informative error message, preventing unhandled external API exceptions and unnecessary `500 Internal Server Error` responses.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Sent a request to `GET /api/jobs?country=xyz` and verified it returns `400 Bad Request` with the message listing valid country codes.
- Sent a request to `GET /api/jobs?country=us` and `GET /api/jobs?country=in` to confirm valid codes successfully fetch and cache jobs.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Validate `country` for `GET /api/jobs` against supported Adzuna country codes.
- Return `400 Bad Request` with valid codes for unsupported values.
- Preserve job fetching and caching for valid country codes.
- Use duplicate-key-safe upserts for job cache writes.
- Validate configured countries during background refreshes.
- Isolate per-role refresh failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->