### PR TITLE
fix(roadmaps): keep completed toggle on subtask-less milestones

### DIFF
--- a/backend/controllers/roadmapController.js
+++ b/backend/controllers/roadmapController.js
@@ -196,6 +196,13 @@ const toggleTask = async (req, res) => {
       if (status !== undefined) {
         milestone.status = status;
         milestone.completed = status === "done";
+      } else if (
+        completed !== undefined &&
+        !(milestone.subtasks && milestone.subtasks.length > 0)
+      ) {
+        // Subtask-less milestones treat `completed` as the source of truth:
+        // sync `status` so recomputeProgress() doesn't revert the toggle.
+        milestone.status = completed ? "done" : "todo";
       }
       // If a milestone with subtasks is toggled directly, cascade to subtasks
       if (

--- a/backend/tests/roadmapController.toggleTask.unit.test.js
+++ b/backend/tests/roadmapController.toggleTask.unit.test.js
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Uses the real RoadmapProject model (no DB connection needed): we stub the
+// static findOne and the instance save, then drive toggleTask and assert on
+// the in-memory roadmap after recomputeProgress() runs.
+// ---------------------------------------------------------------------------
+
+const RoadmapProject = require('../models/RoadmapProject');
+const { toggleTask } = require('../controllers/roadmapController');
+
+const VALID_USER_ID = '507f1f77bcf86cd799439011';
+
+function makeRoadmap(milestones) {
+  const roadmap = new RoadmapProject({
+    userId: VALID_USER_ID,
+    projectIdea: 'Test project',
+    milestones,
+    testingChecklist: [],
+  });
+  roadmap.save = vi.fn().mockResolvedValue(roadmap);
+  return roadmap;
+}
+
+function makeReq(body, roadmap) {
+  return {
+    params: { id: 'roadmap-1' },
+    user: { _id: VALID_USER_ID },
+    body,
+    roadmap, // test helper to inject the found roadmap
+  };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+const milestone = (overrides = {}) => ({
+  id: 'm1',
+  title: 'Milestone',
+  description: '',
+  order: 0,
+  completed: false,
+  status: 'todo',
+  notes: '',
+  subtasks: [],
+  ...overrides,
+});
+
+beforeEach(() => {
+  RoadmapProject.findOne = vi.fn();
+});
+
+describe('toggleTask — subtask-less milestone (issue #1448)', () => {
+  it('persists completed: true and reports a completed roadmap', async () => {
+    const roadmap = makeRoadmap([milestone()]);
+    RoadmapProject.findOne.mockResolvedValue(roadmap);
+
+    const res = makeRes();
+    await toggleTask(makeReq({ type: 'milestone', milestoneId: 'm1', completed: true }, roadmap), res);
+
+    const sent = res.json.mock.calls[0][0];
+    expect(sent.success).toBe(true);
+    expect(sent.roadmap.milestones[0].completed).toBe(true);
+    expect(sent.roadmap.milestones[0].status).toBe('done');
+    expect(sent.roadmap.progressPercent).toBe(100);
+    expect(sent.roadmap.status).toBe('completed');
+    expect(roadmap.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists completed: false on a done milestone and reverts progress', async () => {
+    const roadmap = makeRoadmap([
+      milestone({ completed: true, status: 'done' }),
+    ]);
+    RoadmapProject.findOne.mockResolvedValue(roadmap);
+
+    const res = makeRes();
+    await toggleTask(makeReq({ type: 'milestone', milestoneId: 'm1', completed: false }, roadmap), res);
+
+    const sent = res.json.mock.calls[0][0];
+    expect(sent.success).toBe(true);
+    expect(sent.roadmap.milestones[0].completed).toBe(false);
+    expect(sent.roadmap.milestones[0].status).toBe('todo');
+    expect(sent.roadmap.progressPercent).toBe(0);
+    expect(sent.roadmap.status).toBe('planning');
+  });
+
+  it('still honors an explicit status change', async () => {
+    const roadmap = makeRoadmap([milestone()]);
+    RoadmapProject.findOne.mockResolvedValue(roadmap);
+
+    const res = makeRes();
+    await toggleTask(
+      makeReq({ type: 'milestone', milestoneId: 'm1', status: 'in-progress' }, roadmap),
+      res,
+    );
+
+    const sent = res.json.mock.calls[0][0];
+    expect(sent.roadmap.milestones[0].status).toBe('in-progress');
+    expect(sent.roadmap.milestones[0].completed).toBe(false);
+  });
+});
+
+describe('toggleTask — milestone with subtasks (regression guard)', () => {
+  it('derives completed/status from the cascaded subtasks', async () => {
+    const roadmap = makeRoadmap([
+      milestone({
+        subtasks: [
+          { id: 's1', title: 'A', completed: false },
+          { id: 's2', title: 'B', completed: false },
+        ],
+      }),
+    ]);
+    RoadmapProject.findOne.mockResolvedValue(roadmap);
+
+    const res = makeRes();
+    await toggleTask(makeReq({ type: 'milestone', milestoneId: 'm1', completed: true }, roadmap), res);
+
+    const sent = res.json.mock.calls[0][0];
+    const m = sent.roadmap.milestones[0];
+    expect(m.subtasks.every((s) => s.completed)).toBe(true);
+    expect(m.completed).toBe(true);
+    expect(m.status).toBe('done');
+    expect(sent.roadmap.progressPercent).toBe(100);
+    expect(sent.roadmap.status).toBe('completed');
+  });
+});


### PR DESCRIPTION
## Problem

`PATCH /api/roadmaps/:id/tasks` with `{ type: "milestone", milestoneId, completed: true }`
(no `status`) returned 200 with a self-contradictory roadmap. `toggleTask`
set `milestone.completed = true`, but `recomputeProgress()`
(`backend/models/RoadmapProject.js` line 126) immediately re-synced
subtask-less milestones with `m.completed = m.status === "done"` — and since
`status` stayed `"todo"`, the toggle was silently reverted:

```text
PATCH /api/roadmaps/:id/tasks  { type: "milestone", milestoneId, completed: true }
-> 200 { success: true, roadmap: { milestones: [{ completed: false, status: "todo" }],
                                   progressPercent: 100, status: "completed" } }
```

`progressPercent` was computed from the pre-revert value, so the roadmap
saved as "completed" while nothing was actually marked complete. The reverse
(clearing `completed` on a `"done"` milestone) was discarded too.

## Fix

Normalize `status` from the toggled `completed` value before
`recomputeProgress()` runs, so the model's sync rule no longer discards the
toggle:

In `toggleTask` (`backend/controllers/roadmapController.js`), when `status`
was omitted, `completed` was provided, and the milestone is subtask-less:

```js
milestone.status = completed ? "done" : "todo";
```

This matches the milestone's documented contract: subtask-less milestones
are toggled manually (`completed` is the toggle field); subtask milestones
are auto-derived and are intentionally left untouched. An explicit `status`
still wins when both are sent.

## Files changed

- `backend/controllers/roadmapController.js` - sync `status` for subtask-less
  milestone toggles before `recomputeProgress()`.
- `backend/tests/roadmapController.toggleTask.unit.test.js` - new suite.

## Testing

`npx vitest run tests/roadmapController.toggleTask.unit.test.js` - 4/4 pass:

- `completed: true` on a subtask-less milestone persists
  `completed === true`, `status === "done"`, `progressPercent === 100`,
  `status === "completed"`.
- `completed: false` on a `"done"` milestone reverts to `completed === false`,
  `progressPercent === 0`, `status === "planning"`.
- An explicit `status` change is still honored.
- A milestone with subtasks still cascades and derives completion from them.

## Related

Closes #1448
