### PR TITLE
fix: remove contradictory process.exit unhandledRejection handler

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -197,9 +197,3 @@ process.on("uncaughtException", (err) => {
   console.error("Uncaught Exception:", err);
   process.exit(1);
 });
-
-// Handle unhandled promise rejections
-process.on("unhandledRejection", (reason, promise) => {
-  console.error("Unhandled Rejection at:", promise, "reason:", reason);
-  process.exit(1);
-});

--- a/backend/tests/unhandledRejection.policy.unit.test.js
+++ b/backend/tests/unhandledRejection.policy.unit.test.js
@@ -1,0 +1,27 @@
+﻿import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ---------------------------------------------------------------------------
+// unhandledRejection policy fix (issue #1441): two contradictory global
+// listeners existed — the first logs and continues, the second called
+// process.exit(1), so any unhandled rejection killed the whole server.
+// Exactly one log-and-continue policy must remain.
+// ---------------------------------------------------------------------------
+
+const serverSource = readFileSync(resolve(__dirname, "../server.js"), "utf8");
+
+describe("server.js unhandledRejection policy", () => {
+  it("registers exactly one unhandledRejection listener", () => {
+    const matches = serverSource.match(/process\.on\(\s*["']unhandledRejection["']/g) || [];
+    expect(matches.length).toBe(1);
+  });
+
+  it("does not exit the process from the unhandledRejection handler", () => {
+    const listenerBlock = serverSource.slice(
+      serverSource.indexOf('"unhandledRejection"'),
+      serverSource.indexOf("unhandledRejection") + 300
+    );
+    expect(listenerBlock).not.toMatch(/process\.exit/);
+  });
+});


### PR DESCRIPTION
## Problem

`server.js` registers two global `unhandledRejection` listeners with opposite intents:
1. Line 7–9: logs the error and keeps the server running.
2. Lines ~200–205: logs and calls `process.exit(1)`, killing the entire server.

Because both are attached to the same event, any unhandled rejection kills the whole process — contradicting the intent of the first handler.

## Fix

Removed the second, `process.exit(1)`-based handler. Exactly one log-and-continue `unhandledRejection` policy now remains; `uncaughtException` still exits deliberately as before.

## Files changed

- `backend/server.js` — removed the exit-based `unhandledRejection` handler.
- `backend/tests/unhandledRejection.policy.unit.test.js` — new test asserting exactly one `unhandledRejection` listener exists and it does not call `process.exit`.

## Testing

`npx vitest run tests/unhandledRejection.policy.unit.test.js` — 2/2 passing.

Closes #1441


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removes the duplicate `unhandledRejection` handler and preserves the log-and-continue policy. Adds tests that verify one listener exists and that it does not call `process.exit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->