### PR TITLE
fix: add protect middleware per-route in resumeRoutes.js (issue #1168)

### DIFF
--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -2,35 +2,34 @@ const express = require('express');
 const router = express.Router();
 const { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume } = require('../controllers/resumeController');
 const { protect } = require('../middlewares/authMiddleware');
-const { upload, uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
+const { uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
 const { aiLimiter } = require('../middlewares/rateLimiter');
 const { validateCompileResume, validateAnalyzeResume, validateSaveResume } = require('../Input_validators/ValidateResume');
 
 
-router.use(protect);
 // @route   POST /api/resume/compile
 // @desc    Compile LaTeX code to PDF
 // @access  Private — requires auth; aiLimiter caps external texlive.net calls to 20/hr per IP
-router.post('/compile', aiLimiter,validateCompileResume, compileResume);
+router.post('/compile', protect, aiLimiter, validateCompileResume, compileResume);
 
 // @route   POST /api/resume/analyze
 // @desc    Analyze resume using Gemini API
 // @access  Private — requires auth; aiLimiter caps Gemini API calls to 20/hr per IP
-router.post('/analyze', aiLimiter, uploadResume.single("resume"), validateResumeMagicBytes, validateAnalyzeResume, analyzeResume);
+router.post('/analyze', protect, aiLimiter, uploadResume.single("resume"), validateResumeMagicBytes, validateAnalyzeResume, analyzeResume);
 
 // @route   POST /api/resume/save
 // @desc    Save or update a resume
 // @access  Private
-router.post('/save', validateSaveResume, saveResume);
+router.post('/save', protect, validateSaveResume, saveResume);
 
 // @route   GET /api/resume/my-resumes
 // @desc    Get all saved resumes for logged-in user
 // @access  Private
-router.get('/my-resumes', getMyResumes);
+router.get('/my-resumes', protect, getMyResumes);
 
 // @route   DELETE /api/resume/:id
 // @desc    Delete a saved resume by ID
 // @access  Private
-router.delete('/:id', deleteResume);
+router.delete('/:id', protect, deleteResume);
 
 module.exports = router;

--- a/backend/tests/resumeRoutes.auth.unit.test.js
+++ b/backend/tests/resumeRoutes.auth.unit.test.js
@@ -11,18 +11,23 @@ let compileResume;
 let analyzeResume;
 
 beforeAll(async () => {
-  // Dynamic import keeps this file runnable without a live DB/env.
-  // The router module only wires Express — it doesn't connect Mongoose.
-  const routerMod = await import("../routes/resumeRoutes.js");
+  // Use CJS require to stay in the same module-cache namespace as the
+  // routes file — import() creates a separate ESM namespace in vitest,
+  // causing function-reference comparisons (toContain) to fail.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const routerMod = require("../routes/resumeRoutes.js");
   router = routerMod.default ?? routerMod;
 
-  const authMod = await import("../middlewares/authMiddleware.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const authMod = require("../middlewares/authMiddleware.js");
   protect = authMod.protect;
 
-  const limiterMod = await import("../middlewares/rateLimiter.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const limiterMod = require("../middlewares/rateLimiter.js");
   aiLimiter = limiterMod.aiLimiter;
 
-  const ctrlMod = await import("../controllers/resumeController.js");
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const ctrlMod = require("../controllers/resumeController.js");
   compileResume = ctrlMod.compileResume;
   analyzeResume = ctrlMod.analyzeResume;
 });
@@ -39,7 +44,11 @@ function getLayerStack(router, method, path) {
       l.route.methods[method.toLowerCase()]
   );
   if (!layer) return null;
-  return layer.route.stack.map((s) => s.handle);
+  // Prepend router-level middleware so global guards appear in the route's effective stack.
+  const routerLevel = router.stack
+    .filter((l) => !l.route)
+    .map((l) => l.handle);
+  return [...routerLevel, ...layer.route.stack.map((s) => s.handle)];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
This PR fixes the resume routes authentication issue by replacing the router-level  middleware with explicit  middleware on each individual route. This ensures the middleware stack is correctly visible in unit tests and follows the standard pattern used elsewhere in the codebase.

## Related Issues
Closes #1168

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] Tests pass
- [x] Code follows existing style guidelines


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Applied `protect` middleware explicitly to each resume route.
- Removed the unused `upload` import.
- Updated authentication tests to use shared CommonJS module references.
- Preserved upload validation and rate limiting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->