### PR TITLE
Security: Fix CSRF token not issued on login/register (Issue #756)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -144,6 +144,15 @@ const registerUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
+
+        if (res.locals._csrf) {
+            res.cookie("csrfToken", res.locals._csrf, {
+                httpOnly: false,
+                secure: process.env.NODE_ENV === "production",
+                sameSite: "strict",
+            });
+        }
+
         res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         return res.status(201).json({
             success: true,
@@ -197,6 +206,15 @@ const loginUser = async (req, res) => {
         user.refreshTokenHash = await bcrypt.hash(refreshToken, REFRESH_TOKEN_SALT_ROUNDS);
         user.refreshTokenExpiresAt = new Date(Date.now() + REFRESH_TOKEN_MAX_AGE_MS);
         await user.save();
+
+        if (res.locals._csrf) {
+            res.cookie("csrfToken", res.locals._csrf, {
+                httpOnly: false,
+                secure: process.env.NODE_ENV === "production",
+                sameSite: "strict",
+            });
+        }
+
         res.cookie("refreshToken", refreshToken, getRefreshCookieOptions());
         res.json({
             success: true,


### PR DESCRIPTION
﻿### Summary of What Has Been Done
The backend includes a CSRF protection middleware that expects a specific CSRF token cookie from the client. However, the server never actually issued this cookie upon login or session creation. As a result, endpoints requiring this CSRF check (like logout and 	oken refresh) were permanently unreachable and returned 403 Forbidden.

### Changes Made
- Modified ackend/controllers/authController.js to ensure the CSRF token is generated and sent as a cookie (csrfToken) during successful loginUser and egisterUser calls.

### Impact it Made
- Fixes broken authentication flows (users can now successfully log out and refresh sessions).
- Successfully implements proper CSRF protection against cross-site request forgery attacks.

Closes #756


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Set a non-`httpOnly` `csrfToken` cookie after successful login and registration.
- Apply production-aware security settings and strict same-site behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->