### PR TITLE
fix : remove stale Joi validation from saveSummary since Zod already validates on the route

### DIFF
--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -6,7 +6,7 @@ const {
   computeReadingTime,
   PdfIntegrityError,
 } = require("../utils/pdfIntegrity");
-const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
+const { aiOutputSchema, saveNotesSummarySchema } = require("../Input_validators/ValidateNotesSummary");
 const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
 const NotesSummary = require("../models/NotesSummary");
 
@@ -247,8 +247,17 @@ const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
 
-    // Validation is handled by the Zod middleware (validateSaveNotesSummary) on the route.
-    // The req.body has already been validated and normalized by Zod before reaching here.
+    // Explicitly validate with Zod to satisfy CodeQL taint analysis.
+    // (The route middleware already validates via validateSaveNotesSummary, but
+    // re-parsing here makes the data-flow contract unambiguous for static analysis.)
+    const validated = saveNotesSummarySchema.safeParse(req.body);
+    if (!validated.success) {
+      return res.status(400).json({
+        success: false,
+        message: validated.error.issues.map((e) => e.message),
+      });
+    }
+
     const {
       fileName,
       sourceType,
@@ -262,7 +271,7 @@ const saveSummary = async (req, res) => {
       difficulty,
       readingTime,
       learningOutcomes,
-    } = req.body;
+    } = validated.data;
 
     const savedSummary = await NotesSummary.findOneAndUpdate(
       {

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -9,7 +9,6 @@ const {
 const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
 const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
 const NotesSummary = require("../models/NotesSummary");
-const Joi = require("joi");
 
 const ALLOWED_REMOTE_HOSTS = new Set(["raw.githubusercontent.com"]);
 const MAX_SAVED_SUMMARIES_PER_USER = 30;
@@ -240,32 +239,6 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
 };
 
 
-const saveSummarySchema = Joi.object({
-  fileName: Joi.string().trim().max(255).required(),
-
-  sourceType: Joi.string().trim().required(),
-
-  sourceUrl: Joi.string().uri().allow("", null),
-
-  pageCount: Joi.number().integer().min(0).required(),
-
-  wordCount: Joi.number().integer().min(0).required(),
-
-  contentHash: Joi.string().required(),
-
-  summary: Joi.string().required(),
-
-  topics: Joi.array().items(Joi.string()).required(),
-
-  prerequisites: Joi.array().items(Joi.string()).required(),
-
-  difficulty: Joi.string().required(),
-
-  readingTime: Joi.number().min(0).required(),
-
-  learningOutcomes: Joi.array().items(Joi.string()).required(),
-});
-
 /**
  * @route POST /api/notes-summary/save
  * @access Private
@@ -274,18 +247,8 @@ const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
 
-    const { error, value } = saveSummarySchema.validate(req.body, {
-      abortEarly: false,
-      stripUnknown: true,
-    });
-
-    if (error) {
-      return res.status(400).json({
-        success: false,
-        message: error.details.map((d) => d.message),
-      });
-    }
-
+    // Validation is handled by the Zod middleware (validateSaveNotesSummary) on the route.
+    // The req.body has already been validated and normalized by Zod before reaching here.
     const {
       fileName,
       sourceType,
@@ -299,7 +262,7 @@ const saveSummary = async (req, res) => {
       difficulty,
       readingTime,
       learningOutcomes,
-    } = value;
+    } = req.body;
 
     const savedSummary = await NotesSummary.findOneAndUpdate(
       {


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the redundant Joi schema and validation from `backend/controllers/notesSummaryController.js`. The `POST /api/notes-summary/save` route already has Zod validation via `validateSaveNotesSummary` middleware, so the controller-level Joi re-validation was unnecessary and caused failures.

The Joi schema had a stale shape (e.g. `difficulty` as `Joi.string()` instead of an object with `level` and `explanation`) that conflicted with what `summarizeNotes` actually returns. Since the Zod validator on the route (`validateSaveNotesSummary`) handles validation, the controller now directly accesses `req.body`.

## Changes Made

- Removed `const Joi = require("joi")` import from `notesSummaryController.js`
- Removed the entire `saveSummarySchema` Joi definition (26 lines)
- Removed the Joi validation call in `saveSummary` controller (6 lines)
- Changed destructuring from `const { ..., error, value } = ...` to `const { ... } = req.body`
- Added clarifying comment that Zod middleware handles validation

## Impact it Made

- Fixes the 400 error on `POST /api/notes-summary/save` that was caused by schema mismatch between Joi and Zod
- Removes redundant validation overhead (Joi ran after Zod already validated the request)
- Aligns the controller with the established pattern used in other controllers in this project

## Closes #1280

## Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed redundant Joi validation from `saveSummary`.
- Reused route-level Zod validation for `POST /api/notes-summary/save`.
- Fixed valid notes summary saves that previously returned `400`.
- Removed the unused Joi import and stale schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->