### PR TITLE
fix(achievements): verify earn conditions server-side before granting

### DIFF
--- a/backend/constants/achievements.js
+++ b/backend/constants/achievements.js
@@ -12,4 +12,20 @@ const VALID_ACHIEVEMENTS = new Set([
   "DSA Master",
 ]);
 
-module.exports = { VALID_ACHIEVEMENTS };
+// Server-side earn conditions. An achievement is only persisted when the
+// user's real data meets its threshold; the client never decides who earns
+// what. `category` maps to a DB count for the current user:
+//   sessions -> Interview Session count
+//   resumes  -> Resume count
+//   sheets   -> followed DSA sheets (UserSheetProgress.followed === true)
+const ACHIEVEMENT_THRESHOLDS = {
+  "First Interview": { category: "sessions", min: 1 },
+  "Interview Pro": { category: "sessions", min: 5 },
+  "Interview Master": { category: "sessions", min: 25 },
+  "Resume Builder": { category: "resumes", min: 1 },
+  "Resume Expert": { category: "resumes", min: 5 },
+  "DSA Beginner": { category: "sheets", min: 1 },
+  "DSA Master": { category: "sheets", min: 5 },
+};
+
+module.exports = { VALID_ACHIEVEMENTS, ACHIEVEMENT_THRESHOLDS };

--- a/backend/controllers/achievementController.js
+++ b/backend/controllers/achievementController.js
@@ -1,5 +1,33 @@
 const User = require('../models/User');
-const { VALID_ACHIEVEMENTS } = require('../constants/achievements');
+const Session = require('../models/Session');
+const Resume = require('../models/Resume');
+const UserSheetProgress = require('../models/UserSheetProgress');
+const { VALID_ACHIEVEMENTS, ACHIEVEMENT_THRESHOLDS } = require('../constants/achievements');
+
+// Counts the user's real engagement per category, derived from actual
+// records rather than anything the client claims.
+const COUNT_QUERIES = {
+    sessions: (userId) => Session.countDocuments({ user: userId }),
+    resumes: (userId) => Resume.countDocuments({ user: userId }),
+    sheets: (userId) => UserSheetProgress.countDocuments({ userId, followed: true }),
+};
+
+// Computes the set of achievements the user has actually earned.
+async function computeEarnedAchievements(userId) {
+    const categories = new Set(
+        Object.values(ACHIEVEMENT_THRESHOLDS).map((spec) => spec.category),
+    );
+    const counts = {};
+    for (const category of categories) {
+        counts[category] = await COUNT_QUERIES[category](userId);
+    }
+
+    const earned = new Set();
+    for (const [id, spec] of Object.entries(ACHIEVEMENT_THRESHOLDS)) {
+        if (counts[spec.category] >= spec.min) earned.add(id);
+    }
+    return earned;
+}
 
 exports.getAchievements = async (req, res) => {
     try {
@@ -32,13 +60,22 @@ exports.saveAchievements = async (req, res) => {
     }
 
     try {
-        // $addToSet is idempotent and additive-only — it never removes
-        // achievements the user already earned, and never duplicates.
-        await User.findByIdAndUpdate(
-            req.user._id,
-            { $addToSet: { unlockedAchievements: { $each: unlockedAchievements } } },
-        );
-        res.json({ success: true });
+        // Server-side verification: only achievements whose earn condition is
+        // met by real user data are persisted. The allowlist above is
+        // defense-in-depth, never the sole authority.
+        const earned = await computeEarnedAchievements(req.user._id);
+        const granted = unlockedAchievements.filter((id) => earned.has(id));
+        const rejected = unlockedAchievements.filter((id) => !earned.has(id));
+
+        if (granted.length > 0) {
+            // $addToSet is idempotent and additive-only — it never removes
+            // achievements the user already earned, and never duplicates.
+            await User.findByIdAndUpdate(
+                req.user._id,
+                { $addToSet: { unlockedAchievements: { $each: granted } } },
+            );
+        }
+        res.json({ success: true, granted, rejected });
     } catch (err) {
         res.status(500).json({ success: false, error: "A server error occurred" });
     }

--- a/backend/tests/achievementController.unit.test.js
+++ b/backend/tests/achievementController.unit.test.js
@@ -1,69 +1,105 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Module from 'module';
 
 // ---------------------------------------------------------------------------
-// Inline mocks — no live DB needed.
+// CJS controllers load their deps via require(), which vi.mock cannot
+// intercept. We stub the models at the require level with a Module._load
+// shim instead, so no live DB is needed.
 // ---------------------------------------------------------------------------
+
+const modelMocks = {};
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request in modelMocks) return modelMocks[request];
+  return originalLoad.apply(this, arguments);
+};
 
 const mockFindById = vi.fn();
 const mockFindByIdAndUpdate = vi.fn();
