### PR TITLE
fix(flashcard): added pagination to getUserFlashcards endpoint with page and limit params

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -108,7 +108,7 @@ const createFlashcard = async (req, res) => {
 const getUserFlashcards = async (req, res) => {
   try {
     const userId = req.user._id;
-    const { due, category } = req.query;
+    const { due, category, page, limit } = req.query;
 
     const query = { userId };
     if (due === "true") {
@@ -118,12 +118,28 @@ const getUserFlashcards = async (req, res) => {
       query.category = category;
     }
 
-    const flashcards = await Flashcard.find(query).sort({ dueDate: 1 });
+    const pageNum = Math.max(1, parseInt(page, 10) || 1);
+    const limitNum = Math.min(100, Math.max(1, parseInt(limit, 10) || 20));
+    const skip = (pageNum - 1) * limitNum;
+
+    const [flashcards, totalItems] = await Promise.all([
+      Flashcard.find(query).sort({ dueDate: 1 }).skip(skip).limit(limitNum).lean(),
+      Flashcard.countDocuments(query),
+    ]);
+
+    const totalPages = Math.ceil(totalItems / limitNum);
 
     return res.status(200).json({
       success: true,
       count: flashcards.length,
       flashcards,
+      pagination: {
+        totalItems,
+        totalPages,
+        page: pageNum,
+        pageSize: limitNum,
+        hasNextPage: pageNum < totalPages,
+      },
     });
   } catch (error) {
     return res.status(500).json({

--- a/backend/tests/flashcardController.unit.test.js
+++ b/backend/tests/flashcardController.unit.test.js
@@ -93,7 +93,13 @@ describe("getUserFlashcards controller", () => {
 
   it("fetches flashcards for user", async () => {
     const cards = [{ _id: "c1" }, { _id: "c2" }];
-    Flashcard.find = vi.fn().mockReturnValue({ sort: vi.fn().mockResolvedValue(cards) });
+    const mockFind = {
+      sort: vi.fn().mockReturnValue({
+        skip: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(cards) }) }),
+      }),
+    };
+    Flashcard.find = vi.fn().mockReturnValue(mockFind);
+    Flashcard.countDocuments = vi.fn().mockResolvedValue(2);
 
     const req = makeReq({}, {}, {});
     const res = makeRes();
@@ -101,11 +107,19 @@ describe("getUserFlashcards controller", () => {
     await getUserFlashcards(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      count: 2,
-      flashcards: cards,
-    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        count: 2,
+        flashcards: cards,
+        pagination: expect.objectContaining({
+          totalItems: 2,
+          totalPages: 1,
+          page: 1,
+          hasNextPage: false,
+        }),
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added optional `page` and `limit` query parameters to the `getUserFlashcards` endpoint in `backend/controllers/flashcardController.js`.

- `page`: defaults to 1, must be a positive integer
- `limit`: defaults to 20, capped at 100 to prevent oversized responses

The response now includes a `pagination` object alongside `flashcards`:
```json
{
  "success": true,
  "count": 20,
  "flashcards": [...],
  "pagination": {
    "totalItems": 150,
    "totalPages": 8,
    "page": 1,
    "pageSize": 20,
    "hasNextPage": true
  }
}
```

## Changes Made

Modified `getUserFlashcards` in `backend/controllers/flashcardController.js` to use `skip`/`limit` pagination with `Promise.all` to fetch both the paginated results and total count in parallel. The corresponding unit test was updated to verify the new pagination response shape.

## Impact it Made

Keeps response payloads bounded and predictable. Users with large SRS decks will receive manageable, paginated responses instead of a single large payload. Consistent with the pagination pattern used by `getMyQuestions`, `getMySummaries`, and other list endpoints in the codebase.

Closes #1477

Note: Please assign this PR to the `tmdeveloper007` account.