### PR TITLE
fix : add min-length guard on note field in ValidateQuestions and skip unchanged note writes

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -18,7 +18,7 @@ const togglePinQuestionSchema = z.object({
 
 // Schema for updating note
 const updateQuestionNoteSchema = z.object({
-  note: z.string(),
+  note: z.string().min(1, "Note text is required").max(5000, "Note must be under 5000 characters"),
 });
 
 

--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -239,7 +239,12 @@ const updateQuestionNote = async (req, res) => {
       });
     }
 
-    question.note = note || "";
+    // Skip DB write if note has not changed
+    if (question.note === note) {
+      return res.status(200).json({ success: true, question });
+    }
+
+    question.note = note;
     await question.save();
 
     res.status(200).json({ success: true, question });


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the note field validation in `backend/Input_validators/ValidateQuestions.js` and optimized the `updateQuestionNote` controller to skip unnecessary database writes.

## Changes Made

1. **Schema fix** (`backend/Input_validators/ValidateQuestions.js`):
   - Changed `note: z.string()` to `note: z.string().min(1, "Note text is required").max(5000, "Note must be under 5000 characters")`

2. **Controller optimization** (`backend/controllers/questionController.js`):
   - Added a guard to skip the database write when the note has not changed: `if (question.note === note) { return res.status(200).json({ success: true, question }); }`
   - Removed the fallback `|| ""` since the Zod validator now guarantees a non-empty string

## Impact it Made

- Prevents empty notes from being saved (enforces minimum 1 character via Zod)
- Caps notes at 5000 characters to prevent oversized payloads
- Avoids unnecessary database writes when a user saves without actually changing the note
- Aligns the schema with data requirements (non-empty, bounded content)

## Closes #1284

## Note: Please assign this PR to the `tmdeveloper007` account.