### PR TITLE
fix: reject malformed ObjectId ids with 400 instead of 500 CastError

### DIFF
--- a/backend/Input_validators/ValidateResume.js
+++ b/backend/Input_validators/ValidateResume.js
@@ -1,5 +1,12 @@
 const { z } = require("zod");
+const mongoose = require("mongoose");
 const { handleValidationError } = require('./ValidateQuestions')
+
+const objectId = (label) =>
+  z
+    .string()
+    .min(1, `${label} is required`)
+    .refine((v) => mongoose.isValidObjectId(v), "Invalid ObjectId format");
 
 // Schema for compileResume request
 const compileResumeSchema = z.object({
@@ -15,7 +22,15 @@ const analyzeResumeSchema = z.object({
 const saveResumeSchema = z.object({
   title: z.string().min(1, "Title is required"),
   latexCode: z.string().min(1, "LaTeX code is required"),
-  resumeId: z.string().optional(),
+  resumeId: z
+    .string()
+    .optional()
+    .refine((v) => !v || mongoose.isValidObjectId(v), "Invalid ObjectId format"),
+});
+
+// Schema for deleteResume request (params)
+const deleteResumeSchema = z.object({
+  id: objectId("Resume ID"),
 });
 
 
@@ -53,8 +68,19 @@ const validateSaveResume = (req, res, next) => {
   }
 };
 
+// Middleware for deleteResume (params)
+const validateDeleteResume = (req, res, next) => {
+  try {
+    deleteResumeSchema.parse(req.params);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
 module.exports = {
   validateCompileResume,
   validateAnalyzeResume,
   validateSaveResume,
+  validateDeleteResume,
 };

--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -1,5 +1,12 @@
 const { z } = require("zod");
+const mongoose = require("mongoose");
 const { handleValidationError } = require("./ValidateQuestions");
+
+const objectId = (label) =>
+  z
+    .string()
+    .min(1, `${label} is required`)
+    .refine((v) => mongoose.isValidObjectId(v), "Invalid ObjectId format");
 
 // Schema for creating a session
 const createSessionSchema = z.object({
@@ -17,12 +24,12 @@ const createSessionSchema = z.object({
 
 // Schema for getting a session by ID (params)
 const getSessionByIdSchema = z.object({
-  id: z.string().min(1, "Session ID is required"),
+  id: objectId("Session ID"),
 });
 
 // Schema for deleting a session (params)
 const deleteSessionSchema = z.object({
-  id: z.string().min(1, "Session ID is required"),
+  id: objectId("Session ID"),
 });
 
 

--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -4,7 +4,7 @@ const { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume } =
 const { protect } = require('../middlewares/authMiddleware');
 const { upload, uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
 const { aiLimiter } = require('../middlewares/rateLimiter');
-const { validateCompileResume, validateAnalyzeResume, validateSaveResume } = require('../Input_validators/ValidateResume');
+const { validateCompileResume, validateAnalyzeResume, validateSaveResume, validateDeleteResume } = require('../Input_validators/ValidateResume');
 
 
 router.use(protect);
@@ -31,6 +31,6 @@ router.get('/my-resumes', getMyResumes);
 // @route   DELETE /api/resume/:id
 // @desc    Delete a saved resume by ID
 // @access  Private
-router.delete('/:id', deleteResume);
+router.delete('/:id', validateDeleteResume, deleteResume);
 
 module.exports = router;

--- a/backend/tests/objectId.validation.unit.test.js
+++ b/backend/tests/objectId.validation.unit.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Issue #1450: malformed ObjectId ids in params/body must return 400 instead
+// of reaching Mongoose and surfacing as a 500 CastError.
+//
+// Covered:
+//   - GET    /api/sessions/:id     (validateGetSessionById)
+//   - DELETE /api/sessions/:id     (validateDeleteSession)
+//   - DELETE /api/resume/:id       (validateDeleteResume — was missing entirely)
+//   - POST   /api/resume/save      (validateSaveResume — resumeId in body)
+// ---------------------------------------------------------------------------
+
+const VALID_ID = "6426c5a5e6a6f6a6f6a6f6a6";
+const BAD_IDS = ["abc", "000", "aaaaaaaa", "not-an-objectid", "zzzz"];
+
+let sessionValidators;
+let resumeValidators;
+let resumeRouter;
+
+beforeAll(async () => {
+  const sessionMod = await import("../Input_validators/ValidateSession.js");
+  sessionValidators = sessionMod;
+
+  const resumeMod = await import("../Input_validators/ValidateResume.js");
+  resumeValidators = resumeMod;
+
+  const resumeRouterMod = await import("../routes/resumeRoutes.js");
+  resumeRouter = resumeRouterMod.default ?? resumeRouterMod;
+});
+
+function run(mw, req) {
+  let passed = false;
+  let statusCode = null;
+  const res = {
+    status: (code) => {
+      statusCode = code;
+      return res;
+    },
+    json: () => res,
+  };
+  mw(req, res, () => {
+    passed = true;
+  });
+  return { passed, statusCode };
+}
+
+describe("ValidateSession — ObjectId params (#1450)", () => {
+  it.each(BAD_IDS)("rejects malformed id '%s' with 400 (getSessionById)", (id) => {
+    const { passed, statusCode } = run(sessionValidators.validateGetSessionById, {
+      params: { id },
+    });
+    expect(passed).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+
+  it.each(BAD_IDS)("rejects malformed id '%s' with 400 (deleteSession)", (id) => {
+    const { passed, statusCode } = run(sessionValidators.validateDeleteSession, {
+      params: { id },
+    });
+    expect(passed).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+
+  it("accepts a valid ObjectId", () => {
+    const { passed } = run(sessionValidators.validateGetSessionById, {
+      params: { id: VALID_ID },
+    });
+    expect(passed).toBe(true);
+  });
+});
+
+describe("ValidateResume — ObjectId id/resumeId (#1450)", () => {
+  it.each(BAD_IDS)("rejects malformed id '%s' with 400 (deleteResume)", (id) => {
+    const { passed, statusCode } = run(resumeValidators.validateDeleteResume, {
+      params: { id },
+    });
+    expect(passed).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+
+  it.each(BAD_IDS)("rejects malformed resumeId '%s' with 400 (saveResume)", (id) => {
+    const { passed, statusCode } = run(resumeValidators.validateSaveResume, {
+      body: { title: "t", latexCode: "l", resumeId: id },
+    });
+    expect(passed).toBe(false);
+    expect(statusCode).toBe(400);
+  });
+
+  it("accepts a valid resumeId", () => {
+    const { passed } = run(resumeValidators.validateSaveResume, {
+      body: { title: "t", latexCode: "l", resumeId: VALID_ID },
+    });
+    expect(passed).toBe(true);
+  });
+
+  it("accepts saveResume without a resumeId (create path)", () => {
+    const { passed } = run(resumeValidators.validateSaveResume, {
+      body: { title: "t", latexCode: "l" },
+    });
+    expect(passed).toBe(true);
+  });
+});
+
+describe("DELETE /api/resume/:id middleware chain (#1450)", () => {
+  function getLayerStack(router, method, path) {
+    const layer = router.stack.find(
+      (l) =>
+        l.route &&
+        l.route.path === path &&
+        l.route.methods[method.toLowerCase()]
+    );
+    if (!layer) return null;
+    return layer.route.stack.map((s) => s.handle);
+  }
+
+  it("registers the route", () => {
+    const stack = getLayerStack(resumeRouter, "DELETE", "/:id");
+    expect(stack).not.toBeNull();
+  });
+
+  it("includes validateDeleteResume before the deleteResume controller", () => {
+    const stack = getLayerStack(resumeRouter, "DELETE", "/:id");
+    const validatorIdx = stack.findIndex(
+      (fn) => fn && fn.name === "validateDeleteResume"
+    );
+    const controllerIdx = stack.findIndex(
+      (fn) => fn && fn.name === "deleteResume"
+    );
+    expect(validatorIdx).toBeGreaterThanOrEqual(0);
+    expect(controllerIdx).toBeGreaterThan(validatorIdx);
+  });
+});


### PR DESCRIPTION
## Problem

Routes accepting a Mongo ObjectId in the URL path or body only asserted `z.string().min(1)`. Non-empty garbage ids (e.g. `abc`, `000`, `aaaaaaaa`) passed validation, reached Mongoose, and threw `CastError`, which generic handlers turned into an opaque `500 "Server Error"`. Affected:

- `GET /api/sessions/:id` and `DELETE /api/sessions/:id` (`ValidateSession.js` — `id: z.string().min(1)`)
- `POST /api/resume/save` with a `resumeId` body field (`ValidateResume.js` — `resumeId: z.string().optional()`)
- `DELETE /api/resume/:id` — had **no validator at all**

## Fix

- `backend/Input_validators/ValidateSession.js` — `id` in `getSessionByIdSchema` / `deleteSessionSchema` is now refined with `mongoose.isValidObjectId`, so malformed ids return 400.
- `backend/Input_validators/ValidateResume.js` — `resumeId` is refined when present; added `deleteResumeSchema` and the previously-missing `validateDeleteResume` middleware.
- `backend/routes/resumeRoutes.js` — `DELETE /:id` now runs `validateDeleteResume` before the controller.
- `backend/tests/objectId.validation.unit.test.js` — new vitest suite covering all four routes plus the DELETE middleware chain.

## Files changed

- `backend/Input_validators/ValidateSession.js`
- `backend/Input_validators/ValidateResume.js`
- `backend/routes/resumeRoutes.js`
- `backend/tests/objectId.validation.unit.test.js`

## Testing

`npx vitest run tests/objectId.validation.unit.test.js` — 25/25 passing. Asserts malformed ids (`abc`, `000`, `aaaaaaaa`, etc.) return 400 (not 500) for all four endpoints, valid ObjectIds pass, `saveResume` without `resumeId` still works, and `DELETE /api/resume/:id` includes `validateDeleteResume` before the controller.

Closes #1450
