### PR TITLE
fix: reject out-of-range and malformed saveProgress fields

### DIFF
--- a/backend/Input_validators/ValidateUserSheetProgress.js
+++ b/backend/Input_validators/ValidateUserSheetProgress.js
@@ -6,7 +6,7 @@ const saveProgressSchema = z.object({
   sheetId: z.string().min(1, "Sheet ID is required"),
   followed: z.boolean().optional(),
   completedTopics: z.record(z.string(), z.boolean()).optional(),
-  percentage: z.number().int().min(0, "Percentage must be at least 0").max(100, "Percentage cannot exceed 100"),
+  percentage: z.number().int().min(0, "Percentage must be at least 0").max(100, "Percentage cannot exceed 100").optional(),
 });
 
 // Schema for getting progress by sheetId (params)

--- a/backend/models/UserSheetProgress.js
+++ b/backend/models/UserSheetProgress.js
@@ -5,7 +5,7 @@ const UserSheetProgressSchema = new mongoose.Schema({
   sheetId: { type: String, required: true },
   followed: { type: Boolean, default: false },
   completedTopics: { type: Object, default: {} },
-  percentage: { type: Number, default: 0 },
+  percentage: { type: Number, default: 0, min: 0, max: 100 },
 }, { timestamps: true });
 
 UserSheetProgressSchema.index({ userId: 1, sheetId: 1 }, { unique: true });

--- a/backend/tests/userSheetProgressController.unit.test.js
+++ b/backend/tests/userSheetProgressController.unit.test.js
@@ -1,116 +1,247 @@
-"use strict";
-
-/**
- * Unit tests for userSheetProgressController
- *
- * These tests use Jest module mocking. Before the fix, jest.mock on
- * '../models/UserSheetProgress' was NOT seen by getAllProgress because the
- * require() in the controller appeared after the export definition, causing
- * the binding to resolve to the real module before the mock could intercept.
- * After moving the require to the top of the file, the mock is applied first
- * and all three handlers see the same mocked binding.
- */
-
-jest.mock("../models/UserSheetProgress");
-
-const UserSheetProgress = require("../models/UserSheetProgress");
-const ctrl = require("../controllers/userSheetProgressController");
+import { Module } from "node:module";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Helpers
+// userSheetProgressController.js is CommonJS and loads its deps via
+// require(), which vitest's vi.mock cannot intercept. We shim Node's module
+// loader so the real UserSheetProgress model is never touched.
+//
+// Covers issue #1449: saveProgress must reject out-of-range / malformed
+// field values (percentage outside [0,100], non-boolean followed,
+// non-object completedTopics) while still allowing partial payloads.
 // ---------------------------------------------------------------------------
-function makeRes() {
-  const res = {};
-  res.status = jest.fn().mockReturnValue(res);
-  res.json = jest.fn().mockReturnValue(res);
-  return res;
-}
+
+const modelMock = vi.hoisted(() => ({
+  find: vi.fn(),
+  findOne: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+  create: vi.fn(),
+  bulkWrite: vi.fn(),
+}));
+
+const testDoubles = new Map();
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (testDoubles.has(request)) {
+    return testDoubles.get(request);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const clearRequireCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (
+      key.includes("controllers\\userSheetProgressController") ||
+      key.includes("controllers/userSheetProgressController") ||
+      key.includes("models\\UserSheetProgress") ||
+      key.includes("models/UserSheetProgress")
+    ) {
+      delete require.cache[key];
+    }
+  });
+};
+
+let saveProgress;
+let getAllProgress;
+let getProgress;
+let validateSaveProgress;
+
+beforeAll(async () => {
+  clearRequireCache();
+  testDoubles.set("../models/UserSheetProgress", {
+    find: modelMock.find,
+    findOne: modelMock.findOne,
+    findOneAndUpdate: modelMock.findOneAndUpdate,
+    create: modelMock.create,
+    bulkWrite: modelMock.bulkWrite,
+  });
+
+  const mod = await import("../controllers/userSheetProgressController.js");
+  saveProgress = mod.saveProgress;
+  getAllProgress = mod.getAllProgress;
+  getProgress = mod.getProgress;
+
+  const validator = await import(
+    "../Input_validators/ValidateUserSheetProgress.js"
+  );
+  validateSaveProgress = validator.validateSaveProgress;
+});
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  modelMock.find.mockReset();
+  modelMock.findOne.mockReset();
+  modelMock.findOneAndUpdate.mockReset();
+  modelMock.create.mockReset();
+  modelMock.bulkWrite.mockReset();
 });
 
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const mockRes = () => {
+  const res = { statusCode: null, body: null };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+};
+
 // ---------------------------------------------------------------------------
-// getAllProgress — this is the regression test that proves the fix
+// validateSaveProgress middleware
 // ---------------------------------------------------------------------------
