### PR TITLE
fix : prevent double-bcrypt hashing on new user registration

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -106,9 +106,6 @@ const registerUser = async (req, res) => {
             });
         }
 
-        // Hash raw password with bcrypt before DB creation (#757)
-        const hashedPassword = await bcrypt.hash(password, PASSWORD_SALT_ROUNDS);
-
         // Split name into first and last names for defaults
         const nameParts = cleanName.split(/\s+/);
         const firstName = nameParts[0] || "";
@@ -118,10 +115,11 @@ const registerUser = async (req, res) => {
         const defaultPrepPilotId = cleanEmail.split("@")[0] + Math.floor(1000 + Math.random() * 9000);
 
         // Auto-verify user — email verification temporarily disabled
+        // Password hashing is handled by the User model's pre-save hook (once, not twice).
         const user = await User.create({
             name: cleanName,
             email: cleanEmail,
-            password: hashedPassword,
+            password: password,
             profileImageUrl,
             firstName,
             lastName,


### PR DESCRIPTION
## Summary of What Has Been Done

Removed the explicit bcrypt hashing from `registerUser` in `backend/controllers/authController.js`. The `User` model already has a `pre('save')` hook that hashes the password, so the controller was hashing it a second time. This caused newly registered users to have their password hashed twice, making login impossible.

## Changes Made

- Removed the line `const hashedPassword = await bcrypt.hash(password, PASSWORD_SALT_ROUNDS);` and its comment
- Changed `password: hashedPassword` to `password: password` in `User.create()`
- Updated the comment on `User.create()` to clarify the pre-save hook handles hashing

## Impact it Made

- Newly registered users can successfully log in (previously broken due to double hashing)
- Removes redundant bcrypt computation (one hash per registration instead of two)
- Aligns the registration flow with `changePassword` and `resetPassword` which both correctly rely on the pre-save hook

## Closes #1282

## Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

`registerUser` no longer hashes the password before `User.create()`. It now passes the raw `password` value to the model.

The `User` pre-save hook now handles password hashing once. This removes the double-hash path, restores login for new users, and aligns registration with the password change and reset flows.

The token and cookie flow is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->