### PR TITLE
fix(events): parse HTML month headings in open source events

### DIFF
--- a/frontend/src/pages/OpenSource/OpenSourceEvents.jsx
+++ b/frontend/src/pages/OpenSource/OpenSourceEvents.jsx
@@ -11,21 +11,10 @@ import {
   ChevronDown,
 } from "lucide-react";
 import { motion } from "framer-motion";
-
-const MONTH_ORDER = [
-  "January",
-  "February",
-  "March",
-  "April",
-  "May",
-  "June",
-  "July",
-  "August",
-  "September",
-  "October",
-  "November",
-  "December",
-];
+import {
+  MONTH_ORDER,
+  parseEventsFromMarkdown,
+} from "../../utils/parseOpenSourceEvents";
 
 const SOURCE_URL =
   "https://raw.githubusercontent.com/EverythingOpenSource/open-source-events/main/README.md";
@@ -92,64 +81,6 @@ const CustomSelect = ({ label, value, options, onChange }) => {
       </div>
     </div>
   );
-};
-
-const parseEventsFromMarkdown = (markdown) => {
-  const lines = markdown.split(/\r?\n/);
-  const events = [];
-  let currentMonth = "";
-
-  for (let i = 0; i < lines.length; i += 1) {
-    const line = lines[i].trim();
-
-    const monthMatch = line.match(/^##\s+([A-Za-z]+)/);
-    const monthCandidate = monthMatch ? monthMatch[1] : "";
-    if (MONTH_ORDER.includes(monthCandidate)) {
-      currentMonth = monthCandidate;
-      continue;
-    }
-
-    const eventMatch = line.match(/^[-*]\s+\[([^\]]+)\]\(([^)]+)\)/);
-    if (!eventMatch) continue;
-
-    let dateLine = "";
-    for (let j = i + 1; j < Math.min(i + 6, lines.length); j += 1) {
-      const peek = lines[j].trim();
-      if (/^[-*]\s+\[/.test(peek) || /^##\s+/.test(peek)) break;
-      const cleaned = peek.replace(/^>\s*/, "");
-      if (/^Date:/i.test(cleaned)) {
-        dateLine = cleaned;
-        break;
-      }
-    }
-
-    let date = "";
-    let mode = "";
-    let location = "";
-    if (dateLine) {
-      const parts = dateLine
-        .replace(/^Date:\s*/i, "")
-        .split("||")
-        .map((part) => part.trim())
-        .filter(Boolean);
-
-      if (parts[0]) date = parts[0];
-      if (parts[1]) mode = parts[1].replace(/^Mode:\s*/i, "").trim();
-      if (parts[2]) location = parts[2].replace(/^Location:\s*/i, "").trim();
-    }
-
-    events.push({
-      id: `${eventMatch[1]}-${events.length}`,
-      name: eventMatch[1],
-      url: eventMatch[2],
-      month: currentMonth || "TBA",
-      date,
-      mode,
-      location,
-    });
-  }
-
-  return events;
 };
 
 const OpenSourceEvents = () => {

--- a/frontend/src/utils/parseOpenSourceEvents.js
+++ b/frontend/src/utils/parseOpenSourceEvents.js
@@ -58,6 +58,14 @@ export const parseEventsFromMarkdown = (markdown) => {
       continue;
     }
 
+    const isMonthContextBoundary =
+      /^##\s+/.test(line) ||
+      /<h2[\s>]/i.test(line) ||
+      /<\/?details\b[^>]*>/i.test(line);
+    if (isMonthContextBoundary) {
+      currentMonth = "";
+    }
+
     const eventMatch = line.match(/^[-*]\s+\[([^\]]+)\]\(([^)]+)\)/);
     if (!eventMatch) continue;
 

