### PR TITLE
fix(resume): added max length guard to latexCode field in compile and save endpoints

### DIFF
--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -17,10 +17,16 @@ const { generateWithFallback } = require('../utils/geminiHelper');
  * @example
  * 200 <PDF binary response>
  */
+const MAX_LATEX_CODE_LENGTH = 100000; // ~100KB — prevents oversized submissions to texlive.net
+
 const compileResume = async (req, res) => {
     try {
         const { code } = req.body;
-      
+
+        if (!code || typeof code !== 'string' || code.length > MAX_LATEX_CODE_LENGTH) {
+            return res.status(400).json({ message: "LaTeX code exceeds the maximum allowed length of 100KB" });
+        }
+
         // Normalize line endings to UNIX format, as texlive.net is highly sensitive to Windows \r\n
         const cleanCode = code.replace(/\r\n/g, '\n');
 
@@ -185,6 +191,10 @@ const saveResume = async (req, res) => {
 
         if (!title || !latexCode) {
             return res.status(400).json({ success: false, message: "Title and LaTeX code are required." });
+        }
+
+        if (latexCode.length > MAX_LATEX_CODE_LENGTH) {
+            return res.status(400).json({ success: false, message: "LaTeX code exceeds the maximum allowed length of 100KB" });
         }
 
         let resume;


### PR DESCRIPTION
## Summary of What Has Been Done

Added a `MAX_LATEX_CODE_LENGTH` constant (100KB) at the top of `backend/controllers/resumeController.js` and enforced it in two places:

1. **`compileResume`**: validates `code` length before sending to texlive.net, returning 400 if exceeded.
2. **`saveResume`**: validates `latexCode` length before storing in MongoDB, returning 400 if exceeded.

## Changes Made

Modified `backend/controllers/resumeController.js`:
```js
const MAX_LATEX_CODE_LENGTH = 100000; // ~100KB — prevents oversized submissions to texlive.net

// In compileResume (after extracting code):
if (!code || typeof code !== 'string' || code.length > MAX_LATEX_CODE_LENGTH) {
    return res.status(400).json({ message: "LaTeX code exceeds the maximum allowed length of 100KB" });
}

// In saveResume (after basic field checks):
if (latexCode.length > MAX_LATEX_CODE_LENGTH) {
    return res.status(400).json({ success: false, message: "LaTeX code exceeds the maximum allowed length of 100KB" });
}
```

## Impact it Made

Prevents abuse via oversized LaTeX submissions. Bounds memory usage on the texlive.net proxy and storage in MongoDB. Without this fix, a malicious client could submit multi-MB LaTeX documents causing DoS conditions.

Closes #1474

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a 100,000-character limit for `latexCode` in `compileResume` and `saveResume`.

Requests that exceed the limit receive HTTP 400 before compilation or database storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->