+const mockSessionCount = vi.fn();
+const mockResumeCount = vi.fn();
+const mockSheetCount = vi.fn();
 
-vi.mock('../models/User.js', () => ({
-    default: {
-        findById: (...args) => mockFindById(...args),
-        findByIdAndUpdate: (...args) => mockFindByIdAndUpdate(...args),
-    },
-}));
+modelMocks['../models/User'] = {
+  findById: (...args) => mockFindById(...args),
+  findByIdAndUpdate: (...args) => mockFindByIdAndUpdate(...args),
+};
+modelMocks['../models/Session'] = {
+  countDocuments: (...args) => mockSessionCount(...args),
+};
+modelMocks['../models/Resume'] = {
+  countDocuments: (...args) => mockResumeCount(...args),
+};
+modelMocks['../models/UserSheetProgress'] = {
+  countDocuments: (...args) => mockSheetCount(...args),
+};
 
-// Re-import after mocks are in place
-const { getAchievements, saveAchievements } = await import('../controllers/achievementController.js');
+const { getAchievements, saveAchievements } = require('../controllers/achievementController');
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
 function makeReq(body = {}, userId = 'user-123') {
-    return { body, user: { _id: userId } };
+  return { body, user: { _id: userId } };
 }
 
 function makeRes() {
-    const res = {};
-    res.status = vi.fn().mockReturnValue(res);
-    res.json = vi.fn().mockReturnValue(res);
-    return res;
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
 }
