### PR TITLE
Chore: Remove trust proxy from Express server

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -29,7 +29,8 @@ const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securit
 const { uploadsStaticHeaders } = require("./middlewares/uploadMiddleware");
 const app = express();
 
-app.set("trust proxy", 1);
+
+
 app.use(generalHeaders);
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [


### PR DESCRIPTION
﻿### Summary of What Has Been Done
Removed the Express server's 	rust proxy configuration which was globally overriding the proxy trust settings.

### Changes Made
- Modified ackend/server.js: Removed the line pp.set("trust proxy", 1);.

### Impact it Made
- Restores default Express proxy behavior.
- *Note: If the application is deployed behind a reverse proxy (like Nginx, Render, etc.) and relies on IP-based rate limiting, further configuration of 	rust proxy may be necessary.*


Closes #1418
