### PR TITLE
fix: allow object-shaped notes summary saves

### DIFF
--- a/backend/Input_validators/ValidateNotesSummary.js
+++ b/backend/Input_validators/ValidateNotesSummary.js
@@ -77,4 +77,5 @@ module.exports = {
   validateSummarizeNotes,
   validateSaveNotesSummary,
   aiOutputSchema,
+  saveNotesSummarySchema,
 };

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -6,7 +6,10 @@ const {
   computeReadingTime,
   PdfIntegrityError,
 } = require("../utils/pdfIntegrity");
-const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
+const {
+  aiOutputSchema,
+  saveNotesSummarySchema,
+} = require("../Input_validators/ValidateNotesSummary");
 const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
 const NotesSummary = require("../models/NotesSummary");
 
@@ -246,6 +249,14 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
 const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
+    const validation = saveNotesSummarySchema.safeParse(req.body);
+
+    if (!validation.success) {
+      return res.status(400).json({
+        success: false,
+        message: validation.error.issues.map((issue) => issue.message),
+      });
+    }
 
     const {
       fileName,
@@ -260,7 +271,7 @@ const saveSummary = async (req, res) => {
       difficulty,
       readingTime,
       learningOutcomes,
-    } = req.body;
+    } = validation.data;
 
     const savedSummary = await NotesSummary.findOneAndUpdate(
       {

--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -9,7 +9,6 @@ const {
 const { aiOutputSchema } = require("../Input_validators/ValidateNotesSummary");
 const { NOTES_MAX_FILE_SIZE } = require("../middlewares/uploadMiddleware");
 const NotesSummary = require("../models/NotesSummary");
-const Joi = require("joi");
 
 const ALLOWED_REMOTE_HOSTS = new Set(["raw.githubusercontent.com"]);
 const MAX_SAVED_SUMMARIES_PER_USER = 30;
@@ -240,32 +239,6 @@ DO NOT wrap the response in markdown code blocks. Return ONLY the raw JSON objec
 };
 
 
-const saveSummarySchema = Joi.object({
-  fileName: Joi.string().trim().max(255).required(),
-
-  sourceType: Joi.string().trim().required(),
-
-  sourceUrl: Joi.string().uri().allow("", null),
-
-  pageCount: Joi.number().integer().min(0).required(),
-
-  wordCount: Joi.number().integer().min(0).required(),
-
-  contentHash: Joi.string().required(),
-
-  summary: Joi.string().required(),
-
-  topics: Joi.array().items(Joi.string()).required(),
-
-  prerequisites: Joi.array().items(Joi.string()).required(),
-
-  difficulty: Joi.string().required(),
-
-  readingTime: Joi.number().min(0).required(),
-
-  learningOutcomes: Joi.array().items(Joi.string()).required(),
-});
-
 /**
  * @route POST /api/notes-summary/save
  * @access Private
@@ -273,18 +246,6 @@ const saveSummarySchema = Joi.object({
 const saveSummary = async (req, res) => {
   try {
     const userId = req.user._id;
-
-    const { error, value } = saveSummarySchema.validate(req.body, {
-      abortEarly: false,
-      stripUnknown: true,
-    });
-
-    if (error) {
-      return res.status(400).json({
-        success: false,
-        message: error.details.map((d) => d.message),
-      });
-    }
 
     const {
       fileName,
@@ -299,7 +260,7 @@ const saveSummary = async (req, res) => {
       difficulty,
       readingTime,
       learningOutcomes,
-    } = value;
+    } = req.body;
 
     const savedSummary = await NotesSummary.findOneAndUpdate(
       {

--- a/backend/tests/notesSummaryController.save.unit.test.js
+++ b/backend/tests/notesSummaryController.save.unit.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/NotesSummary.js");
+
+const NotesSummary = require("../models/NotesSummary.js");
+const { saveSummary } = require("../controllers/notesSummaryController.js");
+
+function makeReq(body = {}, userId = "507f1f77bcf86cd799439011") {
+  return { body, user: { _id: userId } };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("saveSummary controller", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("saves a Zod-validated notes summary payload with object metadata", async () => {
+    const payload = {
+      fileName: "operating-systems.pdf",
+      sourceType: "upload",
+      sourceUrl: null,
+      pageCount: 12,
+      wordCount: 2400,
+      contentHash: "abc123",
+      summary: "These notes cover scheduling, memory management, and file systems.",
+      topics: {
+        chapters: ["Processes"],
+        subtopics: ["Scheduling"],
+        keywords: ["kernel", "thread"],
+      },
+      prerequisites: ["Basic computer architecture"],
+      difficulty: {
+        level: "Intermediate",
+        explanation: "Requires familiarity with OS fundamentals.",
+      },
+      readingTime: {
+        minutes: 10,
+        label: "10 min read",
+        pages: 12,
+      },
+      learningOutcomes: ["Explain process scheduling tradeoffs"],
+    };
+    const safeSummary = { _id: "summary-1", ...payload };
+
+    NotesSummary.findOneAndUpdate = vi.fn().mockResolvedValue({
+      toSafeObject: vi.fn().mockReturnValue(safeSummary),
+    });
+    NotesSummary.countDocuments = vi.fn().mockResolvedValue(1);
+
+    const req = makeReq(payload);
+    const res = makeRes();
+
+    await saveSummary(req, res);
+
+    expect(NotesSummary.findOneAndUpdate).toHaveBeenCalledWith(
+      {
+        user: req.user._id,
+        fileName: payload.fileName,
+      },
+      expect.objectContaining({
+        user: req.user._id,
+        topics: payload.topics,
+        difficulty: payload.difficulty,
+        readingTime: payload.readingTime,
+      }),
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true,
+      }
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      summary: safeSummary,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Remove the stale Joi revalidation inside `saveSummary` that rejected valid object-shaped notes-summary metadata.
- Reuse the existing canonical Zod `saveNotesSummarySchema` in the controller so route and controller validation stay aligned.
- Add a focused unit test that saves a notes summary payload with object `topics`, `difficulty`, and `readingTime` metadata.

Closes #1280

## Changes Made
- Exported the existing Zod save schema from `ValidateNotesSummary.js`.
- Replaced the stale Joi schema in `notesSummaryController.js` with `saveNotesSummarySchema.safeParse(req.body)`.
- Kept persistence/upsert behavior unchanged after validation succeeds.
- Added regression coverage for the valid notes-summary save payload shape.

## Testing
- `cd backend && npm test -- --run tests/notesSummaryController.save.unit.test.js` - passed, 1 test
- `cd backend && npm test -- --run tests/notesSummaryController.save.unit.test.js tests/sheetValidation.unit.test.js tests/aiChatPayload.unit.test.js` - passed, 25 tests
- `node --check backend/controllers/notesSummaryController.js` - passed
- `node --check backend/Input_validators/ValidateNotesSummary.js` - passed
- `git diff --check` - passed
- GitHub CI: Node 18 build-and-test, Node 20 build-and-test, CodeQL Advanced, CodeQL, and CodeRabbit all passed

## Full Suite Note
- `cd backend && npm test` currently fails on existing unrelated test harness issues, including Jest globals used under Vitest and broken model mock default exports in other test files. This PR's focused regression test and CI build-and-test jobs pass.

## Edge Cases Handled
- Object-shaped `topics`, `difficulty`, and `readingTime` generated by the notes summarizer now flow through the save controller without being rejected by stale scalar Joi rules.
- Unknown fields are still stripped/rejected through the canonical Zod schema before persistence.

## Screenshots
- Not applicable: backend validation fix only.