+
+const ALL_IDS = [
+  'First Interview',
+  'Interview Pro',
+  'Interview Master',
+  'Resume Builder',
+  'Resume Expert',
+  'DSA Beginner',
+  'DSA Master',
+];
+
+beforeEach(() => {
+  mockFindById.mockReset();
+  mockFindByIdAndUpdate.mockReset();
+  mockSessionCount.mockReset();
+  mockResumeCount.mockReset();
+  mockSheetCount.mockReset();
+});
 
 // ---------------------------------------------------------------------------
 // getAchievements
 // ---------------------------------------------------------------------------
 
 describe('getAchievements', () => {
-    beforeEach(() => vi.clearAllMocks());
-
-    it('returns the user unlockedAchievements on success', async () => {
-        mockFindById.mockReturnValue({
-            select: vi.fn().mockResolvedValue({ unlockedAchievements: ['First Interview'] }),
-        });
-        const res = makeRes();
-        await getAchievements(makeReq(), res);
-        expect(res.json).toHaveBeenCalledWith({
-            success: true,
-            unlockedAchievements: ['First Interview'],
-        });
+  it('returns the user unlockedAchievements on success', async () => {
+    mockFindById.mockReturnValue({
+      select: vi.fn().mockResolvedValue({ unlockedAchievements: ['First Interview'] }),
     });
-
-    it('returns 404 when user is not found', async () => {
-        mockFindById.mockReturnValue({ select: vi.fn().mockResolvedValue(null) });
-        const res = makeRes();
-        await getAchievements(makeReq(), res);
-        expect(res.status).toHaveBeenCalledWith(404);
+    const res = makeRes();
+    await getAchievements(makeReq(), res);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      unlockedAchievements: ['First Interview'],
     });
+  });
 
-    it('returns 500 on a database error', async () => {
-        mockFindById.mockReturnValue({ select: vi.fn().mockRejectedValue(new Error('DB down')) });
-        const res = makeRes();
-        await getAchievements(makeReq(), res);
-        expect(res.status).toHaveBeenCalledWith(500);
-    });
+  it('returns 404 when user is not found', async () => {
+    mockFindById.mockReturnValue({ select: vi.fn().mockResolvedValue(null) });
+    const res = makeRes();
+    await getAchievements(makeReq(), res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 500 on a database error', async () => {
+    mockFindById.mockReturnValue({ select: vi.fn().mockRejectedValue(new Error('DB down')) });
+    const res = makeRes();
+    await getAchievements(makeReq(), res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -71,82 +107,127 @@ describe('getAchievements', () => {
 // ---------------------------------------------------------------------------
 
 describe('saveAchievements — input validation', () => {
-    beforeEach(() => vi.clearAllMocks());
+  it('returns 400 when unlockedAchievements is missing', async () => {
+    const res = makeRes();
+    await saveAchievements(makeReq({}), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
 
-    it('returns 400 when unlockedAchievements is missing', async () => {
-        const res = makeRes();
-        await saveAchievements(makeReq({}), res);
-        expect(res.status).toHaveBeenCalledWith(400);
-        expect(res.json).toHaveBeenCalledWith(
-            expect.objectContaining({ success: false }),
-        );
-    });
+  it('returns 400 when unlockedAchievements is not an array', async () => {
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: 'First Interview' }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 
-    it('returns 400 when unlockedAchievements is not an array', async () => {
-        const res = makeRes();
-        await saveAchievements(makeReq({ unlockedAchievements: 'First Interview' }), res);
-        expect(res.status).toHaveBeenCalledWith(400);
-    });
+  it('returns 400 when an unknown achievement ID is submitted', async () => {
+    const res = makeRes();
+    await saveAchievements(
+      makeReq({ unlockedAchievements: ['First Interview', 'FAKE_ACHIEVEMENT'] }),
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, error: expect.stringContaining('FAKE_ACHIEVEMENT') }),
+    );
+  });
 
-    it('returns 400 when an unknown achievement ID is submitted', async () => {
-        const res = makeRes();
-        await saveAchievements(
-            makeReq({ unlockedAchievements: ['First Interview', 'FAKE_ACHIEVEMENT'] }),
-            res,
-        );
-        expect(res.status).toHaveBeenCalledWith(400);
-        expect(res.json).toHaveBeenCalledWith(
-            expect.objectContaining({ success: false, error: expect.stringContaining('FAKE_ACHIEVEMENT') }),
-        );
-    });
-
-    it('returns 400 when every achievement ID in the system is force-submitted', async () => {
-        // Simulates the exact exploit described in the issue
-        const allIds = [
-            'First Interview', 'Interview Pro', 'Interview Master',
-            'Resume Builder', 'Resume Expert', 'DSA Beginner', 'DSA Master',
-            'INJECTED_SUPER_BADGE',
-        ];
-        const res = makeRes();
-        await saveAchievements(makeReq({ unlockedAchievements: allIds }), res);
-        expect(res.status).toHaveBeenCalledWith(400);
-    });
+  it('returns 400 when every achievement ID plus an injected badge is force-submitted', async () => {
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: [...ALL_IDS, 'INJECTED_SUPER_BADGE'] }), res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
 });
 
 // ---------------------------------------------------------------------------
-// saveAchievements — additive-only semantics
+// saveAchievements — server-side earn-condition verification
 // ---------------------------------------------------------------------------
 
-describe('saveAchievements — additive-only semantics', () => {
-    beforeEach(() => vi.clearAllMocks());
+describe('saveAchievements — server-side verification', () => {
+  it('grants only achievements whose earn condition is met by real data', async () => {
+    // 1 interview session, no resumes, no followed sheets
+    mockSessionCount.mockResolvedValue(1);
+    mockResumeCount.mockResolvedValue(0);
+    mockSheetCount.mockResolvedValue(0);
 
-    it('uses $addToSet so existing achievements are never removed', async () => {
-        mockFindByIdAndUpdate.mockResolvedValue({});
-        const res = makeRes();
-        await saveAchievements(
-            makeReq({ unlockedAchievements: ['First Interview'] }),
-            res,
-        );
-        const [, update] = mockFindByIdAndUpdate.mock.calls[0];
-        expect(update).toHaveProperty('$addToSet');
-        expect(update).not.toHaveProperty('unlockedAchievements'); // no wholesale replace
-        expect(res.json).toHaveBeenCalledWith({ success: true });
-    });
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: ALL_IDS }), res);
 
-    it('succeeds with an empty array without touching the DB', async () => {
-        const res = makeRes();
-        await saveAchievements(makeReq({ unlockedAchievements: [] }), res);
-        // No unknown IDs, but nothing to add — still resolves successfully
-        expect(res.json).toHaveBeenCalledWith({ success: true });
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      granted: ['First Interview'],
+      rejected: ALL_IDS.filter((id) => id !== 'First Interview'),
     });
+    expect(mockFindByIdAndUpdate).toHaveBeenCalledWith(
+      'user-123',
+      { $addToSet: { unlockedAchievements: { $each: ['First Interview'] } } },
+    );
+  });
 
-    it('returns 500 on a database error', async () => {
-        mockFindByIdAndUpdate.mockRejectedValue(new Error('DB error'));
-        const res = makeRes();
-        await saveAchievements(
-            makeReq({ unlockedAchievements: ['First Interview'] }),
-            res,
-        );
-        expect(res.status).toHaveBeenCalledWith(500);
+  it('persists nothing when no claimed achievement is earned', async () => {
+    mockSessionCount.mockResolvedValue(0);
+    mockResumeCount.mockResolvedValue(0);
+    mockSheetCount.mockResolvedValue(0);
+
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: ['DSA Master'] }), res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      granted: [],
+      rejected: ['DSA Master'],
     });
+    expect(mockFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('grants the full set at the threshold boundary', async () => {
+    mockSessionCount.mockResolvedValue(25);
+    mockResumeCount.mockResolvedValue(5);
+    mockSheetCount.mockResolvedValue(5);
+
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: ALL_IDS }), res);
+
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      granted: ALL_IDS,
+      rejected: [],
+    });
+  });
+
+  it('uses $addToSet so existing achievements are never removed', async () => {
+    mockSessionCount.mockResolvedValue(1);
+    mockResumeCount.mockResolvedValue(0);
+    mockSheetCount.mockResolvedValue(0);
+
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: ['First Interview'] }), res);
+
+    const [, update] = mockFindByIdAndUpdate.mock.calls[0];
+    expect(update).toHaveProperty('$addToSet');
+    expect(update).not.toHaveProperty('unlockedAchievements');
+  });
+
+  it('succeeds with an empty array without touching the DB', async () => {
+    mockSessionCount.mockResolvedValue(0);
+    mockResumeCount.mockResolvedValue(0);
+    mockSheetCount.mockResolvedValue(0);
+
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: [] }), res);
+
+    expect(mockFindByIdAndUpdate).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ success: true, granted: [], rejected: [] });
+  });
+
+  it('returns 500 on a database error', async () => {
+    mockSessionCount.mockRejectedValue(new Error('DB error'));
+
+    const res = makeRes();
+    await saveAchievements(makeReq({ unlockedAchievements: ['First Interview'] }), res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
 });


### PR DESCRIPTION
## Problem

`saveAchievements` persisted whatever achievement IDs the client sent. The
only server-side check was the hardcoded allowlist
(`backend/constants/achievements.js`) — there was no verification that the
user actually met the earn condition (completed interview sessions, created
resumes, followed DSA sheets, etc.). Any authenticated user could unlock the
entire set in one request:

```text
POST /api/user/achievements
{ "unlockedAchievements": ["First Interview","Interview Pro","Interview Master",
  "Resume Builder","Resume Expert","DSA Beginner","DSA Master"] }
-> 200 { success: true }
```

## Fix

Achievements are now granted only when the user's real data proves the earn
condition is met:

- `backend/constants/achievements.js` now exports `ACHIEVEMENT_THRESHOLDS`,
  mapping each achievement ID to a `category` + minimum count:
  - `sessions` -> Interview `Session` count: First Interview (1),
    Interview Pro (5), Interview Master (25)
  - `resumes` -> `Resume` count: Resume Builder (1), Resume Expert (5)
  - `sheets` -> followed DSA sheets (`UserSheetProgress.followed === true`):
    DSA Beginner (1), DSA Master (5)
- `backend/controllers/achievementController.js`:
  - New `computeEarnedAchievements(userId)` runs real `countDocuments` queries
    against `Session`, `Resume`, and `UserSheetProgress` for the user.
  - `saveAchievements` filters the claimed IDs against the computed earned
    set; only verified IDs are persisted via `$addToSet`.
  - Response now reports `{ success: true, granted, rejected }` so the client
    knows which claims were accepted and which were denied.
  - The allowlist stays as defense-in-depth, but is no longer the sole
    authority.

No client changes required; the endpoint contract (POST an array of IDs)
is unchanged.

## Files changed

- `backend/constants/achievements.js` - added `ACHIEVEMENT_THRESHOLDS`.
- `backend/controllers/achievementController.js` - added
  `computeEarnedAchievements` and server-side verification in
  `saveAchievements`.
- `backend/tests/achievementController.unit.test.js` - rewrote with a
  `Module._load` shim (the previous `vi.mock` could not intercept the CJS
  controller's `require()` calls) and added earn-condition tests.

## Testing

`npx vitest run tests/achievementController.unit.test.js` - 13/13 pass,
including:
- All previous input-validation cases (missing/not-an-array/unknown IDs).
- A user with 1 session, 0 resumes, 0 sheets claiming all 7 gets only
  `First Interview`; the rest are rejected and not persisted.
- A user with 0 sessions claiming `DSA Master` gets an empty `granted` and
  no DB write.
- A user at the threshold boundary (25 sessions, 5 resumes, 5 sheets) is
  granted the full set.
- `$addToSet` semantics preserved; empty array touches no DB.

## Related

Closes #1447
