### PR TITLE
fix(questions): make addQuestionToSession atomic and bounded

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -8,7 +8,9 @@ const addQuestionToSessionSchema = z.object({
       question: z.string().min(1, "Question text is required"),
       answer: z.string().min(1, "Answer text is required"),
     })
-  ).min(1, "At least one question is required"),
+  )
+    .min(1, "At least one question is required")
+    .max(50, "At most 50 questions per request"),
 });
 
 // Schema for toggling pin (params only)

--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -115,39 +115,66 @@ const getMyQuestions = async (req, res) => {
  * 201 [{"_id":"...","session":"...","question":"...","answer":"..."}]
  */
 const addQuestionToSession = async (req, res) => {
-  try {
-    const { sessionId, questions } = req.body;
+  const mongoSession = await mongoose.startSession();
 
-    if (!sessionId || !Array.isArray(questions) || questions.length === 0) {
+  try {
+    let createdQuestions;
+
+    await mongoSession.withTransaction(async () => {
+      const { sessionId, questions } = req.body;
+
+      if (!sessionId || !Array.isArray(questions) || questions.length === 0) {
+        throw new Error("INVALID_INPUT");
+      }
+
+      const session = await Session.findById(sessionId).session(mongoSession);
+
+      if (!session) {
+        throw new Error("SESSION_NOT_FOUND");
+      }
+
+      if (!session.user || session.user.toString() !== req.user._id.toString()) {
+        throw new Error("FORBIDDEN");
+      }
+
+      createdQuestions = await Question.insertMany(
+        questions.map((q) => ({
+          session: sessionId,
+          question: q.question,
+          answer: q.answer,
+        })),
+        { session: mongoSession }
+      );
+
+      // Atomic linkage: $push on the session document (no read-modify-write),
+      // so concurrent adds both persist without losing a batch. The insert and
+      // this update commit or roll back together inside the transaction, so a
+      // failed session update can never leave orphaned questions.
+      await Session.updateOne(
+        { _id: sessionId },
+        { $push: { questions: { $each: createdQuestions.map((q) => q._id) } } },
+        { session: mongoSession }
+      );
+    });
+
+    res.status(201).json(createdQuestions);
+  } catch (error) {
+    if (error.message === "INVALID_INPUT") {
       return res.status(400).json({
         success: false,
         message: "Valid sessionId and non-empty questions array are required.",
       });
     }
-
-    const session = await Session.findById(sessionId);
-
-    if (!session) {
+    if (error.message === "SESSION_NOT_FOUND") {
       return res.status(404).json({ success: false, message: "Requested session could not be found" });
     }
-
-    if (!session.user || session.user.toString() !== req.user._id.toString()) {
+    if (error.message === "FORBIDDEN") {
       return res.status(403).json({ success: false, message: "Unauthorized access" });
     }
-    const createdQuestions = await Question.insertMany(
-      questions.map((q) => ({
-        session: sessionId,
-        question: q.question,
-        answer: q.answer,
-      }))
-    );
-    //update session to include new question IDs
-    session.questions.push(...createdQuestions.map((q) => q._id));
-    await session.save();
-    res.status(201).json(createdQuestions);
-  } catch (error) {
     console.error("Add question error:", error);
-    res.status(500).json({ success: false, message: "Internal server error occurred" });
+    return res.status(500).json({ success: false, message: "Internal server error occurred" });
+  } finally {
+    await mongoSession.endSession();
   }
 };
 

--- a/backend/tests/questionController.ownership.unit.test.js
+++ b/backend/tests/questionController.ownership.unit.test.js
@@ -1,36 +1,46 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import Module from "module";
 
 // ---------------------------------------------------------------------------
-// Unit tests for addQuestionToSession — ownership guard
+// CJS controller mocks via Module._load shim (vi.mock cannot intercept the
+// require() calls inside the CJS controller).
 // ---------------------------------------------------------------------------
 
-// Mock Mongoose models before importing the controller
-vi.mock("../models/Session.js", () => ({
-  default: { findById: vi.fn() },
-}));
-vi.mock("../models/Question.js", () => ({
-  default: { insertMany: vi.fn() },
-}));
+const moduleMocks = {};
 
-let addQuestionToSession;
-let Session;
-let Question;
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request in moduleMocks) return moduleMocks[request];
+  return originalLoad.apply(this, arguments);
+};
 
-beforeEach(async () => {
-  vi.resetModules();
-  vi.clearAllMocks();
+const mockStartSession = vi.fn();
+const mockSessionFindById = vi.fn();
+const mockSessionUpdateOne = vi.fn();
+const mockQuestionInsertMany = vi.fn();
 
-  // Re-import after reset so mocks are fresh each suite
-  const ctrl = await import("../controllers/questionController.js");
-  addQuestionToSession = ctrl.addQuestionToSession;
+function makeFakeMongoSession() {
+  return {
+    withTransaction: async (fn) => fn(),
+    endSession: vi.fn().mockResolvedValue(),
+  };
+}
 
-  Session = (await import("../models/Session.js")).default;
-  Question = (await import("../models/Question.js")).default;
-});
+moduleMocks["mongoose"] = {
+  startSession: (...args) => mockStartSession(...args),
+};
 
-// ---------------------------------------------------------------------------
-// Helper: build minimal req / res stubs
-// ---------------------------------------------------------------------------
+moduleMocks["../models/Session"] = {
+  findById: (...args) => mockSessionFindById(...args),
+  updateOne: (...args) => mockSessionUpdateOne(...args),
+};
+
+moduleMocks["../models/Question"] = {
+  insertMany: (...args) => mockQuestionInsertMany(...args),
+};
+
+const { addQuestionToSession } = require("../controllers/questionController");
+
 function makeReq({ sessionId, questions, userId }) {
   return {
     body: { sessionId, questions },
@@ -45,18 +55,24 @@ function makeRes() {
   return res;
 }
 
-// ---------------------------------------------------------------------------
-// 403 — User B tries to write into User A's session
-// ---------------------------------------------------------------------------
+beforeEach(() => {
+  mockStartSession.mockReset();
+  mockSessionFindById.mockReset();
+  mockSessionUpdateOne.mockReset();
+  mockQuestionInsertMany.mockReset();
+
+  mockStartSession.mockResolvedValue(makeFakeMongoSession());
+});
+
 describe("addQuestionToSession — cross-user write (issue #212)", () => {
   it("returns 403 when req.user does not own the session", async () => {
     const ownerUserId = "aaaaaaaaaaaaaaaaaaaaaaaa";
     const attackerUserId = "bbbbbbbbbbbbbbbbbbbbbbbb";
 
-    Session.findById.mockResolvedValue({
-      user: { toString: () => ownerUserId },
-      questions: [],
-      save: vi.fn(),
+    mockSessionFindById.mockReturnValue({
+      session: vi.fn().mockResolvedValue({
+        user: { toString: () => ownerUserId },
+      }),
     });
 
     const req = makeReq({
@@ -72,31 +88,28 @@ describe("addQuestionToSession — cross-user write (issue #212)", () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ success: false, message: "Unauthorized access" })
     );
-    // Critical: no questions must have been written
-    expect(Question.insertMany).not.toHaveBeenCalled();
+    expect(mockQuestionInsertMany).not.toHaveBeenCalled();
+    expect(mockSessionUpdateOne).not.toHaveBeenCalled();
   });
 });
 
-// ---------------------------------------------------------------------------
-// 201 — Owner adds questions to their own session (happy path)
-// ---------------------------------------------------------------------------
 describe("addQuestionToSession — owner adds questions", () => {
-  it("returns 201 and persists questions when the caller owns the session", async () => {
+  it("returns 201, inserts questions, and links them atomically", async () => {
     const userId = "aaaaaaaaaaaaaaaaaaaaaaaa";
     const sessionId = "sessionid123";
 
-    const mockSession = {
-      user: { toString: () => userId },
-      questions: [],
-      save: vi.fn().mockResolvedValue(true),
-    };
+    mockSessionFindById.mockReturnValue({
+      session: vi.fn().mockResolvedValue({
+        user: { toString: () => userId },
+      }),
+    });
 
     const mockCreated = [
       { _id: "q1", session: sessionId, question: "What is closure?", answer: "A function…" },
     ];
 
-    Session.findById.mockResolvedValue(mockSession);
-    Question.insertMany.mockResolvedValue(mockCreated);
+    mockQuestionInsertMany.mockResolvedValue(mockCreated);
+    mockSessionUpdateOne.mockResolvedValue({ modifiedCount: 1 });
 
     const req = makeReq({
       sessionId,
@@ -107,19 +120,54 @@ describe("addQuestionToSession — owner adds questions", () => {
 
     await addQuestionToSession(req, res);
 
-    expect(Question.insertMany).toHaveBeenCalledOnce();
-    expect(mockSession.save).toHaveBeenCalledOnce();
+    expect(mockQuestionInsertMany).toHaveBeenCalledOnce();
+    expect(mockQuestionInsertMany).toHaveBeenCalledWith(
+      [{ session: sessionId, question: "What is closure?", answer: "A function…" }],
+      expect.objectContaining({ session: expect.anything() }),
+    );
+    // Atomic $push linkage (no read-modify-write) so concurrent adds don't
+    // lose a batch; the session's questions array is never saved wholesale.
+    expect(mockSessionUpdateOne).toHaveBeenCalledWith(
+      { _id: sessionId },
+      { $push: { questions: { $each: ["q1"] } } },
+      expect.objectContaining({ session: expect.anything() }),
+    );
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith(mockCreated);
   });
+
+  it("returns 500 and rolls back when the session linkage update fails (no orphans)", async () => {
+    const userId = "aaaaaaaaaaaaaaaaaaaaaaaa";
+    const sessionId = "sessionid123";
+
+    mockSessionFindById.mockReturnValue({
+      session: vi.fn().mockResolvedValue({ user: { toString: () => userId } }),
+    });
+    mockQuestionInsertMany.mockResolvedValue([{ _id: "q1" }]);
+    mockSessionUpdateOne.mockRejectedValue(new Error("DB down"));
+
+    const res = makeRes();
+    await addQuestionToSession(
+      makeReq({
+        sessionId,
+        questions: [{ question: "Q", answer: "A" }],
+        userId,
+      }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    // The insert and linkage run in one transaction (withTransaction), so a
+    // failure here aborts the whole operation rather than orphaning questions.
+    expect(mockQuestionInsertMany).toHaveBeenCalled();
+  });
 });
 
-// ---------------------------------------------------------------------------
-// 404 — session not found still returns 404 (regression)
-// ---------------------------------------------------------------------------
 describe("addQuestionToSession — session not found", () => {
   it("returns 404 when session does not exist", async () => {
-    Session.findById.mockResolvedValue(null);
+    mockSessionFindById.mockReturnValue({
+      session: vi.fn().mockResolvedValue(null),
+    });
 
     const req = makeReq({
       sessionId: "nonexistent",
@@ -131,13 +179,10 @@ describe("addQuestionToSession — session not found", () => {
     await addQuestionToSession(req, res);
 
     expect(res.status).toHaveBeenCalledWith(404);
-    expect(Question.insertMany).not.toHaveBeenCalled();
+    expect(mockQuestionInsertMany).not.toHaveBeenCalled();
   });
 });
 
-// ---------------------------------------------------------------------------
-// 400 — missing / invalid body (regression)
-// ---------------------------------------------------------------------------
 describe("addQuestionToSession — bad input", () => {
   it("returns 400 when questions is not an array", async () => {
     const req = makeReq({ sessionId: "s1", questions: "bad", userId: "u1" });


### PR DESCRIPTION
## Problem

`addQuestionToSession` performed two writes that were not atomic:

```js
const createdQuestions = await Question.insertMany(questions.map(...)); // write 1
session.questions.push(...createdQuestions.map((q) => q._id));          // memory
await session.save();                                                   // write 2
```

1. If `session.save()` failed (or the connection dropped between the
   writes), the `Question` documents were already inserted but never linked —
   permanently orphaned rows no API path surfaces.
2. Two concurrent `addQuestionToSession` calls each loaded the session,
   pushed their own IDs, and `save()`d; the later `save()` overwrote the
   earlier push, silently dropping one batch's linkage.
3. `questions` had no upper bound per request.

## Fix

`backend/controllers/questionController.js` — `addQuestionToSession` now
runs entirely inside a `mongoose.startSession()` transaction (mirroring
`createSession` / `deleteSession`), and the linkage is an atomic `$push`:

- The session ownership check, `Question.insertMany`, and the session update
  commit or roll back together — a failed session update can no longer leave
  orphaned questions.
- Linkage uses `Session.updateOne({ _id }, { $push: { questions: { $each: ids } } })`
  instead of read-modify-write + `save()`, so concurrent adds both persist
  without losing a batch.
- Input/ownership errors map to 400/404/403 explicitly.

`backend/Input_validators/ValidateQuestions.js` — the `questions` array is
now capped at `max(50)` per request.

## Files changed

- `backend/controllers/questionController.js` - transactional
  `addQuestionToSession` with atomic `$push` linkage.
- `backend/Input_validators/ValidateQuestions.js` - `questions` capped at 50.
- `backend/tests/questionController.ownership.unit.test.js` - rewrote with a
  `Module._load` shim (the previous `vi.mock` could not intercept the CJS
  controller's `require()` calls; it was already failing 5/5 on
  `origin/main`).

## Testing

`npx vitest run tests/questionController.ownership.unit.test.js` - 6/6 pass:

- 403 cross-user write: no insert, no linkage update.
- 201 happy path: `insertMany` once; linkage via `$push: { questions: { $each } }`
  (no `session.save()`).
- Linkage update failure -> 500; both writes run inside one `withTransaction`,
  so no orphaned questions are possible.
- 404 when the session does not exist.
- 400 for invalid/missing input.
- `questionBank.unit.test.js` still passes (6/6).

## Related

Closes #1453
