### PR TITLE
fix: reject non-numeric page/limit with 400 instead of 500

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -21,6 +21,16 @@ const updateQuestionNoteSchema = z.object({
   note: z.string(),
 });
 
+// Schema for query params of getMyQuestions. page/limit are coerced and must
+// be positive integers (limit capped at 100) so NaN never reaches the
+// controller's .skip()/.limit().
+const getMyQuestionsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+  sessionId: z.string().optional(),
+  pinned: z.enum(["true", "false"]).optional(),
+});
+
 
 // Helper for consistent error responses
 const handleValidationError = (res, error) => {
@@ -64,9 +74,20 @@ const validateUpdateQuestionNote = (req, res, next) => {
   }
 };
 
+// Middleware for getMyQuestions query params
+const validateGetMyQuestions = (req, res, next) => {
+  try {
+    getMyQuestionsQuerySchema.parse(req.query);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
 module.exports = {
   validateAddQuestionToSession,
   validateTogglePinQuestion,
   validateUpdateQuestionNote,
+  validateGetMyQuestions,
   handleValidationError
 };

--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -62,8 +62,16 @@ const getMyQuestions = async (req, res) => {
       ];
     }
 
-    const pageNum = Math.max(1, parseInt(page, 10));
-    const limitNum = Math.min(100, Math.max(1, parseInt(limit, 10)));
+    // Defensive coercion: NaN (non-numeric input) must never reach
+    // .skip()/.limit() and become a 500. Invalid values fall back to safe
+    // defaults (page 1, limit 20) — the route layer rejects them with 400.
+    const parsedPage = Number(page);
+    const parsedLimit = Number(limit);
+    const pageNum =
+      Number.isFinite(parsedPage) && parsedPage >= 1 ? Math.floor(parsedPage) : 1;
+    const limitNum = Number.isFinite(parsedLimit)
+      ? Math.min(100, Math.max(1, Math.floor(parsedLimit)))
+      : 20;
     const skip = (pageNum - 1) * limitNum;
 
     const [questions, totalItems] = await Promise.all([

--- a/backend/routes/questionRoutes.js
+++ b/backend/routes/questionRoutes.js
@@ -8,7 +8,7 @@ const {
 const {protect} = require("../middlewares/authMiddleware");
 
 const { generalLimiter } = require("../middlewares/rateLimiter");
-const { validateAddQuestionToSession, validateTogglePinQuestion, validateUpdateQuestionNote } = require('../Input_validators/ValidateQuestions');
+const { validateAddQuestionToSession, validateTogglePinQuestion, validateUpdateQuestionNote, validateGetMyQuestions } = require('../Input_validators/ValidateQuestions');
 const router = express.Router();
 
 /**
@@ -20,7 +20,7 @@ router.use(generalLimiter, protect);
  * Get all questions for the authenticated user across their sessions.
  * @route GET /api/questions/my-questions
  */
-router.get('/my-questions', getMyQuestions);
+router.get('/my-questions', validateGetMyQuestions, getMyQuestions);
 
 /**
  * Add new questions to an existing session.

--- a/backend/tests/questionController.pageLimit.unit.test.js
+++ b/backend/tests/questionController.pageLimit.unit.test.js
@@ -1,0 +1,185 @@
+﻿import { Module } from "node:module";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// getMyQuestions — non-numeric page/limit must not 500 (issue #1445).
+// The route-layer zod schema rejects malformed values with 400; the controller
+// defensively coerces so NaN can never reach .skip()/.limit().
+// ---------------------------------------------------------------------------
+
+const sessionMock = vi.hoisted(() => ({ find: vi.fn() }));
+const questionMock = vi.hoisted(() => ({ find: vi.fn(), countDocuments: vi.fn() }));
+
+const testDoubles = new Map();
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (testDoubles.has(request)) {
+    return testDoubles.get(request);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const clearRequireCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (
+      key.includes("controllers\\questionController") ||
+      key.includes("controllers/questionController") ||
+      key.includes("models\\Session") ||
+      key.includes("models/Session") ||
+      key.includes("models\\Question") ||
+      key.includes("models/Question")
+    ) {
+      delete require.cache[key];
+    }
+  });
+};
+
+const chainable = (value) => {
+  const stub = {
+    select: vi.fn().mockReturnThis(),
+    sort: vi.fn().mockReturnThis(),
+    skip: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    populate: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(value),
+  };
+  return stub;
+};
+
+let getMyQuestions;
+let validateGetMyQuestions;
+
+beforeAll(async () => {
+  clearRequireCache();
+  testDoubles.set("../models/Session", { find: sessionMock.find });
+  testDoubles.set("../models/Question", {
+    find: questionMock.find,
+    countDocuments: questionMock.countDocuments,
+  });
+
+  const ctrl = await import("../controllers/questionController.js");
+  getMyQuestions = ctrl.getMyQuestions;
+
+  const validators = await import("../Input_validators/ValidateQuestions.js");
+  validateGetMyQuestions = validators.validateGetMyQuestions;
+});
+
+beforeEach(() => {
+  sessionMock.find.mockReset();
+  questionMock.find.mockReset();
+  questionMock.countDocuments.mockReset();
+});
+
+const makeReq = (query = {}) => ({ query, user: { _id: "u1" } });
+
+const mockRes = () => {
+  const res = { statusCode: 200, body: null };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+};
+
+// Seeds a healthy controller call and returns the query stub for assertions.
+const seed = () => {
+  sessionMock.find.mockImplementation(() => chainable([{ _id: "s1" }]));
+  const queryStub = chainable([]);
+  questionMock.find.mockImplementation(() => queryStub);
+  questionMock.countDocuments.mockResolvedValue(0);
+  return queryStub;
+};
+
+// ---------------------------------------------------------------------------
+// Route-layer validation: malformed page/limit → 400, valid → next()
+// ---------------------------------------------------------------------------
+describe("validateGetMyQuestions — route layer (issue #1445)", () => {
+  it.each(["abc", "1e5!", "0", "-1", "1.5"])("rejects page=%s with 400", async (page) => {
+    const res = mockRes();
+    const next = vi.fn();
+    validateGetMyQuestions(makeReq({ page }), res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Validation failed");
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it.each(["abc", "xyz", "0", "-1", "101", "1.5"])("rejects limit=%s with 400", async (limit) => {
+    const res = mockRes();
+    const next = vi.fn();
+    validateGetMyQuestions(makeReq({ limit }), res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("passes valid query params through to the handler", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    validateGetMyQuestions(makeReq({ page: "3", limit: "25", pinned: "true", q: "loops" }), res, next);
+
+    expect(res.statusCode).toBe(200);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes when page/limit are absent (defaults handled by the controller)", () => {
+    const res = mockRes();
+    const next = vi.fn();
+    validateGetMyQuestions(makeReq({}), res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Controller layer: defensive coercion, no NaN into .skip()/.limit(), no 500
+// ---------------------------------------------------------------------------
+describe("getMyQuestions — controller defensive coercion (issue #1445)", () => {
+  it("falls back to page=1 limit=20 for a non-numeric page (no 500)", async () => {
+    const queryStub = seed();
+    const res = mockRes();
+
+    await getMyQuestions(makeReq({ page: "abc" }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(queryStub.skip).toHaveBeenCalledWith(0);
+    expect(queryStub.limit).toHaveBeenCalledWith(20);
+  });
+
+  it("falls back to the default limit for a non-numeric limit (no 500)", async () => {
+    const queryStub = seed();
+    const res = mockRes();
+
+    await getMyQuestions(makeReq({ page: "2", limit: "xyz" }), res);
+
+    expect(res.statusCode).toBe(200);
+    expect(queryStub.skip).toHaveBeenCalledWith(20);
+    expect(queryStub.limit).toHaveBeenCalledWith(20);
+  });
+
+  it("never passes NaN to skip/limit for garbage values", async () => {
+    const queryStub = seed();
+    const res = mockRes();
+
+    await getMyQuestions(makeReq({ page: "1e5!", limit: "10x" }), res);
+
+    const skipArg = queryStub.skip.mock.calls[0][0];
+    const limitArg = queryStub.limit.mock.calls[0][0];
+    expect(Number.isNaN(skipArg)).toBe(false);
+    expect(Number.isNaN(limitArg)).toBe(false);
+  });
+
+  it("clamps an oversized limit to 100", async () => {
+    const queryStub = seed();
+    const res = mockRes();
+
+    await getMyQuestions(makeReq({ limit: "5000" }), res);
+
+    expect(queryStub.limit).toHaveBeenCalledWith(100);
+  });
+});


### PR DESCRIPTION
## Problem

`GET /api/questions/my-questions` with a non-numeric `page` or `limit` (e.g. `?page=abc`) returned a **500**. `parseInt('abc')` produces `NaN`, which `Math.max(1, NaN)` silently propagates into `.skip(NaN)`/`.limit(NaN)`, throwing a Mongoose validation error that the catch turned into an internal-server-error response.

## Fix

- The route now validates `page`/`limit` through a zod query schema (`validateGetMyQuestions`), returning a clean **400** `Validation failed` for non-numeric, negative, zero, fractional, or oversized (`limit > 100`) values.
- The controller defensively coerces via `Number()` + `Number.isFinite`, so `NaN` can never reach Mongo: invalid values fall back to `page=1`/`limit=20` and `limit` is clamped to 100.

## Files changed

- `backend/Input_validators/ValidateQuestions.js` — `getMyQuestionsQuerySchema` + `validateGetMyQuestions` middleware.
- `backend/routes/questionRoutes.js` — wire `validateGetMyQuestions` onto `GET /my-questions`.
- `backend/controllers/questionController.js` — defensive page/limit coercion.
- `backend/tests/questionController.pageLimit.unit.test.js` — route-layer (400s) and controller-layer (coercion, no NaN, clamp) tests.

## Testing

`npx vitest run tests/questionController.pageLimit.unit.test.js` — 17/17 passing. Full suite shows no new failures vs. the origin/main baseline.

Closes #1445