--- a/frontend/src/utils/parseOpenSourceEvents.js
+++ b/frontend/src/utils/parseOpenSourceEvents.js
@@ -1,0 +1,106 @@
+const MONTH_ORDER = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+const MONTH_NAME_PATTERN = MONTH_ORDER.join("|");
+
+const capitalizeMonth = (month) => {
+  const normalized = month.toLowerCase();
+  return MONTH_ORDER.find((m) => m.toLowerCase() === normalized) || "";
+};
+
+const extractMonthFromLine = (line) => {
+  const markdownMatch = line.match(
+    new RegExp(`^##\\s+(${MONTH_NAME_PATTERN})\\b`, "i"),
+  );
+  if (markdownMatch) {
+    return capitalizeMonth(markdownMatch[1]);
+  }
+
+  const htmlMatch = line.match(
+    new RegExp(`<h2[^>]*>\\s*(?:[^A-Za-z]*)?(${MONTH_NAME_PATTERN})\\b`, "i"),
+  );
+  if (htmlMatch) {
+    return capitalizeMonth(htmlMatch[1]);
+  }
+
+  return "";
+};
+
+const isSectionBoundary = (line) =>
+  /^[-*]\s+\[/.test(line) ||
+  /^##\s+/.test(line) ||
+  /<h2[\s>]/i.test(line) ||
+  /^<\/?details>/i.test(line);
+
+export const parseEventsFromMarkdown = (markdown) => {
+  const lines = markdown.split(/\r?\n/);
+  const events = [];
+  let currentMonth = "";
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+
+    const monthCandidate = extractMonthFromLine(line);
+    if (monthCandidate) {
+      currentMonth = monthCandidate;
+      continue;
+    }
+
+    const eventMatch = line.match(/^[-*]\s+\[([^\]]+)\]\(([^)]+)\)/);
+    if (!eventMatch) continue;
+
+    let dateLine = "";
+    for (let j = i + 1; j < Math.min(i + 6, lines.length); j += 1) {
+      const peek = lines[j].trim();
+      if (isSectionBoundary(peek)) break;
+      const cleaned = peek.replace(/^>\s*/, "");
+      if (/^Date:/i.test(cleaned)) {
+        dateLine = cleaned;
+        break;
+      }
+    }
+
+    let date = "";
+    let mode = "";
+    let location = "";
+    if (dateLine) {
+      const parts = dateLine
+        .replace(/^Date:\s*/i, "")
+        .split("||")
+        .map((part) => part.trim())
+        .filter(Boolean);
+
+      if (parts[0]) date = parts[0];
+      if (parts[1]) mode = parts[1].replace(/^Mode:\s*/i, "").trim();
+      if (parts[2]) {
+        location = parts[2].replace(/^Location[s]?:\s*/i, "").trim();
+      }
+    }
+
+    events.push({
+      id: `${eventMatch[1]}-${events.length}`,
+      name: eventMatch[1],
+      url: eventMatch[2],
+      month: currentMonth || "TBA",
+      date,
+      mode,
+      location,
+    });
+  }
+
+  return events;
+};
+
+export { MONTH_ORDER };

