### PR TITLE
fix(hive): search open labelled issues for Good First Issue

### DIFF
--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   Search,
   Github,
@@ -9,14 +9,23 @@ import {
   Loader,
   AlertCircle,
   ExternalLink,
+  MessageCircle,
+  ThumbsUp,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { motion } from "framer-motion";
 import {
   FILTER_OPTIONS,
+  REPOSITORY_SORT_OPTIONS,
+  ISSUE_SORT_OPTIONS,
   buildGitHubSearchUrl,
   normalizeSearchResponse,
   usesIssueLabelSearch,
+  getSearchPageInfo,
 } from "../../utils/repositoryHiveSearch";
+
+const PER_PAGE = 30;
 
 const RepositoryHive = () => {
   const [selectedFilters, setSelectedFilters] = useState(["good-first-issue"]);
@@ -25,12 +34,21 @@ const RepositoryHive = () => {
   const [error, setError] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("stars");
+  const [page, setPage] = useState(1);
+  const [pageInfo, setPageInfo] = useState({
+    totalCount: 0,
+    currentPage: 1,
+    totalPages: 1,
+    hasNextPage: false,
+    hasPrevPage: false,
+  });
 
-  useEffect(() => {
-    fetchRepositories();
-  }, [selectedFilters, sortBy]);
+  const showingIssueBackedResults = usesIssueLabelSearch(selectedFilters);
+  const sortOptions = showingIssueBackedResults
+    ? ISSUE_SORT_OPTIONS
+    : REPOSITORY_SORT_OPTIONS;
 
-  const fetchRepositories = async () => {
+  const fetchRepositories = useCallback(async () => {
     setLoading(true);
     setError("");
 
@@ -39,10 +57,19 @@ const RepositoryHive = () => {
         selectedFilters,
         searchQuery,
         sortBy,
+        perPage: PER_PAGE,
+        page,
       });
 
       if (!url) {
         setRepositories([]);
+        setPageInfo({
+          totalCount: 0,
+          currentPage: 1,
+          totalPages: 1,
+          hasNextPage: false,
+          hasPrevPage: false,
+        });
         setLoading(false);
         return;
       }
@@ -59,6 +86,7 @@ const RepositoryHive = () => {
 
       const data = await response.json();
       setRepositories(normalizeSearchResponse(selectedFilters, data));
+      setPageInfo(getSearchPageInfo(data, page, PER_PAGE));
     } catch (err) {
       setError(
         err.message || "Failed to fetch repositories. Please try again later.",
@@ -67,9 +95,17 @@ const RepositoryHive = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedFilters, searchQuery, sortBy, page]);
+
+  // Auto-fetch on filter/sort/page; search text applies only via Search / Enter.
+  useEffect(() => {
+    fetchRepositories();
+    // intentionally omit searchQuery — typing should not hit GitHub until Search
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedFilters, sortBy, page]);
 
   const toggleFilter = (filterId) => {
+    setPage(1);
     setSelectedFilters((prev) =>
       prev.includes(filterId)
         ? prev.filter((f) => f !== filterId)
@@ -82,12 +118,17 @@ const RepositoryHive = () => {
   };
 
   const handleSearch = () => {
-    if (repositories.length > 0 || searchQuery) {
-      fetchRepositories();
+    if (page !== 1) {
+      setPage(1);
+      return;
     }
+    fetchRepositories();
   };
 
-  const showingIssueBackedResults = usesIssueLabelSearch(selectedFilters);
+  const handleSortChange = (nextSort) => {
+    setPage(1);
+    setSortBy(nextSort);
+  };
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-[#0f172a]">
@@ -144,19 +185,15 @@ const RepositoryHive = () => {
           </div>
 
           {/* Sort Options */}
-          <div className="flex gap-3 mb-6">
+          <div className="flex gap-3 mb-6 flex-wrap">
             <span className="text-sm font-semibold text-gray-700 dark:text-gray-300 flex items-center">
               Sort by:
             </span>
-            <div className="flex gap-2">
-              {[
-                { id: "stars", label: "⭐ Most Stars" },
-                { id: "recent", label: "📅 Recently Updated" },
-                { id: "forks", label: "🔀 Most Forks" },
-              ].map((option) => (
+            <div className="flex gap-2 flex-wrap">
+              {sortOptions.map((option) => (
                 <button
                   key={option.id}
-                  onClick={() => setSortBy(option.id)}
+                  onClick={() => handleSortChange(option.id)}
                   className={`px-4 py-2 rounded-lg border transition-all font-medium text-sm ${
                     sortBy === option.id
                       ? "bg-violet-600 text-white border-violet-600"
@@ -329,27 +366,54 @@ const RepositoryHive = () => {
                   )}
                 </div>
 
-                {/* Stats */}
+                {/* Stats — issue metrics vs repository metrics */}
                 <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-white/10 text-sm">
-                  <div className="flex items-center gap-4">
-                    <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
-                      <Star size={14} />
-                      <span className="font-medium">
-                        {repo.stargazers_count}
-                      </span>
+                  {repo.metricsMode === "issue" ? (
+                    <div className="flex items-center gap-4">
+                      <div
+                        className="flex items-center gap-1 text-gray-600 dark:text-gray-400"
+                        title="Issue reactions"
+                      >
+                        <ThumbsUp size={14} />
+                        <span className="font-medium">
+                          {repo.reactions_count ?? 0}
+                        </span>
+                      </div>
+                      <div
+                        className="flex items-center gap-1 text-gray-600 dark:text-gray-400"
+                        title="Issue comments"
+                      >
+                        <MessageCircle size={14} />
+                        <span className="font-medium">
+                          {repo.comments_count ?? 0}
+                        </span>
+                      </div>
                     </div>
-                    <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
-                      <GitFork size={14} />
-                      <span className="font-medium">{repo.forks_count}</span>
-                    </div>
-                    <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
-                      <Eye size={14} />
-                      <span className="font-medium">{repo.watchers_count}</span>
-                    </div>
-                  </div>
-                  <div className="text-xs text-gray-600 dark:text-gray-400">
-                    {repo.open_issues_count} issues
-                  </div>
+                  ) : (
+                    <>
+                      <div className="flex items-center gap-4">
+                        <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+                          <Star size={14} />
+                          <span className="font-medium">
+                            {repo.stargazers_count}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+                          <GitFork size={14} />
+                          <span className="font-medium">{repo.forks_count}</span>
+                        </div>
+                        <div className="flex items-center gap-1 text-gray-600 dark:text-gray-400">
+                          <Eye size={14} />
+                          <span className="font-medium">
+                            {repo.watchers_count}
+                          </span>
+                        </div>
+                      </div>
+                      <div className="text-xs text-gray-600 dark:text-gray-400">
+                        {repo.open_issues_count} issues
+                      </div>
+                    </>
+                  )}
                 </div>
               </motion.div>
             ))}
@@ -375,19 +439,44 @@ const RepositoryHive = () => {
           </motion.div>
         )}
 
-        {/* Results Count */}
+        {/* Results Count + Pagination */}
         {!loading && repositories.length > 0 && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            className="mt-8 text-center text-gray-600 dark:text-gray-400"
+            className="mt-8 flex flex-col items-center gap-4 text-gray-600 dark:text-gray-400"
           >
             <p>
               Showing {repositories.length}{" "}
               {showingIssueBackedResults
                 ? "repositories with open labelled issues"
                 : "repositories"}
+              {pageInfo.totalCount > 0
+                ? ` · page ${pageInfo.currentPage} of ${pageInfo.totalPages}`
+                : ""}
             </p>
+            {(pageInfo.hasPrevPage || pageInfo.hasNextPage) && (
+              <div className="flex items-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={!pageInfo.hasPrevPage || loading}
+                  className="inline-flex items-center gap-1 px-4 py-2 rounded-lg border border-gray-300 dark:border-white/10 text-sm font-medium disabled:opacity-40 hover:border-violet-400"
+                >
+                  <ChevronLeft size={16} />
+                  Previous
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={!pageInfo.hasNextPage || loading}
+                  className="inline-flex items-center gap-1 px-4 py-2 rounded-lg border border-gray-300 dark:border-white/10 text-sm font-medium disabled:opacity-40 hover:border-violet-400"
+                >
+                  Next
+                  <ChevronRight size={16} />
+                </button>
+              </div>
+            )}
           </motion.div>
         )}
       </div>

--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import {
   Search,
   Github,
@@ -26,6 +26,13 @@ import {
 } from "../../utils/repositoryHiveSearch";
 
 const PER_PAGE = 30;
+const EMPTY_PAGE_INFO = {
+  totalCount: 0,
+  currentPage: 1,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPrevPage: false,
+};
 
 const RepositoryHive = () => {
   const [selectedFilters, setSelectedFilters] = useState(["good-first-issue"]);
@@ -35,13 +42,8 @@ const RepositoryHive = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("stars");
   const [page, setPage] = useState(1);
-  const [pageInfo, setPageInfo] = useState({
-    totalCount: 0,
-    currentPage: 1,
-    totalPages: 1,
-    hasNextPage: false,
-    hasPrevPage: false,
-  });
+  const [pageInfo, setPageInfo] = useState(EMPTY_PAGE_INFO);
+  const abortRef = useRef(null);
 
   const showingIssueBackedResults = usesIssueLabelSearch(selectedFilters);
   const sortOptions = showingIssueBackedResults
@@ -49,6 +51,10 @@ const RepositoryHive = () => {
     : REPOSITORY_SORT_OPTIONS;
 
   const fetchRepositories = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
     setLoading(true);
     setError("");
 
@@ -62,14 +68,9 @@ const RepositoryHive = () => {
       });
 
       if (!url) {
+        if (controller.signal.aborted) return;
         setRepositories([]);
-        setPageInfo({
-          totalCount: 0,
-          currentPage: 1,
-          totalPages: 1,
-          hasNextPage: false,
-          hasPrevPage: false,
-        });
+        setPageInfo(EMPTY_PAGE_INFO);
         setLoading(false);
         return;
       }
@@ -78,6 +79,7 @@ const RepositoryHive = () => {
         headers: {
           Accept: "application/vnd.github.v3+json",
         },
+        signal: controller.signal,
       });
 
       if (!response.ok) {
@@ -85,21 +87,30 @@ const RepositoryHive = () => {
       }
 
       const data = await response.json();
+      if (controller.signal.aborted) return;
+
       setRepositories(normalizeSearchResponse(selectedFilters, data));
       setPageInfo(getSearchPageInfo(data, page, PER_PAGE));
     } catch (err) {
+      if (err?.name === "AbortError" || controller.signal.aborted) return;
       setError(
         err.message || "Failed to fetch repositories. Please try again later.",
       );
       setRepositories([]);
+      setPageInfo(EMPTY_PAGE_INFO);
     } finally {
-      setLoading(false);
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
     }
   }, [selectedFilters, searchQuery, sortBy, page]);
 
   // Auto-fetch on filter/sort/page; search text applies only via Search / Enter.
   useEffect(() => {
     fetchRepositories();
+    return () => {
+      abortRef.current?.abort();
+    };
     // intentionally omit searchQuery — typing should not hit GitHub until Search
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedFilters, sortBy, page]);

--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -8,29 +8,15 @@ import {
   Code,
   Loader,
   AlertCircle,
+  ExternalLink,
 } from "lucide-react";
 import { motion } from "framer-motion";
-
-const FILTER_OPTIONS = [
-  {
-    id: "good-first-issue",
-    label: "Good First Issue",
-    topic: "good-first-issue",
-  },
-  {
-    id: "beginner-friendly",
-    label: "Beginner Friendly",
-    topic: "beginner-friendly",
-  },
-  { id: "documentation", label: "Documentation", topic: "documentation" },
-  { id: "bug-fix", label: "Bug Fix", topic: "bug-fix" },
-  { id: "feature", label: "Feature Request", topic: "feature" },
-  { id: "open-source", label: "Open Source", topic: "open-source" },
-  { id: "hacktoberfest", label: "Hacktoberfest", topic: "hacktoberfest" },
-  { id: "python", label: "Python", topic: "language:python" },
-  { id: "javascript", label: "JavaScript", topic: "language:javascript" },
-  { id: "java", label: "Java", topic: "language:java" },
-];
+import {
+  FILTER_OPTIONS,
+  buildGitHubSearchUrl,
+  normalizeSearchResponse,
+  usesIssueLabelSearch,
+} from "../../utils/repositoryHiveSearch";
 
 const RepositoryHive = () => {
   const [selectedFilters, setSelectedFilters] = useState(["good-first-issue"]);
@@ -49,34 +35,17 @@ const RepositoryHive = () => {
     setError("");
 
     try {
-      let queryParams = [];
-
-      // Build query with selected filters
-      selectedFilters.forEach((filter) => {
-        const option = FILTER_OPTIONS.find((f) => f.id === filter);
-        if (option) {
-          queryParams.push(option.topic);
-        }
+      const url = buildGitHubSearchUrl({
+        selectedFilters,
+        searchQuery,
+        sortBy,
       });
 
-      if (searchQuery.trim()) {
-        queryParams.push(searchQuery.trim());
-      }
-
-      const query = queryParams.join(" ").trim();
-      if (!query) {
+      if (!url) {
         setRepositories([]);
         setLoading(false);
         return;
       }
-
-      const sortMap = {
-        stars: "sort=stars&order=desc",
-        recent: "sort=updated&order=desc",
-        forks: "sort=forks&order=desc",
-      };
-
-      const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&${sortMap[sortBy]}&per_page=30`;
 
       const response = await fetch(url, {
         headers: {
@@ -89,7 +58,7 @@ const RepositoryHive = () => {
       }
 
       const data = await response.json();
-      setRepositories(data.items || []);
+      setRepositories(normalizeSearchResponse(selectedFilters, data));
     } catch (err) {
       setError(
         err.message || "Failed to fetch repositories. Please try again later.",
@@ -117,6 +86,8 @@ const RepositoryHive = () => {
       fetchRepositories();
     }
   };
+
+  const showingIssueBackedResults = usesIssueLabelSearch(selectedFilters);
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-[#0f172a]">
@@ -158,7 +129,7 @@ const RepositoryHive = () => {
                 value={searchQuery}
                 onChange={handleSearchChange}
                 onKeyPress={(e) => e.key === "Enter" && handleSearch()}
-                placeholder="Search repositories (e.g., react, django, kubernetes)..."
+                placeholder="Search repositories (e.g., react, django, tensorflow)..."
                 className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-white/5 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-violet-500"
               />
             </div>
@@ -251,7 +222,9 @@ const RepositoryHive = () => {
               className="text-violet-600 dark:text-violet-400 animate-spin mb-4"
             />
             <p className="text-gray-600 dark:text-gray-400">
-              Loading repositories...
+              {showingIssueBackedResults
+                ? "Looking for open labelled issues..."
+                : "Loading repositories..."}
             </p>
           </div>
         )}
@@ -265,11 +238,8 @@ const RepositoryHive = () => {
             className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
           >
             {repositories.map((repo, index) => (
-              <motion.a
+              <motion.div
                 key={repo.id}
-                href={repo.html_url}
-                target="_blank"
-                rel="noreferrer"
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ duration: 0.3, delay: index * 0.05 }}
@@ -283,9 +253,14 @@ const RepositoryHive = () => {
                       className="text-violet-600 dark:text-violet-400 flex-shrink-0"
                     />
                     <div className="flex-1 min-w-0">
-                      <h3 className="text-base font-bold text-gray-900 dark:text-white truncate group-hover:text-violet-600 dark:group-hover:text-violet-400 transition-colors">
+                      <a
+                        href={repo.html_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-base font-bold text-gray-900 dark:text-white truncate group-hover:text-violet-600 dark:group-hover:text-violet-400 transition-colors block"
+                      >
                         {repo.name}
-                      </h3>
+                      </a>
                       <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
                         {repo.owner.login}
                       </p>
@@ -295,6 +270,31 @@ const RepositoryHive = () => {
                     {repo.description || "No description available"}
                   </p>
                 </div>
+
+                {repo.matchingIssue && (
+                  <a
+                    href={repo.matchingIssue.html_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mb-4 block rounded-lg border border-violet-500/30 bg-violet-500/5 px-3 py-2 hover:bg-violet-500/10 transition-colors"
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="text-[10px] font-bold uppercase tracking-wide text-violet-500 mb-1">
+                          Open starter issue
+                        </p>
+                        <p className="text-sm font-semibold text-gray-900 dark:text-white line-clamp-2">
+                          #{repo.matchingIssue.number} {repo.matchingIssue.title}
+                        </p>
+                      </div>
+                      <ExternalLink
+                        size={14}
+                        className="text-violet-500 flex-shrink-0 mt-1"
+                      />
+                    </div>
+                  </a>
+                )}
 
                 {/* Language & Topics */}
                 <div className="mb-4 flex-1">
@@ -351,7 +351,7 @@ const RepositoryHive = () => {
                     {repo.open_issues_count} issues
                   </div>
                 </div>
-              </motion.a>
+              </motion.div>
             ))}
           </motion.div>
         )}
@@ -368,7 +368,9 @@ const RepositoryHive = () => {
               className="mx-auto text-gray-400 dark:text-gray-600 mb-4"
             />
             <p className="text-gray-600 dark:text-gray-400 text-lg">
-              No repositories found. Try adjusting your filters or search query.
+              {showingIssueBackedResults
+                ? "No open issues found for the selected labels. Try another filter or search term."
+                : "No repositories found. Try adjusting your filters or search query."}
             </p>
           </motion.div>
         )}
@@ -380,7 +382,12 @@ const RepositoryHive = () => {
             animate={{ opacity: 1 }}
             className="mt-8 text-center text-gray-600 dark:text-gray-400"
           >
-            <p>Showing {repositories.length} repositories</p>
+            <p>
+              Showing {repositories.length}{" "}
+              {showingIssueBackedResults
+                ? "repositories with open labelled issues"
+                : "repositories"}
+            </p>
           </motion.div>
         )}
       </div>

--- a/frontend/src/utils/repositoryHiveSearch.js
+++ b/frontend/src/utils/repositoryHiveSearch.js
@@ -1,0 +1,185 @@
+const ISSUE_LABEL_FILTERS = {
+  "good-first-issue": ['"good first issue"', "good-first-issue"],
+  "beginner-friendly": ['"beginner friendly"', "beginner-friendly", "beginner"],
+  "bug-fix": ["bug"],
+  documentation: ["documentation"],
+  feature: ["enhancement", "feature"],
+};
+
+const TOPIC_OR_LANGUAGE_FILTERS = {
+  "open-source": "topic:open-source",
+  hacktoberfest: "topic:hacktoberfest",
+  python: "language:python",
+  javascript: "language:javascript",
+  java: "language:java",
+};
+
+export const FILTER_OPTIONS = [
+  {
+    id: "good-first-issue",
+    label: "Good First Issue",
+    topic: "good-first-issue",
+  },
+  {
+    id: "beginner-friendly",
+    label: "Beginner Friendly",
+    topic: "beginner-friendly",
+  },
+  { id: "documentation", label: "Documentation", topic: "documentation" },
+  { id: "bug-fix", label: "Bug Fix", topic: "bug-fix" },
+  { id: "feature", label: "Feature Request", topic: "feature" },
+  { id: "open-source", label: "Open Source", topic: "open-source" },
+  { id: "hacktoberfest", label: "Hacktoberfest", topic: "hacktoberfest" },
+  { id: "python", label: "Python", topic: "language:python" },
+  { id: "javascript", label: "JavaScript", topic: "language:javascript" },
+  { id: "java", label: "Java", topic: "language:java" },
+];
+
+const SORT_MAP = {
+  stars: "sort=stars&order=desc",
+  recent: "sort=updated&order=desc",
+  forks: "sort=forks&order=desc",
+};
+
+const ISSUE_SORT_MAP = {
+  stars: "sort=reactions&order=desc",
+  recent: "sort=updated&order=desc",
+  forks: "sort=comments&order=desc",
+};
+
+export const usesIssueLabelSearch = (selectedFilters = []) =>
+  selectedFilters.some((id) => Boolean(ISSUE_LABEL_FILTERS[id]));
+
+export const buildRepositorySearchQuery = (selectedFilters = [], searchQuery = "") => {
+  const parts = [];
+
+  selectedFilters.forEach((filterId) => {
+    if (ISSUE_LABEL_FILTERS[filterId]) return;
+    if (TOPIC_OR_LANGUAGE_FILTERS[filterId]) {
+      parts.push(TOPIC_OR_LANGUAGE_FILTERS[filterId]);
+      return;
+    }
+    const option = FILTER_OPTIONS.find((f) => f.id === filterId);
+    if (option?.topic) parts.push(option.topic);
+  });
+
+  if (searchQuery.trim()) parts.push(searchQuery.trim());
+  return parts.join(" ").trim();
+};
+
+export const buildIssueSearchQuery = (selectedFilters = [], searchQuery = "") => {
+  const parts = ["is:issue", "is:open"];
+
+  selectedFilters.forEach((filterId) => {
+    const labels = ISSUE_LABEL_FILTERS[filterId];
+    if (labels) {
+      if (labels.length === 1) {
+        parts.push(`label:${labels[0]}`);
+      } else {
+        parts.push(`(${labels.map((label) => `label:${label}`).join(" OR ")})`);
+      }
+      return;
+    }
+    if (TOPIC_OR_LANGUAGE_FILTERS[filterId]) {
+      parts.push(TOPIC_OR_LANGUAGE_FILTERS[filterId]);
+    }
+  });
+
+  if (searchQuery.trim()) parts.push(searchQuery.trim());
+  return parts.join(" ").trim();
+};
+
+export const parseRepoFromIssue = (issue) => {
+  const htmlUrl = issue.html_url || "";
+  const match = htmlUrl.match(/github\.com\/([^/]+)\/([^/]+)\//);
+  if (match) {
+    return { owner: match[1], name: match[2], fullName: `${match[1]}/${match[2]}` };
+  }
+
+  const repoUrl = issue.repository_url || "";
+  const apiMatch = repoUrl.match(/repos\/([^/]+)\/([^/]+)$/);
+  if (apiMatch) {
+    return {
+      owner: apiMatch[1],
+      name: apiMatch[2],
+      fullName: `${apiMatch[1]}/${apiMatch[2]}`,
+    };
+  }
+
+  return null;
+};
+
+/**
+ * Group open labelled issues by repository and keep the first match per repo.
+ * Metadata-only repo hits are excluded because every card comes from a real open issue.
+ */
+export const groupIssuesByRepository = (issues = []) => {
+  const repos = new Map();
+
+  for (const issue of issues) {
+    if (issue.pull_request) continue;
+    if (issue.state && issue.state !== "open") continue;
+
+    const parsed = parseRepoFromIssue(issue);
+    if (!parsed) continue;
+
+    if (repos.has(parsed.fullName)) continue;
+
+    const labels = (issue.labels || [])
+      .map((label) => (typeof label === "string" ? label : label?.name))
+      .filter(Boolean);
+
+    repos.set(parsed.fullName, {
+      id: `${parsed.fullName}-${issue.id}`,
+      name: parsed.name,
+      full_name: parsed.fullName,
+      html_url: `https://github.com/${parsed.fullName}`,
+      description: issue.body
+        ? String(issue.body).replace(/\s+/g, " ").slice(0, 160)
+        : null,
+      owner: { login: parsed.owner },
+      language: null,
+      topics: labels.slice(0, 5),
+      stargazers_count: issue.reactions?.total_count ?? 0,
+      forks_count: 0,
+      watchers_count: 0,
+      open_issues_count: 1,
+      matchingIssue: {
+        id: issue.id,
+        number: issue.number,
+        title: issue.title,
+        html_url: issue.html_url,
+        labels,
+      },
+      updated_at: issue.updated_at,
+    });
+  }
+
+  return Array.from(repos.values());
+};
+
+export const buildGitHubSearchUrl = ({
+  selectedFilters = [],
+  searchQuery = "",
+  sortBy = "stars",
+  perPage = 30,
+} = {}) => {
+  if (usesIssueLabelSearch(selectedFilters)) {
+    const query = buildIssueSearchQuery(selectedFilters, searchQuery);
+    if (!query) return null;
+    const sort = ISSUE_SORT_MAP[sortBy] || ISSUE_SORT_MAP.recent;
+    return `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}`;
+  }
+
+  const query = buildRepositorySearchQuery(selectedFilters, searchQuery);
+  if (!query) return null;
+  const sort = SORT_MAP[sortBy] || SORT_MAP.stars;
+  return `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}`;
+};
+
+export const normalizeSearchResponse = (selectedFilters, data) => {
+  if (usesIssueLabelSearch(selectedFilters)) {
+    return groupIssuesByRepository(data?.items || []);
+  }
+  return data?.items || [];
+};

--- a/frontend/src/utils/repositoryHiveSearch.js
+++ b/frontend/src/utils/repositoryHiveSearch.js
@@ -47,6 +47,18 @@ const ISSUE_SORT_MAP = {
   forks: "sort=comments&order=desc",
 };
 
+export const REPOSITORY_SORT_OPTIONS = [
+  { id: "stars", label: "Most Stars" },
+  { id: "recent", label: "Recently Updated" },
+  { id: "forks", label: "Most Forks" },
+];
+
+export const ISSUE_SORT_OPTIONS = [
+  { id: "stars", label: "Most Reactions" },
+  { id: "recent", label: "Recently Updated" },
+  { id: "forks", label: "Most Comments" },
+];
+
 export const usesIssueLabelSearch = (selectedFilters = []) =>
   selectedFilters.some((id) => Boolean(ISSUE_LABEL_FILTERS[id]));
 
@@ -111,7 +123,7 @@ export const parseRepoFromIssue = (issue) => {
 
 /**
  * Group open labelled issues by repository and keep the first match per repo.
- * Metadata-only repo hits are excluded because every card comes from a real open issue.
+ * Cards expose issue metrics (reactions/comments), not fake repository stats.
  */
 export const groupIssuesByRepository = (issues = []) => {
   const repos = new Map();
@@ -129,6 +141,9 @@ export const groupIssuesByRepository = (issues = []) => {
       .map((label) => (typeof label === "string" ? label : label?.name))
       .filter(Boolean);
 
+    const reactions = issue.reactions?.total_count ?? 0;
+    const comments = issue.comments ?? 0;
+
     repos.set(parsed.fullName, {
       id: `${parsed.fullName}-${issue.id}`,
       name: parsed.name,
@@ -140,16 +155,18 @@ export const groupIssuesByRepository = (issues = []) => {
       owner: { login: parsed.owner },
       language: null,
       topics: labels.slice(0, 5),
-      stargazers_count: issue.reactions?.total_count ?? 0,
-      forks_count: 0,
-      watchers_count: 0,
-      open_issues_count: 1,
+      // Issue-backed metrics — UI must not label these as repo stars/forks.
+      metricsMode: "issue",
+      reactions_count: reactions,
+      comments_count: comments,
       matchingIssue: {
         id: issue.id,
         number: issue.number,
         title: issue.title,
         html_url: issue.html_url,
         labels,
+        reactions_count: reactions,
+        comments_count: comments,
       },
       updated_at: issue.updated_at,
     });
@@ -163,23 +180,43 @@ export const buildGitHubSearchUrl = ({
   searchQuery = "",
   sortBy = "stars",
   perPage = 30,
+  page = 1,
 } = {}) => {
+  const safePage = Math.max(1, Number(page) || 1);
+
   if (usesIssueLabelSearch(selectedFilters)) {
     const query = buildIssueSearchQuery(selectedFilters, searchQuery);
     if (!query) return null;
     const sort = ISSUE_SORT_MAP[sortBy] || ISSUE_SORT_MAP.recent;
-    return `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}`;
+    return `https://api.github.com/search/issues?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}&page=${safePage}`;
   }
 
   const query = buildRepositorySearchQuery(selectedFilters, searchQuery);
   if (!query) return null;
   const sort = SORT_MAP[sortBy] || SORT_MAP.stars;
-  return `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}`;
+  return `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&${sort}&per_page=${perPage}&page=${safePage}`;
 };
 
 export const normalizeSearchResponse = (selectedFilters, data) => {
   if (usesIssueLabelSearch(selectedFilters)) {
     return groupIssuesByRepository(data?.items || []);
   }
-  return data?.items || [];
+  return (data?.items || []).map((repo) => ({
+    ...repo,
+    metricsMode: "repository",
+  }));
+};
+
+/** GitHub search caps total_count reporting at 1000 results. */
+export const getSearchPageInfo = (data, page = 1, perPage = 30) => {
+  const totalCount = Math.min(Number(data?.total_count) || 0, 1000);
+  const currentPage = Math.max(1, Number(page) || 1);
+  const totalPages = Math.max(1, Math.ceil(totalCount / perPage) || 1);
+  return {
+    totalCount,
+    currentPage,
+    totalPages,
+    hasNextPage: currentPage < totalPages,
+    hasPrevPage: currentPage > 1,
+  };
 };

--- a/frontend/src/utils/repositoryHiveSearch.unit.test.js
+++ b/frontend/src/utils/repositoryHiveSearch.unit.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildGitHubSearchUrl,
   buildIssueSearchQuery,
+  getSearchPageInfo,
   groupIssuesByRepository,
   normalizeSearchResponse,
   usesIssueLabelSearch,
@@ -20,6 +21,23 @@ describe("repositoryHiveSearch", () => {
     expect(decodeURIComponent(url)).toContain('label:"good first issue"');
     expect(decodeURIComponent(url)).toContain("is:open");
     expect(decodeURIComponent(url)).toContain("is:issue");
+    expect(url).toContain("page=1");
+  });
+
+  it("includes page in issue and repository search URLs", () => {
+    const issueUrl = buildGitHubSearchUrl({
+      selectedFilters: ["good-first-issue"],
+      page: 3,
+      perPage: 30,
+    });
+    expect(issueUrl).toContain("page=3");
+    expect(issueUrl).toContain("per_page=30");
+
+    const repoUrl = buildGitHubSearchUrl({
+      selectedFilters: ["python"],
+      page: 2,
+    });
+    expect(repoUrl).toContain("page=2");
   });
 
   it("keeps non-label filters on the repositories search API", () => {
@@ -44,6 +62,7 @@ describe("repositoryHiveSearch", () => {
         state: "open",
         labels: [{ name: "good first issue" }],
         reactions: { total_count: 3 },
+        comments: 7,
       },
       {
         id: 2,
@@ -67,6 +86,10 @@ describe("repositoryHiveSearch", () => {
 
     expect(grouped).toHaveLength(1);
     expect(grouped[0].full_name).toBe("acme/alpha");
+    expect(grouped[0].metricsMode).toBe("issue");
+    expect(grouped[0].reactions_count).toBe(3);
+    expect(grouped[0].comments_count).toBe(7);
+    expect(grouped[0].stargazers_count).toBeUndefined();
     expect(grouped[0].matchingIssue).toEqual(
       expect.objectContaining({
         number: 10,
@@ -102,5 +125,45 @@ describe("repositoryHiveSearch", () => {
     expect(normalizeSearchResponse(["good-first-issue"], { items: [] })).toEqual(
       [],
     );
+  });
+
+  it("computes pagination for later pages and duplicate-repo grouping", () => {
+    const pageInfo = getSearchPageInfo({ total_count: 95 }, 2, 30);
+    expect(pageInfo).toMatchObject({
+      totalCount: 95,
+      currentPage: 2,
+      totalPages: 4,
+      hasNextPage: true,
+      hasPrevPage: true,
+    });
+
+    // Two issues on the same repo collapse to one card for that page.
+    const pageItems = groupIssuesByRepository([
+      {
+        id: 1,
+        number: 1,
+        title: "First",
+        html_url: "https://github.com/acme/one/issues/1",
+        state: "open",
+        labels: [{ name: "good first issue" }],
+      },
+      {
+        id: 2,
+        number: 2,
+        title: "Second same repo",
+        html_url: "https://github.com/acme/one/issues/2",
+        state: "open",
+        labels: [{ name: "good first issue" }],
+      },
+      {
+        id: 3,
+        number: 3,
+        title: "Other repo",
+        html_url: "https://github.com/acme/two/issues/3",
+        state: "open",
+        labels: [{ name: "good first issue" }],
+      },
+    ]);
+    expect(pageItems).toHaveLength(2);
   });
 });

--- a/frontend/src/utils/repositoryHiveSearch.unit.test.js
+++ b/frontend/src/utils/repositoryHiveSearch.unit.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildGitHubSearchUrl,
+  buildIssueSearchQuery,
+  groupIssuesByRepository,
+  normalizeSearchResponse,
+  usesIssueLabelSearch,
+} from "./repositoryHiveSearch";
+
+describe("repositoryHiveSearch", () => {
+  it("routes Good First Issue through the issues search API", () => {
+    expect(usesIssueLabelSearch(["good-first-issue"])).toBe(true);
+
+    const url = buildGitHubSearchUrl({
+      selectedFilters: ["good-first-issue"],
+      sortBy: "recent",
+    });
+
+    expect(url).toContain("https://api.github.com/search/issues?");
+    expect(decodeURIComponent(url)).toContain('label:"good first issue"');
+    expect(decodeURIComponent(url)).toContain("is:open");
+    expect(decodeURIComponent(url)).toContain("is:issue");
+  });
+
+  it("keeps non-label filters on the repositories search API", () => {
+    const url = buildGitHubSearchUrl({
+      selectedFilters: ["python"],
+      searchQuery: "django",
+      sortBy: "stars",
+    });
+
+    expect(url).toContain("https://api.github.com/search/repositories?");
+    expect(decodeURIComponent(url)).toContain("language:python");
+    expect(decodeURIComponent(url)).toContain("django");
+  });
+
+  it("ignores metadata-only repository matches by requiring open labelled issues", () => {
+    const issues = [
+      {
+        id: 1,
+        number: 10,
+        title: "Add docs for beginners",
+        html_url: "https://github.com/acme/alpha/issues/10",
+        state: "open",
+        labels: [{ name: "good first issue" }],
+        reactions: { total_count: 3 },
+      },
+      {
+        id: 2,
+        number: 11,
+        title: "Closed starter task",
+        html_url: "https://github.com/acme/beta/issues/11",
+        state: "closed",
+        labels: [{ name: "good first issue" }],
+      },
+      {
+        id: 3,
+        number: 12,
+        title: "Another starter in alpha",
+        html_url: "https://github.com/acme/alpha/issues/12",
+        state: "open",
+        labels: [{ name: "good first issue" }],
+      },
+    ];
+
+    const grouped = groupIssuesByRepository(issues);
+
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].full_name).toBe("acme/alpha");
+    expect(grouped[0].matchingIssue).toEqual(
+      expect.objectContaining({
+        number: 10,
+        title: "Add docs for beginners",
+        html_url: "https://github.com/acme/alpha/issues/10",
+      }),
+    );
+  });
+
+  it("skips pull requests and supports multiple label variants", () => {
+    const query = buildIssueSearchQuery(["good-first-issue", "python"], "help");
+    expect(query).toContain("language:python");
+    expect(query).toContain("help");
+    expect(query).toContain('label:"good first issue"');
+    expect(query).toContain("label:good-first-issue");
+
+    const grouped = groupIssuesByRepository([
+      {
+        id: 9,
+        number: 9,
+        title: "PR disguised as issue",
+        html_url: "https://github.com/acme/gamma/pull/9",
+        state: "open",
+        pull_request: { url: "https://api.github.com/repos/acme/gamma/pulls/9" },
+        labels: [{ name: "good first issue" }],
+      },
+    ]);
+
+    expect(grouped).toHaveLength(0);
+  });
+
+  it("returns an empty list for a clear no-results state", () => {
+    expect(normalizeSearchResponse(["good-first-issue"], { items: [] })).toEqual(
+      [],
+    );
+  });
+});


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #932

### Summary
Good First Issue was searching `search/repositories` with a topic token, so metadata matches showed up even with no open starter issue. Label filters now hit `search/issues` (`is:open` + label variants), results are grouped by repo, and each card links the matching issue. Empty state covers the no-open-issue case.

---

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Other(please describe) ______

---

### How Has This Been Tested?
- `vitest run src/utils/repositoryHiveSearch.unit.test.js` (5 passing)
- Covers issue vs repo routing, closed/PR exclusion, multi-label variants, empty results

### Screenshots (if applicable)
N/A

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes the Good First Issue filter by searching GitHub’s open issues instead of repository metadata.

- Uses `search/issues` with `is:open` and label variants.
- Excludes closed issues and pull requests.
- Groups matching issues by repository.
- Links repository cards to matching starter issues.
- Displays issue reactions and comments instead of fabricated repository statistics.
- Cancels stale searches when filters, sorting, pages, or new searches change.
- Supports pagination and navigation controls.
- Uses repository search for non-label filters.
- Shows an empty state when no matching issues exist.
- Adds utilities and Vitest coverage for routing, filtering, grouping, pagination, duplicate repositories, and empty results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->