### PR TITLE
fix: escape user search term in getMyQuestions to prevent ReDoS

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -2,6 +2,11 @@ const mongoose = require("mongoose");
 const Question = require("../models/Question");
 const Session = require("../models/Session");
 
+// Escape regex metacharacters so user search text is treated as a literal
+// substring. Building a RegExp from raw input allowed catastrophic-backtracking
+// patterns (e.g. `(a+)+$`) to stall the shared mongod process (ReDoS).
+const escapeRegex = (string) => string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 /**
  * Get all questions for the authenticated user across their sessions.
  * @route GET /api/questions/my-questions
@@ -54,7 +59,8 @@ const getMyQuestions = async (req, res) => {
     }
 
     if (typeof q === "string" && q.trim().length > 0) {
-      const searchRegex = new RegExp(q.trim(), "i");
+      const term = q.trim().slice(0, 200);
+      const searchRegex = new RegExp(escapeRegex(term), "i");
       filter.$or = [
         { question: searchRegex },
         { answer: searchRegex },

--- a/backend/tests/questionController.redos.unit.test.js
+++ b/backend/tests/questionController.redos.unit.test.js
@@ -1,0 +1,136 @@
+﻿import { Module } from "node:module";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// getMyQuestions — ReDoS-safe search handling (issue #1443).
+//
+// authController-style CommonJS modules load deps via require(), which vitest's
+// vi.mock cannot intercept. We shim Node's module loader so the real mongoose
+// models are never touched, then assert on the filter object that gets passed
+// to Question.find().
+// ---------------------------------------------------------------------------
+
+const sessionMock = vi.hoisted(() => ({ find: vi.fn() }));
+const questionMock = vi.hoisted(() => ({ find: vi.fn(), countDocuments: vi.fn() }));
+
+const testDoubles = new Map();
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (testDoubles.has(request)) {
+    return testDoubles.get(request);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const clearRequireCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (
+      key.includes("controllers\\questionController") ||
+      key.includes("controllers/questionController") ||
+      key.includes("models\\Session") ||
+      key.includes("models/Session") ||
+      key.includes("models\\Question") ||
+      key.includes("models/Question")
+    ) {
+      delete require.cache[key];
+    }
+  });
+};
+
+// Mimics the mongoose Query methods getMyQuestions chains onto its models.
+const chainable = (value) => {
+  const stub = {
+    select: vi.fn().mockReturnThis(),
+    sort: vi.fn().mockReturnThis(),
+    skip: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    populate: vi.fn().mockReturnThis(),
+    lean: vi.fn().mockResolvedValue(value),
+  };
+  return stub;
+};
+
+let getMyQuestions;
+
+beforeAll(async () => {
+  clearRequireCache();
+  testDoubles.set("../models/Session", { find: sessionMock.find });
+  testDoubles.set("../models/Question", {
+    find: questionMock.find,
+    countDocuments: questionMock.countDocuments,
+  });
+
+  const mod = await import("../controllers/questionController.js");
+  getMyQuestions = mod.getMyQuestions;
+});
+
+beforeEach(() => {
+  sessionMock.find.mockReset();
+  questionMock.find.mockReset();
+  questionMock.countDocuments.mockReset();
+});
+
+const makeReq = (query = {}) => ({ query, user: { _id: "u1" } });
+
+const mockRes = () => {
+  const res = { statusCode: null, body: null };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+};
+
+const seed = () => {
+  sessionMock.find.mockImplementation(() => chainable([{ _id: "s1" }]));
+  questionMock.find.mockImplementation(() => chainable([]));
+  questionMock.countDocuments.mockResolvedValue(0);
+};
+
+async function runAndGetSearchRegex(query) {
+  seed();
+  await getMyQuestions(makeReq(query), mockRes());
+  const filter = questionMock.find.mock.calls[0][0];
+  return filter.$or;
+}
+
+describe("getMyQuestions — regex-safe search term (issue #1443)", () => {
+  it("escapes regex metacharacters so the query is a literal substring", async () => {
+    const $or = await runAndGetSearchRegex({ q: "(a+)+$" });
+
+    const source = $or[0].question.source;
+    expect(source).toBe("\\(a\\+\\)\\+\\$");
+  });
+
+  it("does not contain nested quantifiers for crafted patterns", async () => {
+    const $or = await runAndGetSearchRegex({
+      q: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa!",
+    });
+
+    expect($or[0].question.source).not.toMatch(/\(\S*\)\+/);
+    expect($or[1].answer.source).toBe($or[0].question.source);
+    expect($or[2].note.source).toBe($or[0].question.source);
+  });
+
+  it("caps the search term length to 200 characters", async () => {
+    const $or = await runAndGetSearchRegex({ q: "x".repeat(5000) });
+
+    expect($or[0].question.source.length).toBeLessThanOrEqual(200);
+  });
+
+  it("keeps matching case-insensitive", async () => {
+    const $or = await runAndGetSearchRegex({ q: "HTTP/2" });
+
+    expect($or[0].question.flags).toContain("i");
+    expect($or[0].question.source).toBe("HTTP\\/2");
+  });
+
+  it("skips the regex when q is empty or whitespace only", async () => {
+    expect(await runAndGetSearchRegex({ q: "   " })).toBeUndefined();
+    expect(await runAndGetSearchRegex({})).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Problem

`GET /api/questions/my-questions` compiles the `q` query param directly into a RegExp:

```js
const searchRegex = new RegExp(q.trim(), "i");
```

A crafted term like `(a+)+$` can trigger catastrophic backtracking when MongoDB evaluates the regex against large text fields, stalling the shared `mongod` process (ReDoS). The term is also unbounded in length, so arbitrarily long inputs create oversized regexes.

## Fix

- Added an `escapeRegex` helper that escapes all regex metacharacters (`[.*+?^${}()|[\]\\]`), so the user term is matched as a literal substring instead of being interpreted as pattern syntax.
- Capped the search term at 200 characters before compiling.

## Files changed

- `backend/controllers/questionController.js` — `escapeRegex` helper + literal, length-capped regex construction.
- `backend/tests/questionController.redos.unit.test.js` — tests that metacharacters are escaped, nested-quantifier patterns are neutralized, length is capped, and case-insensitivity is preserved.

## Testing

`npx vitest run tests/questionController.redos.unit.test.js` — 5/5 passing. Full suite shows no new failures vs. the origin/main baseline.

Closes #1443
