### PR TITLE
Fix: Validate country field against numeric input (Issue #1301)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -428,6 +428,13 @@ const updateUserProfile = async (req, res) => {
             profileImageUrl
         } = req.body;
 
+        if (country !== undefined && country !== "") {
+            const countryRegex = /^[a-zA-Z\s\-]+$/;
+            if (!countryRegex.test(country)) {
+                return res.status(400).json({ success: false, message: "Invalid country name provided" });
+            }
+        }
+
         const user = await User.findById(userId);
         if (!user) {
             return res.status(404).json({ success: false, message: "User not found" });


### PR DESCRIPTION
﻿### Summary of What Has Been Done
The profile form contains a "Country" input field that lacked strict validation on the backend. Users could submit arbitrary numeric data or special characters, which bypassed the schema and corrupted the database.

### Changes Made
- Modified ackend/controllers/authController.js in the updateUserProfile function.
- Added strict regex validation /^[a-zA-Z\s\-]+$/ to the country field to ensure only valid alphabetical strings (and hyphens) are accepted.

### Impact it Made
- Greatly improves database data integrity.
- Prevents errors when calling third-party APIs that rely on strict country codes.

Closes #1301


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates `updateUserProfile` to reject invalid country values before database operations. The validation accepts alphabetic characters, spaces, and hyphens. Numeric and special-character values return HTTP 400.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->