### PR TITLE
fix : wait for MongoDB connection before starting server (issue #1303)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -75,16 +75,48 @@ app.use((req, res, next) => {
   next();
 });
 
+// Start Server — wait for DB connection first so the server never accepts
+// requests while MongoDB is unreachable (issue #1303).
+const PORT = process.env.PORT || 5000;
+
+function startServer() {
+  const server = app.listen(PORT, "0.0.0.0", () => {
+    console.log(`Server connected and running on port ${PORT}`);
+    if (process.env.NODE_ENV === "production") {
+      console.log("Allowed CORS origins (production):");
+    } else {
+      console.log("Allowed CORS origins (development):");
+    }
+    for (const o of allowedOrigins) {
+      console.log("  -", o);
+    }
+  });
+
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(
+        `Port ${PORT} is already in use. Please free the port or use a different one.`,
+      );
+      process.exit(1);
+    } else {
+      console.error("Server error:", err);
+    }
+  });
+}
+
 connectDB()
   .then((success) => {
     if (success) {
       console.log("MongoDB connected successfully");
+      startServer();
     } else {
-      console.warn("⚠️ Failed to connect to MongoDB - server will run without database connection");
+      console.error("MongoDB connection failed — refusing to start server without database.");
+      process.exit(1);
     }
   })
   .catch((err) => {
     console.error("Database connection error:", err.message);
+    process.exit(1);
   });
 
 // Middleware
@@ -164,31 +196,6 @@ if (process.env.ADZUNA_APP_ID && process.env.ADZUNA_API_KEY) {
   refreshJobCache();
   setInterval(refreshJobCache, 24 * 60 * 60 * 1000);
 }
-
-// Start Server
-const PORT = process.env.PORT || 5000;
-const server = app.listen(PORT, "0.0.0.0", () => {
-  console.log(`Server connected and running on port ${PORT}`);
-  if (process.env.NODE_ENV === "production") {
-    console.log("Allowed CORS origins (production):");
-  } else {
-    console.log("Allowed CORS origins (development):");
-  }
-  for (const o of allowedOrigins) {
-    console.log("  -", o);
-  }
-});
-
-server.on("error", (err) => {
-  if (err.code === "EADDRINUSE") {
-    console.error(
-      `Port ${PORT} is already in use. Please free the port or use a different one.`,
-    );
-    process.exit(1);
-  } else {
-    console.error("Server error:", err);
-  }
-});
 
 // Handle uncaught exceptions
 process.on("uncaughtException", (err) => {


### PR DESCRIPTION
## Summary of What Has Been Done

Modified `backend/server.js` to defer the `app.listen()` call until after `connectDB()` resolves. Previously, the server would accept incoming requests before MongoDB was reachable, leading to degraded functionality with no clear error.

## Changes Made

- Wrapped `app.listen()` inside a `startServer()` function
- Moved the server startup call into the `connectDB().then()` block so it only fires when the database connection succeeds
- Changed the "failed to connect" branch to `console.error` + `process.exit(1)` instead of silently continuing
- The `catch` handler also now exits with `process.exit(1)` instead of swallowing the error

## Impact it Made

- Server no longer accepts HTTP requests before MongoDB is available
- Clear error messages and non-zero exit codes when the database is unreachable
- Eliminates the "degraded functionality without proper error handling" described in issue #1303

## Note: Please assign this PR to the `tmdeveloper007` account.

Closes #1303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Delays HTTP server startup until `connectDB()` succeeds.
- Logs database connection failures and exits with status `1`.
- Keeps server and port-error handling inside `startServer()`.

## Testing

Not run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->