### PR TITLE
fix: mount roadmap routes so the Project Roadmap feature stops 404ing

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -144,6 +144,8 @@ const coursesRoutes = require("./routes/coursesRoutes");
 app.use("/api/courses", generalLimiter, coursesRoutes);
 const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
+const roadmapRoutes = require("./routes/roadmapRoutes");
+app.use("/api/roadmaps", roadmapRoutes);
 
 
 app.use(


### PR DESCRIPTION
## Problem

The Project Roadmap feature 404'd: `roadmapRoutes.js` defines the full roadmap API (CRUD + task toggle, protected, rate-limited) but `server.js` never registered the router, so every frontend call to `/api/roadmaps*` returned 404.

## Fix


Mounted `roadmapRoutes` in `server.js` at `/api/roadmaps`, matching the frontend `API_PATHS.ROADMAP` entries. The router already applies `generalLimiter` and `protect` internally, so no additional middleware is needed at the mount point.

## Files changed


- `backend/server.js`

## Testing


- Booted the server locally and verified `GET /api/roadmaps` now returns 401 (auth required) instead of 404, confirming the router is mounted and the auth middleware chain is reached.

Closes #1265


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Mounted `roadmapRoutes` in `backend/server.js` at `/api/roadmaps`.

This makes the Project Roadmap API reachable from the frontend paths in `API_PATHS.ROADMAP`.

It also restores the router middleware chain for roadmap CRUD, task toggling, protection, and rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->