### PR TITLE
fix(sheets): restrict catalog write routes to admin allow-list

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -22,6 +22,11 @@ FRONTEND_ORIGIN=https://preppilot-12n6.onrender.com
 # For staging/preview: https://your-staging-frontend.onrender.com
 EXTRA_ORIGINS=http://localhost:5173,https://localhost:5173,http://127.0.0.1:5173
 
+# Administrator emails (comma-separated) allowed to write to the shared DSA
+# sheet catalog (/api/sheets/upload, /validate, PUT /:id, DELETE /:id).
+# Leave empty to keep admin write routes closed.
+ADMIN_EMAILS=
+
 # Google Gemini AI Configuration
 # Get your API key from: https://makersuite.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -44,4 +44,24 @@ const protect = async (req, res, next) => {
   }
 };
 
-module.exports = { protect };
+// Middleware to restrict a route to administrators (must run after protect).
+// Admins are allow-listed by email via the ADMIN_EMAILS env var
+// (comma-separated). With no allow-list configured, admin routes are closed.
+const requireAdmin = (req, res, next) => {
+  const adminEmails = (process.env.ADMIN_EMAILS || "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (adminEmails.length === 0) {
+    return res.status(403).json({ message: "Forbidden: no admins configured" });
+  }
+
+  if (!req.user || !adminEmails.includes(req.user.email.toLowerCase())) {
+    return res.status(403).json({ message: "Forbidden: admin access required" });
+  }
+
+  next();
+};
+
+module.exports = { protect, requireAdmin };