-describe("getAllProgress", () => {
-  it("calls UserSheetProgress.find with the authenticated user's id", async () => {
-    const userId = "user-abc-123";
-    const fakeList = [{ sheetId: "arrays", percentage: 80 }];
+describe("validateSaveProgress — field validation (#1449)", () => {
+  it.each([
+    ["percentage 150", { sheetId: "arrays", percentage: 150 }],
+    ["percentage -1", { sheetId: "arrays", percentage: -1 }],
+    ["percentage non-numeric", { sheetId: "arrays", percentage: "abc" }],
+    ["followed non-boolean", { sheetId: "arrays", followed: "yes" }],
+    ["completedTopics malformed", { sheetId: "arrays", completedTopics: "x" }],
+    ["missing sheetId", { followed: true }],
+  ])("rejects %s with 400", (_name, body) => {
+    const res = mockRes();
+    let nextCalled = false;
 
-    UserSheetProgress.find = jest.fn().mockResolvedValue(fakeList);
+    validateSaveProgress({ body }, res, () => {
+      nextCalled = true;
+    });
 
-    const req = { user: { _id: userId } };
-    const res = makeRes();
-
-    await ctrl.getAllProgress(req, res);
-
-    // KEY assertion: the mock must have been called.
-    // Before the fix this fails — find is called on the real model, not the mock.
-    expect(UserSheetProgress.find).toHaveBeenCalledWith({ userId });
-    expect(res.json).toHaveBeenCalledWith({ success: true, progressList: fakeList });
+    expect(nextCalled).toBe(false);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toEqual(expect.objectContaining({ success: false }));
   });
 
-  it("returns 500 when find throws", async () => {
-    UserSheetProgress.find = jest.fn().mockRejectedValue(new Error("db error"));
+  it("accepts a valid full payload", () => {
+    const res = mockRes();
+    let nextCalled = false;
 
-    const req = { user: { _id: "user-xyz" } };
-    const res = makeRes();
-
-    await ctrl.getAllProgress(req, res);
-
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ success: false, error: "db error" })
+    validateSaveProgress(
+      {
+        body: {
+          sheetId: "arrays",
+          followed: true,
+          completedTopics: { "two-pointers": true },
+          percentage: 80,
+        },
+      },
+      res,
+      () => {
+        nextCalled = true;
+      }
     );
+
+    expect(nextCalled).toBe(true);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it("accepts a partial payload (only followed) so $set preserves other fields", () => {
+    const res = mockRes();
+    let nextCalled = false;
+
+    validateSaveProgress(
+      { body: { sheetId: "arrays", followed: true } },
+      res,
+      () => {
+        nextCalled = true;
+      }
+    );
+
+    expect(nextCalled).toBe(true);
   });
 });
 
 // ---------------------------------------------------------------------------
-// saveProgress
+// saveProgress controller
 // ---------------------------------------------------------------------------
-describe("saveProgress — update existing", () => {
-  it("updates and saves an existing progress document", async () => {
-    const mockProgress = {
-      followed: false,
-      completedTopics: [],
-      percentage: 0,
-      save: jest.fn().mockResolvedValue(true),
+describe("saveProgress", () => {
+  it("upserts only the explicitly provided fields via findOneAndUpdate", async () => {
+    const fakeProgress = {
+      sheetId: "arrays",
+      followed: true,
+      completedTopics: {},
+      percentage: 80,
     };
-
-    UserSheetProgress.findOne = jest.fn().mockResolvedValue(mockProgress);
+    modelMock.findOneAndUpdate.mockResolvedValue(fakeProgress);
 
     const req = {
       user: { _id: "user-1" },
-      body: { sheetId: "arrays", followed: true, completedTopics: ["Two Pointers"], percentage: 50 },
+      body: { sheetId: "arrays", followed: true, percentage: 80 },
     };
-    const res = makeRes();
+    const res = mockRes();
 
-    await ctrl.saveProgress(req, res);
+    await saveProgress(req, res);
 
-    expect(mockProgress.save).toHaveBeenCalledOnce();
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ success: true })
+    expect(modelMock.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: "user-1", sheetId: "arrays" },
+      { $set: { followed: true, percentage: 80 } },
+      expect.objectContaining({ upsert: true, new: true })
     );
+    expect(res.body).toEqual({ success: true, progress: fakeProgress });
+  });
+
+  it("rejects an invalid sheetId with 400", async () => {
+    const req = {
+      user: { _id: "user-1" },
+      body: { sheetId: "   " },
+    };
+    const res = mockRes();
+
+    await saveProgress(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(modelMock.findOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when findOneAndUpdate throws", async () => {
+    modelMock.findOneAndUpdate.mockRejectedValue(new Error("db error"));
+
+    const req = {
+      user: { _id: "user-1" },
+      body: { sheetId: "arrays", percentage: 50 },
+    };
+    const res = mockRes();
+
+    await saveProgress(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual(expect.objectContaining({ success: false }));
   });
 });
 
-describe("saveProgress — create new", () => {
-  it("creates a new progress document when none exists", async () => {
-    const created = { sheetId: "trees", percentage: 20 };
-    UserSheetProgress.findOne = jest.fn().mockResolvedValue(null);
-    UserSheetProgress.create = jest.fn().mockResolvedValue(created);
+// ---------------------------------------------------------------------------
+// getAllProgress
+// ---------------------------------------------------------------------------
+describe("getAllProgress", () => {
+  it("calls UserSheetProgress.find with the authenticated user's id", async () => {
+    const fakeList = [{ sheetId: "arrays", percentage: 80 }];
+    const findPromise = Promise.resolve(fakeList);
+    findPromise.limit = vi.fn().mockReturnValue(findPromise);
+    modelMock.find.mockReturnValue(findPromise);
 
-    const req = {
-      user: { _id: "user-2" },
-      body: { sheetId: "trees", followed: false, completedTopics: [], percentage: 20 },
-    };
-    const res = makeRes();
+    const req = { user: { _id: "user-abc" } };
+    const res = mockRes();
 
-    await ctrl.saveProgress(req, res);
+    await getAllProgress(req, res);
 
-    expect(UserSheetProgress.create).toHaveBeenCalledOnce();
-    expect(res.json).toHaveBeenCalledWith({ success: true, progress: created });
+    expect(modelMock.find).toHaveBeenCalledWith({ userId: "user-abc" });
+    expect(res.body).toEqual({ success: true, progressList: fakeList });
+  });
+
+  it("returns 500 when find throws", async () => {
+    modelMock.find.mockRejectedValue(new Error("db error"));
+
+    const req = { user: { _id: "user-xyz" } };
+    const res = mockRes();
+
+    await getAllProgress(req, res);
+
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual(expect.objectContaining({ success: false }));
   });
 });
 
@@ -120,31 +251,39 @@ describe("saveProgress — create new", () => {
 describe("getProgress", () => {
   it("returns progress for the given sheetId", async () => {
     const fakeProgress = { sheetId: "graphs", percentage: 60 };
-    UserSheetProgress.findOne = jest.fn().mockResolvedValue(fakeProgress);
+    modelMock.findOne.mockResolvedValue(fakeProgress);
 
     const req = { user: { _id: "user-3" }, params: { sheetId: "graphs" } };
-    const res = makeRes();
+    const res = mockRes();
 
-    await ctrl.getProgress(req, res);
+    await getProgress(req, res);
 
-    expect(UserSheetProgress.findOne).toHaveBeenCalledWith({
+    expect(modelMock.findOne).toHaveBeenCalledWith({
       userId: "user-3",
       sheetId: "graphs",
     });
-    expect(res.json).toHaveBeenCalledWith({ success: true, progress: fakeProgress });
+    expect(res.body).toEqual({ success: true, progress: fakeProgress });
+  });
+
+  it("rejects an invalid sheetId with 400", async () => {
+    const req = { user: { _id: "user-4" }, params: { sheetId: "" } };
+    const res = mockRes();
+
+    await getProgress(req, res);
+
+    expect(res.statusCode).toBe(400);
+    expect(modelMock.findOne).not.toHaveBeenCalled();
   });
 
   it("returns 500 when findOne throws", async () => {
-    UserSheetProgress.findOne = jest.fn().mockRejectedValue(new Error("timeout"));
+    modelMock.findOne.mockRejectedValue(new Error("timeout"));
 
     const req = { user: { _id: "user-4" }, params: { sheetId: "dp" } };
-    const res = makeRes();
+    const res = mockRes();
 
-    await ctrl.getProgress(req, res);
+    await getProgress(req, res);
 
-    expect(res.status).toHaveBeenCalledWith(500);
-    expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ success: false, error: "timeout" })
-    );
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toEqual(expect.objectContaining({ success: false }));
   });
 });


### PR DESCRIPTION
## Problem

`saveProgress` (`backend/controllers/userSheetProgressController.js`) copies `followed`, `completedTopics`, and `percentage` verbatim into the `$set`, and the `UserSheetProgress` model imposes no constraints. Negative / >100 / non-numeric percentages (`"abc"` becomes `NaN`) and malformed `followed` / `completedTopics` shapes get persisted and break the frontend render and the export/import round-trip.

The route already had a Zod middleware, but it **required** `percentage` even for legitimate partial payloads (e.g. `{ sheetId, followed }` → 400), and the model had no min/max guard.

## Fix

- `backend/Input_validators/ValidateUserSheetProgress.js` — `percentage` is now optional so partial updates pass, while `percentage` outside `[0,100]`, non-numeric values, non-boolean `followed`, and non-object `completedTopics` still return 400.
- `backend/models/UserSheetProgress.js` — added `min: 0, max: 100` to `percentage` as a last-line-of-defense guard.
- `backend/tests/userSheetProgressController.unit.test.js` — rewrote the stale Jest test (failed under vitest with `jest is not defined`) as a vitest suite using the `Module._load` shim pattern (the controller is CommonJS and loads deps via `require`).

## Files changed

- `backend/Input_validators/ValidateUserSheetProgress.js`
- `backend/models/UserSheetProgress.js`
- `backend/tests/userSheetProgressController.unit.test.js`

## Testing

`npx vitest run tests/userSheetProgressController.unit.test.js` — 16/16 passing. Asserts 400 for `percentage: 150`, `-1`, `"abc"`, `followed: "yes"`, `completedTopics: "x"`, and missing `sheetId`; accepts valid and partial payloads; covers controller upsert / 400 / 500 paths for `saveProgress`, `getAllProgress`, `getProgress`.

Closes #1449
