### PR TITLE
Security: Enforce email verification on registration (Issue #717)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -134,8 +134,7 @@ const registerUser = async (req, res) => {
                 workExperience: "",
                 socials: { github: "", linkedin: "", twitter: "", portfolio: "" }
             },
-            platformPreferences: { theme: "light", notificationsEnabled: true },
-            isEmailVerified: true, // skip email verification until SMTP is configured
+            platformPreferences: { theme: "light", notificationsEnabled: true }
         });
 
         const accessToken = generateAccessToken(user._id, user.tokenVersion);
@@ -143,7 +142,19 @@ const registerUser = async (req, res) => {
 
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
+        
+        const verificationToken = crypto.randomBytes(32).toString("hex");
+        user.emailVerificationToken = crypto
+            .createHash("sha256")
+            .update(verificationToken)
+            .digest("hex");
+        user.emailVerificationExpires = Date.now() + 24 * 60 * 60 * 1000;
+        
         await user.save();
+
+        const verificationUrl = `${process.env.CLIENT_URL || 'http://localhost:5173'}/verify-email?token=${verificationToken}`;
+        await sendVerificationEmail(user.email, verificationUrl).catch(err => console.error("Email error:", err));
+
         res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         return res.status(201).json({
             success: true,


### PR DESCRIPTION
﻿### Summary of What Has Been Done
During user registration, the isEmailVerified field is being hardcoded to 	rue when saving the new user to the database. This completely bypasses the email verification requirement, allowing anyone to register with fake or unowned email addresses.

### Changes Made
- Modified ackend/controllers/authController.js.
- Removed isEmailVerified: true from the user creation payload, defaulting it to alse.
- Added logic to generate emailVerificationToken and trigger the sendVerificationEmail utility upon successful registration.

### Impact it Made
- Secures the platform from bot registrations and spam accounts.
- Ensures only verified email owners can access authenticated features and consume server resources.

Closes #717