--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const Sheet = require('../models/Sheet');
-const { protect } = require('../middlewares/authMiddleware');
+const { protect, requireAdmin } = require('../middlewares/authMiddleware');
 const {
   normalizeSheet,
   computeSheetStats,
@@ -9,7 +9,7 @@ const {
 
 // POST /api/sheets/upload
 // Body: { filename: "file.json", data: {...sheet data...} }
-router.post('/upload', protect, async (req, res) => {
+router.post('/upload', protect, requireAdmin, async (req, res) => {
   const { filename, data } = req.body;
 
   if (!filename || !data) {
@@ -55,7 +55,7 @@ router.post('/upload', protect, async (req, res) => {
 // POST /api/sheets/validate
 // Body: { data: {...sheet data...} }
 // Dry-run: returns stats + errors without writing to the DB.
-router.post('/validate', protect, async (req, res) => {
+router.post('/validate', protect, requireAdmin, async (req, res) => {
   const { data } = req.body;
 
   if (!data) {
@@ -94,7 +94,7 @@ router.post('/validate', protect, async (req, res) => {
 
 // PUT /api/sheets/:id
 // Update a single sheet after validation.
-router.put('/:id', protect, async (req, res) => {
+router.put('/:id', protect, requireAdmin, async (req, res) => {
   const { id } = req.params;
   const body = req.body && req.body.sheet ? req.body.sheet : req.body;
 
@@ -127,7 +127,7 @@ router.put('/:id', protect, async (req, res) => {
 
 // DELETE /api/sheets/:id
 // Requires confirmId matching :id to prevent accidental deletion.
-router.delete('/:id', protect, async (req, res) => {
+router.delete('/:id', protect, requireAdmin, async (req, res) => {
   const { id } = req.params;
   const { confirmId } = req.body || {};
 

--- a/backend/tests/sheetRoutes.adminAuthz.unit.test.js
+++ b/backend/tests/sheetRoutes.adminAuthz.unit.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Issue #1446: /api/sheets write routes must be admin-only. Non-admin users
+// must receive 403 on POST /upload, POST /validate, PUT /:id, and DELETE /:id,
+// while the public read routes stay open.
+// ---------------------------------------------------------------------------
+
+let sheetRouter;
+let requireAdmin;
+
+beforeAll(async () => {
+  const sheetRouterMod = await import("../routes/sheetJsonUpload.js");
+  sheetRouter = sheetRouterMod.default ?? sheetRouterMod;
+
+  const authMod = await import("../middlewares/authMiddleware.js");
+  requireAdmin = authMod.requireAdmin;
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+function getLayerStack(router, method, path) {
+  const layer = router.stack.find(
+    (l) =>
+      l.route &&
+      l.route.path === path &&
+      l.route.methods[method.toLowerCase()]
+  );
+  if (!layer) return null;
+  return layer.route.stack.map((s) => s.handle);
+}
+
+const WRITE_ROUTES = [
+  ["POST", "/upload"],
+  ["POST", "/validate"],
+  ["PUT", "/:id"],
+  ["DELETE", "/:id"],
+];
+
+describe("/api/sheets write routes require admin (#1446)", () => {
+  it.each(WRITE_ROUTES)("%s %s mounts protect then requireAdmin", (method, path) => {
+    const stack = getLayerStack(sheetRouter, method, path);
+    expect(stack).not.toBeNull();
+    const protectIdx = stack.findIndex((fn) => fn && fn.name === "protect");
+    const adminIdx = stack.findIndex((fn) => fn && fn.name === "requireAdmin");
+    expect(protectIdx).toBeGreaterThanOrEqual(0);
+    expect(adminIdx).toBe(protectIdx + 1);
+  });
+});
+
+describe("public read routes remain unprotected (#1446)", () => {
+  it.each([
+    ["GET", "/"],
+    ["GET", "/:id"],
+  ])("%s %s does not mount protect or requireAdmin", (method, path) => {
+    const stack = getLayerStack(sheetRouter, method, path);
+    expect(stack).not.toBeNull();
+    expect(stack.some((fn) => fn && fn.name === "protect")).toBe(false);
+    expect(stack.some((fn) => fn && fn.name === "requireAdmin")).toBe(false);
+  });
+});
+
+describe("requireAdmin middleware (#1446)", () => {
+  it("returns 403 when no admin allow-list is configured", () => {
+    vi.stubEnv("ADMIN_EMAILS", "");
+    let statusCode = null;
+    const res = {
+      status: (code) => {
+        statusCode = code;
+        return res;
+      },
+      json: () => res,
+    };
+    requireAdmin({ user: { email: "user@example.com" } }, res, () => {});
+    expect(statusCode).toBe(403);
+  });
+
+  it("returns 403 for an email not in the allow-list", () => {
+    vi.stubEnv("ADMIN_EMAILS", "admin@example.com");
+    let statusCode = null;
+    const res = {
+      status: (code) => {
+        statusCode = code;
+        return res;
+      },
+      json: () => res,
+    };
+    requireAdmin({ user: { email: "user@example.com" } }, res, () => {});
+    expect(statusCode).toBe(403);
+  });
+
+  it("calls next() for an allow-listed email (case-insensitive)", () => {
+    vi.stubEnv("ADMIN_EMAILS", "Admin@Example.com");
+    let nextCalled = false;
+    const res = { status: () => res, json: () => res };
+    requireAdmin({ user: { email: "admin@example.com" } }, res, () => {
+      nextCalled = true;
+    });
+    expect(nextCalled).toBe(true);
+  });
+
+  it("returns 403 when req.user is missing", () => {
+    vi.stubEnv("ADMIN_EMAILS", "admin@example.com");
+    let statusCode = null;
+    const res = {
+      status: (code) => {
+        statusCode = code;
+        return res;
+      },
+      json: () => res,
+    };
+    requireAdmin({}, res, () => {});
+    expect(statusCode).toBe(403);
+  });
+});


### PR DESCRIPTION
## Problem

Any authenticated user can write to the shared DSA sheet catalog:

- `POST /api/sheets/upload` inserts a new canonical sheet.
- `POST /api/sheets/validate` is the upload dry-run.
- `PUT /api/sheets/:id` replaces an existing sheet wholesale (`findOneAndUpdate` with a plain replacement document).
- `DELETE /api/sheets/:id` deletes a canonical sheet.

All four routes are guarded only by `protect` (any logged-in user), so a
non-admin can overwrite or delete sheets that every user depends on. The
`User` model has no `role`/admin field, so there is currently no way to
restrict these routes to maintainers.

## Fix

Add an admin allow-list middleware and mount it on all four write routes:

- New `requireAdmin` middleware in `backend/middlewares/authMiddleware.js`.
  - Reads `ADMIN_EMAILS` env var (comma-separated list).
  - Trims/lowercases entries for a case-insensitive match against
    `req.user.email`.
  - Returns `403` when the allow-list is empty (write routes closed by
    default) or the user is not on it. Must run after `protect`.
- Mounted as `protect, requireAdmin` on `POST /upload`, `POST /validate`,
  `PUT /:id`, and `DELETE /:id` in `backend/routes/sheetJsonUpload.js`.
- Public read routes `GET /` and `GET /:id` stay open.
- Document `ADMIN_EMAILS` in `backend/.env.example`.

This requires no schema migration; admins are configured via environment
only.

## Files changed

- `backend/middlewares/authMiddleware.js` - added `requireAdmin`.
- `backend/routes/sheetJsonUpload.js` - mounted `requireAdmin` after
  `protect` on the four write routes.
- `backend/.env.example` - documented `ADMIN_EMAILS`.
- `backend/tests/sheetRoutes.adminAuthz.unit.test.js` - new suite.

## Testing

`npx vitest run tests/sheetValidation.unit.test.js tests/sheetRoutes.adminAuthz.unit.test.js`
- 27/27 tests pass, including:
  - All four write routes mount `protect` then `requireAdmin` in order.
  - `GET /` and `GET /:id` remain public.
  - `requireAdmin` returns 403 with no allow-list, for a non-listed email,
    and when `req.user` is missing; calls `next()` for a listed email.

## Related

Closes #1446
