### PR TITLE
fix: wait for MongoDB connection before starting server (issue #1303)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -75,16 +75,48 @@ app.use((req, res, next) => {
   next();
 });
 
+// Start Server — wait for DB connection first so the server never accepts
+// requests while MongoDB is unreachable (issue #1303).
+const PORT = process.env.PORT || 5000;
+
+function startServer() {
+  const server = app.listen(PORT, "0.0.0.0", () => {
+    console.log(`Server connected and running on port ${PORT}`);
+    if (process.env.NODE_ENV === "production") {
+      console.log("Allowed CORS origins (production):");
+    } else {
+      console.log("Allowed CORS origins (development):");
+    }
+    for (const o of allowedOrigins) {
+      console.log("  -", o);
+    }
+  });
+
+  server.on("error", (err) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(
+        `Port ${PORT} is already in use. Please free the port or use a different one.`,
+      );
+      process.exit(1);
+    } else {
+      console.error("Server error:", err);
+    }
+  });
+}
+
 connectDB()
   .then((success) => {
     if (success) {
       console.log("MongoDB connected successfully");
+      startServer();
     } else {
-      console.warn("⚠️ Failed to connect to MongoDB - server will run without database connection");
+      console.error("MongoDB connection failed — refusing to start server without database.");
+      process.exit(1);
     }
   })
   .catch((err) => {
     console.error("Database connection error:", err.message);
+    process.exit(1);
   });
 
 // Middleware
@@ -164,31 +196,6 @@ if (process.env.ADZUNA_APP_ID && process.env.ADZUNA_API_KEY) {
   refreshJobCache();
   setInterval(refreshJobCache, 24 * 60 * 60 * 1000);
 }
-
-// Start Server
-const PORT = process.env.PORT || 5000;
-const server = app.listen(PORT, "0.0.0.0", () => {
-  console.log(`Server connected and running on port ${PORT}`);
-  if (process.env.NODE_ENV === "production") {
-    console.log("Allowed CORS origins (production):");
-  } else {
-    console.log("Allowed CORS origins (development):");
-  }
-  for (const o of allowedOrigins) {
-    console.log("  -", o);
-  }
-});
-
-server.on("error", (err) => {
-  if (err.code === "EADDRINUSE") {
-    console.error(
-      `Port ${PORT} is already in use. Please free the port or use a different one.`,
-    );
-    process.exit(1);
-  } else {
-    console.error("Server error:", err);
-  }
-});
 
 // Handle uncaught exceptions
 process.on("uncaughtException", (err) => {


### PR DESCRIPTION
## Description
Fixed server startup race condition: moved app.listen() inside connectDB().then() block. Added process.exit(1) on DB connection failure to fail fast.

## Type of Change
- [x] Bug fix

## Checklist
- [x] Tests pass
- [x] Code follows style guidelines
