### PR TITLE
fix: prevent X-Forwarded-For rate-limit bypass

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -4,6 +4,12 @@
 # Server Configuration
 PORT=8000
 
+# Comma-separated CIDRs of trusted reverse proxies (e.g. your hosting
+# platform's egress ranges). X-Forwarded-For is ONLY honored from these
+# addresses, so rate limiting cannot be bypassed by spoofing the header.
+# Leave unset when the server is directly reachable.
+# REVERSE_PROXY_CIDR=10.0.0.0/8
+
 # Base URL for constructing absolute URLs (e.g. for image uploads)
 # In production, set this to your actual domain like https://preppilot-backend.onrender.com
 # BASE_URL=https://preppilot-backend.onrender.com

--- a/backend/middlewares/rateLimiter.js
+++ b/backend/middlewares/rateLimiter.js
@@ -1,9 +1,18 @@
 const rateLimit = require('express-rate-limit');
 
+// Rate-limit key derived from the trusted client IP. req.ip honors
+// X-Forwarded-For only from the configured trusted proxy CIDR(s); without one
+// it is the direct socket address, so a spoofed header cannot rotate the limit
+// bucket. The library's ipKeyGenerator helper masks IPv6 addresses to a subnet
+// so IPv6 callers cannot dodge limits by rotating addresses.
+const ipKeyGenerator = (req) =>
+  rateLimit.ipKeyGenerator(req.ip || req.socket?.remoteAddress || "unknown");
+
 // Login endpoint: strict brute-force protection (10 attempts per 15 minutes)
 const loginLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 10, // Limit each IP to 10 login attempts per window
+    keyGenerator: ipKeyGenerator,
     message: { error: 'Too many login attempts. Your account is temporarily locked. Please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -14,6 +23,7 @@ const loginLimiter = rateLimit({
 const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 50, // Limit each IP to 50 requests per `window`
+    keyGenerator: ipKeyGenerator,
     message: { error: 'Too many registration or authentication attempts, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -24,6 +34,7 @@ const authLimiter = rateLimit({
 const aiLimiter = rateLimit({
     windowMs: 60 * 60 * 1000, // 1 hour
     max: 20, // Limit each IP to 20 requests per `window` (here, per hour)
+    keyGenerator: ipKeyGenerator,
     message: { error: 'AI generation limit reached (20 requests per hour) to prevent API abuse. Please try again later.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -33,6 +44,7 @@ const aiLimiter = rateLimit({
 const generalLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+    keyGenerator: ipKeyGenerator,
     message: { error: 'Too many requests, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers
@@ -42,6 +54,7 @@ const generalLimiter = rateLimit({
 const sensitiveAuthLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 10, // Limit each IP to 10 sensitive account requests per window
+    keyGenerator: ipKeyGenerator,
     message: { error: 'Too many sensitive account action attempts, please try again after 15 minutes.' },
     standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
     legacyHeaders: false, // Disable the `X-RateLimit-*` headers

--- a/backend/server.js
+++ b/backend/server.js
@@ -29,7 +29,18 @@ const { generalHeaders, sensitiveRouteHeaders } = require("./middlewares/securit
 const { uploadsStaticHeaders } = require("./middlewares/uploadMiddleware");
 const app = express();
 
-app.set("trust proxy", 1);
+// Trust X-Forwarded-For only when it comes from a known reverse proxy. The
+// previous blanket `trust proxy: 1` let any client spoof the header and rotate
+// their IP on every request, defeating every rate limiter. With no CIDR
+// configured the header is ignored entirely and req.ip is the direct socket
+// address, so it cannot be reset by the caller.
+const reverseProxyCidrs = (process.env.REVERSE_PROXY_CIDR || "")
+  .split(",")
+  .map((cidr) => cidr.trim())
+  .filter(Boolean);
+if (reverseProxyCidrs.length > 0) {
+  app.set("trust proxy", reverseProxyCidrs);
+}
 app.use(generalHeaders);
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [

--- a/backend/tests/rateLimiter.xff.bypass.unit.test.js
+++ b/backend/tests/rateLimiter.xff.bypass.unit.test.js
@@ -1,0 +1,40 @@
+﻿import { describe, it, expect, beforeAll } from "vitest";
+import express from "express";
+import request from "supertest";
+import { loginLimiter } from "../middlewares/rateLimiter.js";
+
+// ---------------------------------------------------------------------------
+// Rate-limit bypass fix (issue #1438): with no trusted reverse proxy
+// configured, a client-supplied X-Forwarded-For header must NOT rotate the
+// rate-limit bucket. req.ip stays the direct socket address, so the 11th login
+// attempt is still rejected even while spoofing a different IP each request.
+// ---------------------------------------------------------------------------
+
+let app;
+
+beforeAll(() => {
+  app = express();
+  app.use(express.json());
+  app.post("/login", loginLimiter, (req, res) => res.status(200).json({ ok: true }));
+});
+
+describe("login limiter keyed on the trusted client IP", () => {
+  it("rejects the 11th attempt even when X-Forwarded-For is rotated per request", async () => {
+    const statuses = [];
+    for (let i = 0; i <= 10; i++) {
+      const res = await request(app)
+        .post("/login")
+        .set("X-Forwarded-For", `203.0.113.${i}`)
+        .send({ email: `user${i}@example.com`, password: "wrong" });
+      statuses.push(res.status);
+    }
+
+    // The first 10 requests pass through to the handler (200), proving the
+    // spoofed header did not create a fresh bucket for each attempt.
+    for (let i = 0; i < 10; i++) {
+      expect(statuses[i]).toBe(200);
+    }
+    // The 11th attempt is rejected by loginLimiter (max: 10).
+    expect(statuses[10]).toBe(429);
+  });
+});


### PR DESCRIPTION
## Problem

`app.set("trust proxy", 1)` combined with the default `keyGenerator` (based on `req.ip`) lets any client send a spoofed `X-Forwarded-For` header. Because the server blindly trusts the first entry of that header, an attacker can rotate their perceived IP on every request and defeat every rate limiter (login brute-force protection, AI cost guards, general endpoint limits).

## Fix

- Replaced the blanket `trust proxy: 1` in `server.js` with a `REVERSE_PROXY_CIDR`-based trust setting. `X-Forwarded-For` is now honored **only** when the request comes from a configured trusted proxy CIDR; when unset, `req.ip` is the direct socket address and the header is ignored entirely.
- All limiters in `rateLimiter.js` now use an explicit IP `keyGenerator` that normalizes IPv6 via the express-rate-limit helper, so IPv6 callers cannot dodge limits by rotating addresses.
- Documented the new `REVERSE_PROXY_CIDR` variable in `.env.example`.

## Files changed

- `backend/server.js` — conditional `trust proxy` from `REVERSE_PROXY_CIDR`.
- `backend/middlewares/rateLimiter.js` — explicit `ipKeyGenerator` on all five limiters.
- `backend/.env.example` — documented `REVERSE_PROXY_CIDR`.
- `backend/tests/rateLimiter.xff.bypass.unit.test.js` — new test proving a rotated `X-Forwarded-For` no longer resets the limit bucket.

## Testing

`npx vitest run tests/rateLimiter.xff.bypass.unit.test.js` — 1/1 passing (11th login attempt rejected with 429 despite spoofing a fresh IP each request).

Closes #1438


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced `trust proxy: 1` with configurable `REVERSE_PROXY_CIDR` trust settings.
- Added IPv6-normalized IP keys to all five rate limiters.
- Added documentation and a regression test for rotating `X-Forwarded-For` values.
- The test confirms that the 11th login attempt returns HTTP 429.

Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->