### PR TITLE
fix: bound JobCache growth by validating role/country keys and adding TTL index

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -11,6 +11,23 @@ const CACHE_TTL_MS   = 24 * 60 * 60 * 1000;
 // instead of crashing the server or spamming failed API calls.
 const isAdzunaConfigured = () => Boolean(ADZUNA_APP_ID && ADZUNA_API_KEY);
 
+// Bound the set of cache keys: role/country are client-controlled, so we trim,
+// normalize, and whitelist them before they touch the JobCache collection.
+const normalizeRole = (role) => {
+  if (typeof role !== "string") return "";
+  const trimmed = role.trim().toLowerCase();
+  if (trimmed.length === 0 || trimmed.length > 64) return "";
+  if (!/^[a-z0-9\s+#.,&()/'\-]*$/.test(trimmed)) return "";
+  return trimmed;
+};
+
+const normalizeCountry = (country) => {
+  if (typeof country !== "string") return ADZUNA_COUNTRY;
+  const trimmed = country.trim().toLowerCase();
+  if (!/^[a-z]{2}$/.test(trimmed)) return ADZUNA_COUNTRY;
+  return trimmed;
+};
+
 async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
   const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1`;
   const { data } = await axios.get(url, {
@@ -52,9 +69,9 @@ exports.getJobs = async (req, res) => {
       .sort({ createdAt: -1 })
       .select("role");
 
-    const role    = req.query.role || latestSession?.role || "software engineer";
-    const country = req.query.country   || ADZUNA_COUNTRY;
-    const cacheKey = `${role.toLowerCase()}|${country}`;
+    const role    = normalizeRole(req.query.role) || normalizeRole(latestSession?.role) || "software engineer";
+    const country = normalizeCountry(req.query.country);
+    const cacheKey = `${role}|${country}`;
 
     const cached = await JobCache.findOne({ cacheKey });
     if (cached && Date.now() - cached.fetchedAt.getTime() < CACHE_TTL_MS) {
@@ -84,8 +101,10 @@ exports.refreshJobCache = async () => {
     });
 
     for (const role of roles) {
-      const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
-      const jobs = await fetchFromAdzuna(role);
+      const normalizedRole = normalizeRole(role);
+      if (!normalizedRole) continue;
+      const cacheKey = `${normalizedRole}|${ADZUNA_COUNTRY}`;
+      const jobs = await fetchFromAdzuna(normalizedRole);
       await JobCache.findOneAndUpdate(
         { cacheKey },
         { jobs, fetchedAt: new Date() },

--- a/backend/models/JobCache.js
+++ b/backend/models/JobCache.js
@@ -18,4 +18,7 @@ const JobCacheSchema = new mongoose.Schema({
   fetchedAt: { type: Date, default: Date.now },
 });
 
+// Stale cache entries are purged automatically instead of accumulating forever.
+JobCacheSchema.index({ fetchedAt: 1 }, { expireAfterSeconds: 86400 });
+
 module.exports = mongoose.model("JobCache", JobCacheSchema);

--- a/backend/tests/jobCache.boundedKeys.unit.test.js
+++ b/backend/tests/jobCache.boundedKeys.unit.test.js
@@ -1,0 +1,114 @@
+import { Module } from "node:module";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// JobCache bounding fix (issue #1439): client-controlled role/country values
+// must be trimmed, normalized, and whitelisted before they form the cache key,
+// so the collection cannot grow unboundedly from arbitrary query strings.
+//
+// jobController.js is CommonJS, so we shim Node's module loader (same pattern
+// as registerEnumeration.unit.test.js) to avoid touching real Mongo models.
+// ---------------------------------------------------------------------------
+
+const sessionMock = vi.hoisted(() => ({ findOne: vi.fn() }));
+const jobCacheMock = vi.hoisted(() => ({
+  findOne: vi.fn(),
+  findOneAndUpdate: vi.fn(),
+}));
+const axiosMock = vi.hoisted(() => ({ get: vi.fn() }));
+
+const testDoubles = new Map();
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (testDoubles.has(request)) {
+    return testDoubles.get(request);
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const clearRequireCache = () => {
+  Object.keys(require.cache).forEach((key) => {
+    if (key.includes("controllers\\jobController") || key.includes("controllers/jobController")) {
+      delete require.cache[key];
+    }
+  });
+};
+
+let getJobs;
+
+beforeEach(() => {
+  clearRequireCache();
+  vi.stubEnv("ADZUNA_APP_ID", "test_app_id");
+  vi.stubEnv("ADZUNA_API_KEY", "test_api_key");
+  vi.stubEnv("ADZUNA_COUNTRY", "in");
+  sessionMock.findOne.mockReset();
+  jobCacheMock.findOne.mockReset();
+  jobCacheMock.findOneAndUpdate.mockReset();
+  axiosMock.get.mockReset();
+
+  testDoubles.set("../models/Session", {
+    findOne: sessionMock.findOne,
+  });
+  testDoubles.set("../models/JobCache", {
+    findOne: jobCacheMock.findOne,
+    findOneAndUpdate: jobCacheMock.findOneAndUpdate,
+  });
+  testDoubles.set("axios", { get: axiosMock.get });
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+const mockRes = () => {
+  const res = { statusCode: null, body: null };
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (body) => {
+    res.body = body;
+    return res;
+  };
+  return res;
+};
+
+const run = async (query) => {
+  const mod = await import("../controllers/jobController.js");
+  getJobs = mod.getJobs;
+  const sessionChain = {
+    sort: vi.fn(() => sessionChain),
+    select: vi.fn(async () => null),
+  };
+  sessionMock.findOne.mockReturnValue(sessionChain);
+  jobCacheMock.findOne.mockResolvedValue(null);
+  axiosMock.get.mockResolvedValue({ data: { results: [] } });
+  jobCacheMock.findOneAndUpdate.mockResolvedValue(null);
+
+  const req = { user: { _id: "user-1" }, query };
+  const res = mockRes();
+  await getJobs(req, res);
+  return jobCacheMock.findOneAndUpdate.mock.calls[0][0].cacheKey;
+};
+
+describe("getJobs — bounded cache keys (#1439)", () => {
+  it("trims and lowercases role and country", async () => {
+    const cacheKey = await run({ role: "  Software Engineer ", country: "US" });
+    expect(cacheKey).toBe("software engineer|us");
+  });
+
+  it("rejects invalid country and falls back to the configured country", async () => {
+    const cacheKey = await run({ role: "backend", country: "USA!!" });
+    expect(cacheKey).toBe("backend|in");
+  });
+
+  it("rejects over-long or non-whitelisted roles and falls back to the default", async () => {
+    const cacheKey = await run({ role: `${"x".repeat(200)}|;;DROP TABLE` });
+    expect(cacheKey).toBe("software engineer|in");
+  });
+
+  it("never creates keys from raw injected separators", async () => {
+    const cacheKey = await run({ role: "admin|*", country: "in'||1=1--" });
+    expect(cacheKey).toBe("software engineer|in");
+  });
+});


### PR DESCRIPTION
## Problem

`getJobs` (`backend/controllers/jobController.js`) built a global cache key from two arbitrary, unvalidated client-controlled query values — `req.query.role` and `req.query.country` — with no trimming, lowercasing (notably `country`), or whitelisting. Every distinct `role|country` combination upserted a permanent document (up to 10 large job listings each) into the shared `JobCache` collection. `refreshJobCache` did the same for attacker-controlled session `role` values.

The `JobCache` model had **no TTL, no expiry index, and no eviction**, so the collection grew without bound until Mongo storage/memory was exhausted.

## Fix

- `backend/controllers/jobController.js` — added `normalizeRole` (trim, lowercase, whitelist alphanumeric + spaces + limited punctuation, max 64 chars) and `normalizeCountry` (2-letter code). Invalid values fall back to defaults instead of creating new keys. Applied in both `getJobs` and `refreshJobCache`.
- `backend/models/JobCache.js` — added a TTL index `{ fetchedAt: 1 }, { expireAfterSeconds: 86400 }` so stale entries are purged automatically.
- `backend/tests/jobCache.boundedKeys.unit.test.js` — new vitest suite (Module._load shim pattern).

## Files changed

- `backend/controllers/jobController.js`
- `backend/models/JobCache.js`
- `backend/tests/jobCache.boundedKeys.unit.test.js`

## Testing

`npx vitest run tests/jobCache.boundedKeys.unit.test.js` — 4/4 passing. Asserts keys are trimmed/lowercased, invalid countries and over-long/injected roles fall back to defaults, and raw separators like `|` / `--` never reach the collection.

Closes #1439
