### PR TITLE
fix : add protect middleware per-route in resumeRoutes.js (issue #1168)

### DIFF
--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -2,35 +2,34 @@ const express = require('express');
 const router = express.Router();
 const { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume } = require('../controllers/resumeController');
 const { protect } = require('../middlewares/authMiddleware');
-const { upload, uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
+const { uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
 const { aiLimiter } = require('../middlewares/rateLimiter');
 const { validateCompileResume, validateAnalyzeResume, validateSaveResume } = require('../Input_validators/ValidateResume');
 
 
-router.use(protect);
 // @route   POST /api/resume/compile
 // @desc    Compile LaTeX code to PDF
 // @access  Private — requires auth; aiLimiter caps external texlive.net calls to 20/hr per IP
-router.post('/compile', aiLimiter,validateCompileResume, compileResume);
+router.post('/compile', protect, aiLimiter, validateCompileResume, compileResume);
 
 // @route   POST /api/resume/analyze
 // @desc    Analyze resume using Gemini API
 // @access  Private — requires auth; aiLimiter caps Gemini API calls to 20/hr per IP
-router.post('/analyze', aiLimiter, uploadResume.single("resume"), validateResumeMagicBytes, validateAnalyzeResume, analyzeResume);
+router.post('/analyze', protect, aiLimiter, uploadResume.single("resume"), validateResumeMagicBytes, validateAnalyzeResume, analyzeResume);
 
 // @route   POST /api/resume/save
 // @desc    Save or update a resume
 // @access  Private
-router.post('/save', validateSaveResume, saveResume);
+router.post('/save', protect, validateSaveResume, saveResume);
 
 // @route   GET /api/resume/my-resumes
 // @desc    Get all saved resumes for logged-in user
 // @access  Private
-router.get('/my-resumes', getMyResumes);
+router.get('/my-resumes', protect, getMyResumes);
 
 // @route   DELETE /api/resume/:id
 // @desc    Delete a saved resume by ID
 // @access  Private
-router.delete('/:id', deleteResume);
+router.delete('/:id', protect, deleteResume);
 
 module.exports = router;

--- a/backend/tests/resumeRoutes.auth.unit.test.js
+++ b/backend/tests/resumeRoutes.auth.unit.test.js
@@ -11,18 +11,23 @@ let compileResume;
 let analyzeResume;
 
 beforeAll(async () => {
-  // Dynamic import keeps this file runnable without a live DB/env.
-  // The router module only wires Express — it doesn't connect Mongoose.
-  const routerMod = await import("../routes/resumeRoutes.js");
+  // Use CJS require to stay in the same module-cache namespace as the
+  // routes file — import() creates a separate ESM namespace in vitest,
+  // causing function-reference comparisons (toContain) to fail.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const routerMod = require("../routes/resumeRoutes.js");
   router = routerMod.default ?? routerMod;
 
-  const authMod = await import("../middlewares/authMiddleware.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const authMod = require("../middlewares/authMiddleware.js");
   protect = authMod.protect;
 
-  const limiterMod = await import("../middlewares/rateLimiter.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const limiterMod = require("../middlewares/rateLimiter.js");
   aiLimiter = limiterMod.aiLimiter;
 
-  const ctrlMod = await import("../controllers/resumeController.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ctrlMod = require("../controllers/resumeController.js");
   compileResume = ctrlMod.compileResume;
   analyzeResume = ctrlMod.analyzeResume;
 });
@@ -39,7 +44,12 @@ function getLayerStack(router, method, path) {
       l.route.methods[method.toLowerCase()]
   );
   if (!layer) return null;
-  return layer.route.stack.map((s) => s.handle);
+  // Prepend router-level middleware (e.g. router.use(protect)) so that
+  // global guards appear at the start of every route's effective stack.
+  const routerLevel = router.stack
+    .filter((l) => !l.route)
+    .map((l) => l.handle);
+  return [...routerLevel, ...layer.route.stack.map((s) => s.handle)];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the resume routes authentication middleware so that every endpoint correctly requires an authenticated user.

## Changes Made

### backend/routes/resumeRoutes.js
- Removed the global `router.use(protect)` which applied protect as router-level middleware (invisible to per-route middleware inspection)
- Added `protect` explicitly to each individual route: `/compile`, `/analyze`, `/save`, `/my-resumes`, `/:id`
- Reordered the middleware chain for `/compile` and `/analyze` to place `protect` first, followed by `aiLimiter`, then validators and controllers

### backend/tests/resumeRoutes.auth.unit.test.js
- Changed dynamic `import()` calls to `require()` for module imports, ensuring that function references loaded in the test match the same module cache used by the routes file (vitest ESM/CJS namespace separation was causing `toContain` comparisons to fail)
- Updated the `getLayerStack` helper to also prepend any router-level middleware to the route stack for completeness

## Impact it Made

- All 16 tests in `resumeRoutes.auth.unit.test.js` now pass (previously all 16 were failing)
- Backend test suite reduced from 43 failing tests to 31 failing tests
- Each resume route now explicitly declares its authentication requirement in the route definition

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #1168


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Applied `protect` middleware explicitly to all resume endpoints.
- Enforced middleware order for `/compile` and `/analyze`.
- Updated authentication tests to inspect router-level middleware.
- All 16 resume route authentication tests pass.
- Backend failing tests decreased from 43 to 31.

Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->