--- a/frontend/src/utils/parseOpenSourceEvents.unit.test.js
+++ b/frontend/src/utils/parseOpenSourceEvents.unit.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { parseEventsFromMarkdown } from "./parseOpenSourceEvents";
+
+describe("parseEventsFromMarkdown", () => {
+  it("parses HTML/details month headings used by the upstream README", () => {
+    const markdown = `
+<details>
+ <summary><h2> January :sparkles: </h2></summary>
+
+- [FOSDEM 26](https://fosdem.org/2026)
+  > Date: 31st January - 1st February || Mode: In-person || Location: Brussels, Belgium.
+
+</details>
+
+<details>
+ <summary><h2> February :sparkles: </h2></summary>
+
+- [DevConf.IN](https://www.devconf.info/in/)
+  > Date: 13th - 14th February || Mode: In-person || Location: Pune, India.
+
+</details>
+`;
+
+    const events = parseEventsFromMarkdown(markdown);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      name: "FOSDEM 26",
+      month: "January",
+      mode: "In-person",
+      location: "Brussels, Belgium.",
+    });
+    expect(events[1]).toMatchObject({
+      name: "DevConf.IN",
+      month: "February",
+      location: "Pune, India.",
+    });
+  });
+
+  it("still supports classic markdown month headings", () => {
+    const markdown = `
+## March
+
+- [Laracon EU](https://laracon.eu/)
+  > Date: 2nd - 3rd March || Mode: In-person || Location: Amsterdam, Netherlands.
+
+## April
+
+- [PyCon US](https://us.pycon.org/)
+  > Date: 15th April || Mode: Hybrid || Location: Pittsburgh, USA.
+`;
+
+    const events = parseEventsFromMarkdown(markdown);
+
+    expect(events.map((e) => e.month)).toEqual(["March", "April"]);
+    expect(events[0].name).toBe("Laracon EU");
+    expect(events[1].mode).toBe("Hybrid");
+  });
+
+  it("keeps TBA only when no recognised month section precedes an event", () => {
+    const markdown = `
+<summary><h2> Subscribe to the Calendar </h2></summary>
+
+- [Orphan Event](https://example.com)
+  > Date: TBD || Mode: Virtual || Location: Global
+
+## May
+
+- [Known Event](https://example.com/may)
+  > Date: 1st May || Mode: In-person || Location: Berlin
+`;
+
+    const events = parseEventsFromMarkdown(markdown);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({ name: "Orphan Event", month: "TBA" });
+    expect(events[1]).toMatchObject({ name: "Known Event", month: "May" });
+  });
+
+  it("ignores malformed sections and preserves event order within a month", () => {
+    const markdown = `
+<details>
+ <summary><h2> June :sparkles: </h2></summary>
+
+- [Zebra Conf](https://example.com/z)
+  > Date: 20th June || Mode: Virtual || Location: Online
+
+not a real event line
+- [Alpha Conf](https://example.com/a)
+  > Date: 5th June || Mode: In-person || Locations: Austin, USA
+
+</details>
+`;
+
+    const events = parseEventsFromMarkdown(markdown);
+
+    expect(events).toHaveLength(2);
+    expect(events.map((e) => e.name)).toEqual(["Zebra Conf", "Alpha Conf"]);
+    expect(events.every((e) => e.month === "June")).toBe(true);
+    expect(events[1].location).toBe("Austin, USA");
+  });
+});

--- a/frontend/src/utils/parseOpenSourceEvents.unit.test.js
+++ b/frontend/src/utils/parseOpenSourceEvents.unit.test.js
@@ -77,6 +77,33 @@ describe("parseEventsFromMarkdown", () => {
     expect(events[1]).toMatchObject({ name: "Known Event", month: "May" });
   });
 
+
+  it("clears month context after an unrecognized section boundary", () => {
+    const markdown = `
+## May
+
+- [May Event](https://example.com/may)
+  > Date: 1st May || Mode: In-person || Location: Berlin
+
+## Community Notes
+
+- [Misplaced Event](https://example.com/notes)
+  > Date: TBD || Mode: Virtual || Location: Global
+
+<summary><h2> Subscribe to the Calendar </h2></summary>
+
+- [Also Misplaced](https://example.com/calendar)
+  > Date: TBD || Mode: Virtual || Location: Global
+`;
+
+    const events = parseEventsFromMarkdown(markdown);
+
+    expect(events).toHaveLength(3);
+    expect(events[0]).toMatchObject({ name: "May Event", month: "May" });
+    expect(events[1]).toMatchObject({ name: "Misplaced Event", month: "TBA" });
+    expect(events[2]).toMatchObject({ name: "Also Misplaced", month: "TBA" });
+  });
+
   it("ignores malformed sections and preserves event order within a month", () => {
     const markdown = `
 <details>


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #933

### Summary
Open Source Events only recognised `## Month` headings. The live EverythingOpenSource README uses `<summary><h2> Month ...</h2></summary>`, so every event landed under TBA. Moved parsing into a util that handles both formats and added unit tests.

---

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Other(please describe) ______

---

### How Has This Been Tested?
- `vitest run src/utils/parseOpenSourceEvents.unit.test.js` (4 tests)
- Parsed the live upstream README locally: 177 events, 0 TBA, months January–December populated

### Screenshots (if applicable)
N/A

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Looks good to me. Ready to merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->