### PR TITLE
fix(hive): keep stale results when GitHub search is rate-limited

### DIFF
--- a/backend/controllers/githubSearchController.js
+++ b/backend/controllers/githubSearchController.js
@@ -1,0 +1,200 @@
+const axios = require("axios");
+const NodeCache = require("node-cache");
+
+const CACHE_TTL_SECONDS = 90;
+const STALE_TTL_SECONDS = 60 * 30;
+const searchCache = new NodeCache({
+  stdTTL: STALE_TTL_SECONDS,
+  checkperiod: 60,
+  useClones: false,
+});
+
+const ALLOWED_TYPES = new Set(["repositories", "issues"]);
+
+const buildCacheKey = ({ type, q, sort, order, per_page }) =>
+  `${type}|${q}|${sort}|${order}|${per_page}`;
+
+const parseRateLimit = (headers = {}) => {
+  const remaining = headers["x-ratelimit-remaining"];
+  const limit = headers["x-ratelimit-limit"];
+  const reset = headers["x-ratelimit-reset"];
+  const retryAfter = headers["retry-after"];
+
+  return {
+    remaining: remaining !== undefined ? Number(remaining) : null,
+    limit: limit !== undefined ? Number(limit) : null,
+    resetAt: reset ? new Date(Number(reset) * 1000).toISOString() : null,
+    retryAfterSeconds: retryAfter !== undefined ? Number(retryAfter) : null,
+  };
+};
+
+const isRecoverableStatus = (status) =>
+  status === 403 || status === 429 || status >= 500;
+
+const fetchGitHubSearch = async ({ type, q, sort, order, per_page }) => {
+  const url = `https://api.github.com/search/${type}`;
+  const headers = {
+    Accept: "application/vnd.github.v3+json",
+    "User-Agent": "PrepPilot-RepositoryHive",
+  };
+
+  if (process.env.GITHUB_TOKEN) {
+    headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await axios.get(url, {
+    params: { q, sort, order, per_page },
+    headers,
+    validateStatus: () => true,
+    timeout: 15000,
+  });
+
+  return response;
+};
+
+/**
+ * @desc Proxied GitHub search with short-lived shared cache and stale fallback
+ * @route GET /api/github/search
+ * @access Public
+ */
+const searchGitHub = async (req, res) => {
+  try {
+    const type = String(req.query.type || "repositories").toLowerCase();
+    const q = String(req.query.q || "").trim();
+    const sort = String(req.query.sort || "stars");
+    const order = String(req.query.order || "desc");
+    const per_page = Math.min(
+      Math.max(Number(req.query.per_page) || 30, 1),
+      30,
+    );
+
+    if (!ALLOWED_TYPES.has(type)) {
+      return res.status(400).json({
+        success: false,
+        message: 'type must be "repositories" or "issues"',
+      });
+    }
+
+    if (!q) {
+      return res.status(400).json({
+        success: false,
+        message: "q is required",
+      });
+    }
+
+    const cacheKey = buildCacheKey({ type, q, sort, order, per_page });
+    const cached = searchCache.get(cacheKey);
+    const cacheAgeMs = cached
+      ? Date.now() - new Date(cached.fetchedAt).getTime()
+      : null;
+    const cacheIsFresh =
+      cached && cacheAgeMs !== null && cacheAgeMs < CACHE_TTL_SECONDS * 1000;
+
+    if (cacheIsFresh) {
+      return res.status(200).json({
+        success: true,
+        stale: false,
+        fromCache: true,
+        rateLimit: cached.rateLimit || null,
+        items: cached.items,
+        total_count: cached.total_count,
+        fetchedAt: cached.fetchedAt,
+      });
+    }
+
+    const response = await fetchGitHubSearch({
+      type,
+      q,
+      sort,
+      order,
+      per_page,
+    });
+    const rateLimit = parseRateLimit(response.headers);
+
+    if (response.status >= 200 && response.status < 300) {
+      const payload = {
+        items: response.data?.items || [],
+        total_count: response.data?.total_count || 0,
+        rateLimit,
+        fetchedAt: new Date().toISOString(),
+      };
+      searchCache.set(cacheKey, payload);
+
+      return res.status(200).json({
+        success: true,
+        stale: false,
+        fromCache: false,
+        rateLimit,
+        items: payload.items,
+        total_count: payload.total_count,
+        fetchedAt: payload.fetchedAt,
+      });
+    }
+
+    if (cached && isRecoverableStatus(response.status)) {
+      return res.status(200).json({
+        success: true,
+        stale: true,
+        fromCache: true,
+        rateLimit,
+        items: cached.items,
+        total_count: cached.total_count,
+        fetchedAt: cached.fetchedAt,
+        warning:
+          response.status === 429 || response.status === 403
+            ? "GitHub rate limit hit. Showing last successful results."
+            : "GitHub search is temporarily unavailable. Showing last successful results.",
+        upstreamStatus: response.status,
+      });
+    }
+
+    return res.status(response.status === 403 || response.status === 429 ? 429 : 502).json({
+      success: false,
+      stale: false,
+      rateLimit,
+      message:
+        response.status === 403 || response.status === 429
+          ? "GitHub rate limit exceeded. Please retry after the reset window."
+          : `GitHub API error: ${response.status}`,
+      upstreamStatus: response.status,
+      retryAfterSeconds: rateLimit.retryAfterSeconds,
+    });
+  } catch (error) {
+    const cachedKey = buildCacheKey({
+      type: String(req.query.type || "repositories").toLowerCase(),
+      q: String(req.query.q || "").trim(),
+      sort: String(req.query.sort || "stars"),
+      order: String(req.query.order || "desc"),
+      per_page: Math.min(Math.max(Number(req.query.per_page) || 30, 1), 30),
+    });
+    const cached = searchCache.get(cachedKey);
+
+    if (cached) {
+      return res.status(200).json({
+        success: true,
+        stale: true,
+        fromCache: true,
+        rateLimit: cached.rateLimit || null,
+        items: cached.items,
+        total_count: cached.total_count,
+        fetchedAt: cached.fetchedAt,
+        warning: "GitHub search failed. Showing last successful results.",
+      });
+    }
+
+    return res.status(502).json({
+      success: false,
+      message: "Failed to reach GitHub search",
+      error: "A server error occurred",
+    });
+  }
+};
+
+module.exports = {
+  searchGitHub,
+  buildCacheKey,
+  parseRateLimit,
+  isRecoverableStatus,
+  searchCache,
+  CACHE_TTL_SECONDS,
+};

--- a/backend/routes/githubSearchRoutes.js
+++ b/backend/routes/githubSearchRoutes.js
@@ -1,0 +1,7 @@
+const express = require("express");
+const router = express.Router();
+const { searchGitHub } = require("../controllers/githubSearchController");
+
+router.get("/search", searchGitHub);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -146,6 +146,8 @@ const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 const roadmapRoutes = require("./routes/roadmapRoutes");
 app.use("/api/roadmaps", roadmapRoutes);
+const githubSearchRoutes = require("./routes/githubSearchRoutes");
+app.use("/api/github", generalLimiter, githubSearchRoutes);
 
 
 app.use(

--- a/backend/tests/githubSearchController.unit.test.js
+++ b/backend/tests/githubSearchController.unit.test.js
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("axios");
+
+const axios = require("axios");
+const {
+  searchGitHub,
+  searchCache,
+  buildCacheKey,
+  parseRateLimit,
+  isRecoverableStatus,
+} = require("../controllers/githubSearchController.js");
+
+function makeReq(query = {}) {
+  return { query };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("githubSearch helpers", () => {
+  it("detects recoverable upstream statuses", () => {
+    expect(isRecoverableStatus(403)).toBe(true);
+    expect(isRecoverableStatus(429)).toBe(true);
+    expect(isRecoverableStatus(503)).toBe(true);
+    expect(isRecoverableStatus(400)).toBe(false);
+  });
+
+  it("parses rate-limit headers including retry-after", () => {
+    const info = parseRateLimit({
+      "x-ratelimit-remaining": "0",
+      "x-ratelimit-limit": "10",
+      "x-ratelimit-reset": "1700000000",
+      "retry-after": "60",
+    });
+
+    expect(info.remaining).toBe(0);
+    expect(info.limit).toBe(10);
+    expect(info.retryAfterSeconds).toBe(60);
+    expect(info.resetAt).toBe(new Date(1700000000 * 1000).toISOString());
+  });
+});
+
+describe("searchGitHub controller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    searchCache.flushAll();
+  });
+
+  it("caches successful repository searches", async () => {
+    axios.get = vi.fn().mockResolvedValue({
+      status: 200,
+      headers: { "x-ratelimit-remaining": "9", "x-ratelimit-limit": "10" },
+      data: { items: [{ id: 1, name: "repo" }], total_count: 1 },
+    });
+
+    const req = makeReq({
+      type: "repositories",
+      q: "good-first-issue",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    const res = makeRes();
+
+    await searchGitHub(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        success: true,
+        stale: false,
+        fromCache: false,
+        items: [{ id: 1, name: "repo" }],
+      }),
+    );
+
+    const key = buildCacheKey({
+      type: "repositories",
+      q: "good-first-issue",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    expect(searchCache.get(key)).toBeTruthy();
+  });
+
+  it("serves stale cache on 403/429 instead of wiping results", async () => {
+    const key = buildCacheKey({
+      type: "repositories",
+      q: "react",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    searchCache.set(key, {
+      items: [{ id: 7, name: "cached-repo" }],
+      total_count: 1,
+      rateLimit: { remaining: 1 },
+      fetchedAt: new Date(Date.now() - 120000).toISOString(),
+    });
+
+    axios.get = vi.fn().mockResolvedValue({
+      status: 403,
+      headers: {
+        "x-ratelimit-remaining": "0",
+        "retry-after": "45",
+      },
+      data: { message: "API rate limit exceeded" },
+    });
+
+    const req = makeReq({
+      type: "repositories",
+      q: "react",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    const res = makeRes();
+
+    await searchGitHub(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.stale).toBe(true);
+    expect(body.items[0].name).toBe("cached-repo");
+    expect(body.rateLimit.retryAfterSeconds).toBe(45);
+    expect(body.warning).toMatch(/rate limit/i);
+  });
+
+  it("returns 429 with retry timing when no cache exists", async () => {
+    axios.get = vi.fn().mockResolvedValue({
+      status: 429,
+      headers: { "retry-after": "30" },
+      data: {},
+    });
+
+    const req = makeReq({ q: "django", type: "repositories" });
+    const res = makeRes();
+
+    await searchGitHub(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(429);
+    expect(res.json.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        success: false,
+        retryAfterSeconds: 30,
+      }),
+    );
+  });
+
+  it("returns fresh cache hit without calling GitHub again", async () => {
+    const key = buildCacheKey({
+      type: "repositories",
+      q: "vite",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    searchCache.set(key, {
+      items: [{ id: 3, name: "vite" }],
+      total_count: 1,
+      rateLimit: { remaining: 8 },
+      fetchedAt: new Date().toISOString(),
+    });
+
+    axios.get = vi.fn();
+
+    const req = makeReq({
+      q: "vite",
+      type: "repositories",
+      sort: "stars",
+      order: "desc",
+      per_page: 30,
+    });
+    const res = makeRes();
+
+    await searchGitHub(req, res);
+
+    expect(axios.get).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].fromCache).toBe(true);
+    expect(res.json.mock.calls[0][0].stale).toBe(false);
+  });
+});

--- a/frontend/src/pages/OpenSource/RepositoryHive.jsx
+++ b/frontend/src/pages/OpenSource/RepositoryHive.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import {
   Search,
   Github,
@@ -10,6 +10,9 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { motion } from "framer-motion";
+import axiosInstance from "../../utils/axiosinstance";
+import { API_PATHS } from "../../utils/apiPaths";
+import { formatRetryMessage } from "../../utils/repositoryHiveRateLimit";
 
 const FILTER_OPTIONS = [
   {
@@ -32,73 +35,124 @@ const FILTER_OPTIONS = [
   { id: "java", label: "Java", topic: "language:java" },
 ];
 
+const SORT_QUERY = {
+  stars: { sort: "stars", order: "desc" },
+  recent: { sort: "updated", order: "desc" },
+  forks: { sort: "forks", order: "desc" },
+};
+
+const DEBOUNCE_MS = 400;
+
 const RepositoryHive = () => {
   const [selectedFilters, setSelectedFilters] = useState(["good-first-issue"]);
   const [repositories, setRepositories] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [warning, setWarning] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [sortBy, setSortBy] = useState("stars");
 
-  useEffect(() => {
-    fetchRepositories();
-  }, [selectedFilters, sortBy]);
+  const abortRef = useRef(null);
+  const requestSeqRef = useRef(0);
+  const debounceRef = useRef(null);
 
-  const fetchRepositories = async () => {
+  const fetchRepositories = useCallback(async () => {
+    const queryParams = [];
+
+    selectedFilters.forEach((filter) => {
+      const option = FILTER_OPTIONS.find((f) => f.id === filter);
+      if (option) queryParams.push(option.topic);
+    });
+
+    if (searchQuery.trim()) {
+      queryParams.push(searchQuery.trim());
+    }
+
+    const query = queryParams.join(" ").trim();
+    if (!query) {
+      setRepositories([]);
+      setError("");
+      setWarning("");
+      setLoading(false);
+      return;
+    }
+
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    const controller = new AbortController();
+    abortRef.current = controller;
+    const requestSeq = ++requestSeqRef.current;
+
     setLoading(true);
     setError("");
+    setWarning("");
 
     try {
-      let queryParams = [];
-
-      // Build query with selected filters
-      selectedFilters.forEach((filter) => {
-        const option = FILTER_OPTIONS.find((f) => f.id === filter);
-        if (option) {
-          queryParams.push(option.topic);
-        }
+      const sortConfig = SORT_QUERY[sortBy] || SORT_QUERY.stars;
+      const response = await axiosInstance.get(API_PATHS.GITHUB.SEARCH, {
+        params: {
+          type: "repositories",
+          q: query,
+          sort: sortConfig.sort,
+          order: sortConfig.order,
+          per_page: 30,
+        },
+        signal: controller.signal,
       });
 
-      if (searchQuery.trim()) {
-        queryParams.push(searchQuery.trim());
-      }
+      if (requestSeq !== requestSeqRef.current) return;
 
-      const query = queryParams.join(" ").trim();
-      if (!query) {
-        setRepositories([]);
-        setLoading(false);
+      const data = response.data || {};
+      setRepositories(data.items || []);
+
+      if (data.stale && data.warning) {
+        const retryHint = formatRetryMessage(
+          data.rateLimit?.retryAfterSeconds,
+          data.rateLimit?.resetAt,
+        );
+        setWarning(`${data.warning} ${retryHint}`);
+      } else {
+        setWarning("");
+      }
+    } catch (err) {
+      if (
+        err?.code === "ERR_CANCELED" ||
+        err?.name === "CanceledError" ||
+        err?.name === "AbortError"
+      ) {
         return;
       }
+      if (requestSeq !== requestSeqRef.current) return;
 
-      const sortMap = {
-        stars: "sort=stars&order=desc",
-        recent: "sort=updated&order=desc",
-        forks: "sort=forks&order=desc",
-      };
-
-      const url = `https://api.github.com/search/repositories?q=${encodeURIComponent(query)}&${sortMap[sortBy]}&per_page=30`;
-
-      const response = await fetch(url, {
-        headers: {
-          Accept: "application/vnd.github.v3+json",
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`GitHub API error: ${response.status}`);
-      }
-
-      const data = await response.json();
-      setRepositories(data.items || []);
-    } catch (err) {
-      setError(
-        err.message || "Failed to fetch repositories. Please try again later.",
+      const payload = err?.response?.data;
+      const retryHint = formatRetryMessage(
+        payload?.retryAfterSeconds ?? payload?.rateLimit?.retryAfterSeconds,
+        payload?.rateLimit?.resetAt,
       );
-      setRepositories([]);
+
+      setError(
+        `${payload?.message || err.message || "Failed to fetch repositories."} ${retryHint}`,
+      );
+      // Keep the last successful cards visible on recoverable refresh failures.
     } finally {
-      setLoading(false);
+      if (requestSeq === requestSeqRef.current) {
+        setLoading(false);
+      }
     }
-  };
+  }, [selectedFilters, searchQuery, sortBy]);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      fetchRepositories();
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      if (abortRef.current) abortRef.current.abort();
+    };
+  }, [fetchRepositories]);
 
   const toggleFilter = (filterId) => {
     setSelectedFilters((prev) =>
@@ -113,9 +167,7 @@ const RepositoryHive = () => {
   };
 
   const handleSearch = () => {
-    if (repositories.length > 0 || searchQuery) {
-      fetchRepositories();
-    }
+    fetchRepositories();
   };
 
   return (
@@ -158,7 +210,7 @@ const RepositoryHive = () => {
                 value={searchQuery}
                 onChange={handleSearchChange}
                 onKeyPress={(e) => e.key === "Enter" && handleSearch()}
-                placeholder="Search repositories (e.g., react, django, kubernetes)..."
+                placeholder="Search repositories (e.g., react, django, tensorflow)..."
                 className="w-full px-4 py-3 rounded-lg border border-gray-300 dark:border-white/10 bg-white dark:bg-white/5 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-violet-500"
               />
             </div>
@@ -239,12 +291,33 @@ const RepositoryHive = () => {
             />
             <div className="text-red-700 dark:text-red-400 text-sm">
               {error}
+              {repositories.length > 0 && (
+                <p className="mt-1 text-red-600/80 dark:text-red-300/80">
+                  Showing your last successful results meanwhile.
+                </p>
+              )}
+            </div>
+          </motion.div>
+        )}
+
+        {warning && !error && (
+          <motion.div
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="mb-6 p-4 bg-amber-50 dark:bg-amber-500/10 border border-amber-200 dark:border-amber-500/30 rounded-lg flex items-start gap-3"
+          >
+            <AlertCircle
+              size={20}
+              className="text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+            />
+            <div className="text-amber-800 dark:text-amber-300 text-sm">
+              {warning}
             </div>
           </motion.div>
         )}
 
         {/* Loading State */}
-        {loading && (
+        {loading && repositories.length === 0 && (
           <div className="flex flex-col items-center justify-center py-12">
             <Loader
               size={40}
@@ -256,8 +329,15 @@ const RepositoryHive = () => {
           </div>
         )}
 
+        {loading && repositories.length > 0 && (
+          <div className="mb-4 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <Loader size={16} className="animate-spin text-violet-500" />
+            Refreshing results...
+          </div>
+        )}
+
         {/* Repositories Grid */}
-        {!loading && repositories.length > 0 && (
+        {repositories.length > 0 && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -287,7 +367,7 @@ const RepositoryHive = () => {
                         {repo.name}
                       </h3>
                       <p className="text-xs text-gray-600 dark:text-gray-400 truncate">
-                        {repo.owner.login}
+                        {repo.owner?.login}
                       </p>
                     </div>
                   </div>
@@ -374,7 +454,7 @@ const RepositoryHive = () => {
         )}
 
         {/* Results Count */}
-        {!loading && repositories.length > 0 && (
+        {repositories.length > 0 && (
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -72,4 +72,7 @@ export const API_PATHS = {
         TOGGLE_TASK: (id) => `/api/roadmaps/${id}/tasks`,
         DELETE: (id) => `/api/roadmaps/${id}`,
     },
+    GITHUB: {
+        SEARCH: "/api/github/search",
+    },
 };

--- a/frontend/src/utils/repositoryHiveRateLimit.js
+++ b/frontend/src/utils/repositoryHiveRateLimit.js
@@ -1,0 +1,12 @@
+export const formatRetryMessage = (retryAfterSeconds, resetAt) => {
+  if (retryAfterSeconds && Number.isFinite(retryAfterSeconds)) {
+    return `Try again in about ${Math.max(1, Math.ceil(retryAfterSeconds))}s.`;
+  }
+  if (resetAt) {
+    const ms = new Date(resetAt).getTime() - Date.now();
+    if (ms > 0) {
+      return `Try again in about ${Math.max(1, Math.ceil(ms / 1000))}s.`;
+    }
+  }
+  return "Try again shortly.";
+};

--- a/frontend/src/utils/repositoryHiveRateLimit.unit.test.js
+++ b/frontend/src/utils/repositoryHiveRateLimit.unit.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { formatRetryMessage } from "./repositoryHiveRateLimit";
+
+describe("formatRetryMessage", () => {
+  it("prefers retry-after seconds when present", () => {
+    expect(formatRetryMessage(45, null)).toBe("Try again in about 45s.");
+  });
+
+  it("falls back to resetAt timing", () => {
+    const resetAt = new Date(Date.now() + 15000).toISOString();
+    expect(formatRetryMessage(null, resetAt)).toMatch(/Try again in about \d+s\./);
+  });
+
+  it("uses a generic hint when no timing is available", () => {
+    expect(formatRetryMessage(null, null)).toBe("Try again shortly.");
+  });
+});


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #934

### Summary
Repository Hive called GitHub from the browser and wiped cards on any non-OK response. Added `/api/github/search` with a short shared cache and stale fallback for 403/429/5xx, and updated the page to debounce/cancel in-flight searches, keep previous results, and show retry timing.

---

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Other(please describe) ______

---

### How Has This Been Tested?
- `vitest run tests/githubSearchController.unit.test.js` (6 passing)
- `vitest run src/utils/repositoryHiveRateLimit.unit.test.js` (3 passing)

### Screenshots (if applicable)
N/A

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

Made with [Cursor](https://cursor.com)