### PR TITLE
fix: route prefix and non-word-character prep topics to the AI mentor

### DIFF
--- a/backend/tests/domainClassifier.prefixKeywords.unit.test.js
+++ b/backend/tests/domainClassifier.prefixKeywords.unit.test.js
@@ -1,0 +1,39 @@
+﻿import { describe, it, expect } from "vitest";
+import { isPrepPilotDomain } from "../utils/domainClassifier.js";
+
+// ---------------------------------------------------------------------------
+// Domain classifier prefix-keyword fix (issue #1440): core prep topics that
+// are prefixes of real words (probab -> probability, scal -> scaling, math ->
+// mathematics, load balanc -> load balancing, negotiat -> negotiation) and
+// keywords containing non-word characters (c++, c#) previously never matched
+// because of the trailing \b in the keyword regex, so the AI mentor refused
+// legitimate questions about them.
+// ---------------------------------------------------------------------------
+
+describe("isPrepPilotDomain — prefix and non-word-character keywords", () => {
+  const cases = [
+    "probability",
+    "Explain probability.",
+    "What is load balancing?",
+    "How do I scale my database?",
+    "scaling",
+    "Explain C++ pointers.",
+    "Explain C# async/await.",
+    "C++",
+    "C#",
+    "negotiation",
+    "mathematics",
+    "quantitative reasoning"
+  ];
+
+  cases.forEach((query) => {
+    it(`routes "${query}" to the AI mentor`, () => {
+      expect(isPrepPilotDomain(query)).toBe(true);
+    });
+  });
+
+  it("still rejects clearly off-topic prompts", () => {
+    expect(isPrepPilotDomain("Who won the FIFA World Cup?")).toBe(false);
+    expect(isPrepPilotDomain("Write a recipe for pasta.")).toBe(false);
+  });
+});

--- a/backend/utils/domainClassifier.js
+++ b/backend/utils/domainClassifier.js
@@ -36,7 +36,13 @@ const escapeRegExp = (string) => {
 };
 
 const escapedKeywords = domainKeywords.map(escapeRegExp);
-const keywordRegex = new RegExp(`\\b(${escapedKeywords.join('|')})\\b`, 'i');
+// Anchor keywords as prefixes: keep the leading word boundary but drop the
+// trailing one. A trailing \b made prefix keywords (scal, load balanc,
+// negotiat, probab, math, quant) and keywords ending in non-word characters
+// (c++, c#) never match — "probability", "load balancing", "C++?" etc. were
+// misclassified as off-topic. Prefix matching over-routes a few extra words
+// (e.g. "google" matching "go"), which is acceptable for an AI mentor router.
+const keywordRegex = new RegExp(`\\b(${escapedKeywords.join('|')})`, 'i');
 
 const conversationalRegex = /^(hi|hello|hey|yo|ok|thanks|thank you|who are you|what should i call you|good morning|good evening|\?)$/i;
 


### PR DESCRIPTION
## Problem

`backend/utils/domainClassifier.js` builds the keyword matcher as `new RegExp(\b(<keywords>)\b, 'i')`. Two classes of keywords could **never** match, so legitimate AI-mentor questions were refused as "off-topic":

1. **Partial-word keywords** — `scal` (scalability), `load balanc` (load balancing), `negotiat` (negotiation), `probab` (probability), `math` (mathematics), `quant` (quantitative). The trailing `\b` requires a non-word char immediately after the prefix, which never happens inside a longer real word.
2. **Keywords with non-word characters** — `c++`/`c#`. The trailing `\b` after `+`/`#` rarely matches ("What is C++?").

`isPrepPilotDomain` gates the model call in `aiRoutes.js`, so these prompts got the canned refusal instead of an answer.

## Fix

Anchored keywords as **prefixes**: keep the leading word boundary, drop the trailing `\b`. `\b(probab|scal|...|c\+\+|c\#)` now matches "probability", "scaling", "C++", "C#", etc. A few extra matches (e.g. "google" → `go`) are acceptable for an AI-mentor router.

## Files changed

- `backend/utils/domainClassifier.js` — dropped trailing `\b` from `keywordRegex`.
- `backend/tests/domainClassifier.prefixKeywords.unit.test.js` — tests routing probability/load balancing/scaling/C++/C#/negotiation/mathematics to the mentor and still rejecting clearly off-topic prompts.

## Testing

`npx vitest run tests/domainClassifier.prefixKeywords.unit.test.js` — 13/13 passing.

Closes #1440
