### PR TITLE
ci: add automated stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,82 @@
+name: "Stale Issue & PR "
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+    
+  workflow_dispatch:
+
+jobs:
+  stale:
+    name: Mark and Close Stale Issues & PRs
+    runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Run Stale Action
+      
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Inactivity thresholds (14 days warning + 7 days close = 21 days total)
+          days-before-stale: 14
+          
+          days-before-close: 7
+
+          # Labels applied when stale
+          stale-issue-label: "stale"
+          
+          stale-pr-label: "stale"
+
+          # Remove stale label automatically if activity resumes
+          remove-stale-when-updated: true
+
+          # Warning comment posted on stale issues
+          
+          stale-issue-message: >
+            This issue has had no activity for **14 days** and has been
+            marked as `stale`. If this is still relevant, please leave a
+            comment or push an update within the next **7 days**, otherwise
+            it will be closed automatically to keep the tracker clean.
+
+          # Warning comment posted on stale PRs
+          
+          stale-pr-message: >
+            This pull request has had no activity for **14 days** and
+            has been marked as `stale`. If this is still being worked on,
+            please push a commit or leave a comment within the next **7 days**,
+            otherwise it will be closed automatically.
+
+          # Comment posted when a stale issue is closed
+          
+          close-issue-message: >
+            This issue has been automatically closed after 21 days of
+            inactivity. If still relevant, please open a new issue with
+            updated context. Thank you for contributing to PrepPilot !
+
+          # Comment posted when a stale PR is closed
+          
+          close-pr-message: >
+            This pull request has been automatically closed after 21 days
+            of inactivity. Please reopen or raise a fresh PR rebased on the
+            latest main branch if you would like to continue. Thank you!
+
+          # Exemptions (Never touch these)
+          
+          exempt-issue-labels: "pinned,security,critical,in-progress,blocked,help wanted,gssoc:approved"
+          exempt-pr-labels: "pinned,security,critical,in-progress,blocked,do-not-merge,gssoc:approved"
+
+
+          # Cap API calls per run to respect GitHub rate limits
+          operations-per-run: 100
+
+          # Process oldest items first
+          ascending: true
+
+
+
+          


### PR DESCRIPTION
## Description
add automated stale issue and PR sweeper workflow
### Related Issue
Closes #1304 

### Summary
Added a GitHub Actions workflow (`stale.yml`) to automatically manage stale issues and pull requests in the PrepPilot repository. This workflow flags inactive items after 14 days and automatically closes them after an additional 7 days of inactivity, keeping the repository's issue and PR tracker clean and organized for maintainers and contributors.

---

### Type of Change
- [x] ✨ New feature
- [x] 🔥 Other - Automation / CI workflow

---

### How Has This Been Tested?
Describe the testing steps performed.
- Validated the GitHub Actions YAML syntax using linter tools.
- Ensured correct inactivity thresholds (14 days before stale, 7 days before close).
- Verified correct repository-specific messaging for PrepPilot 

---

### Screenshots (if applicable)
Add screenshots or videos to demonstrate the changes.
*(not available for Backend CI/CD workflow update)*

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors


under gssoc 26 review it 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a daily GitHub Actions workflow to manage inactive issues and pull requests.

- Marks items stale after 14 days of inactivity.
- Closes stale items after an additional 7 days.
- Posts repository-specific warning and closure messages.
- Applies and removes the stale label.
- Supports exempt labels and manual execution.
- Processes up to 100 oldest items per run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->