### PR TITLE
fix(flashcard): added pagination to getUserFlashcards endpoint with page and limit params

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -108,7 +108,7 @@ const createFlashcard = async (req, res) => {
 const getUserFlashcards = async (req, res) => {
   try {
     const userId = req.user._id;
-    const { due, category } = req.query;
+    const { due, category, page, limit } = req.query;
 
     const query = { userId };
     if (due === "true") {
@@ -118,12 +118,32 @@ const getUserFlashcards = async (req, res) => {
       query.category = category;
     }
 
-    const flashcards = await Flashcard.find(query).sort({ dueDate: 1 });
+    const VALID_PAGE_SIZES = [5, 10, 20, 50, 100];
+    const parsedPage = parseInt(page, 10);
+    const parsedLimit = parseInt(limit, 10);
+    // Use only values from a predefined safe set to satisfy CodeQL taint tracking
+    const safePage = Number.isSafeInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
+    const safeLimit = VALID_PAGE_SIZES.includes(parsedLimit) ? parsedLimit : 20;
+    const skipVal = (safePage - 1) * safeLimit;
+
+    const [flashcards, totalItems] = await Promise.all([
+      Flashcard.find(query).sort({ dueDate: 1 }).skip(skipVal).limit(safeLimit).lean(),
+      Flashcard.countDocuments(query),
+    ]);
+
+    const totalPages = Math.ceil(totalItems / safeLimit);
 
     return res.status(200).json({
       success: true,
       count: flashcards.length,
       flashcards,
+      pagination: {
+        totalItems,
+        totalPages,
+        page: safePage,
+        pageSize: safeLimit,
+        hasNextPage: safePage < totalPages,
+      },
     });
   } catch (error) {
     return res.status(500).json({

--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -110,20 +110,24 @@ const getUserFlashcards = async (req, res) => {
     const userId = req.user._id;
     const { due, category, page, limit } = req.query;
 
+    // Validate and sanitize query parameters before building the query object
+    const sanitizedDue = due === "true" ? true : false;
+    const sanitizedCategory = (typeof category === "string" && category.length <= 50) ? category : null;
+
     const query = { userId };
-    if (due === "true") {
+    if (sanitizedDue) {
       query.dueDate = { $lte: new Date() };
     }
-    if (category && category !== "All") {
-      query.category = category;
+    if (sanitizedCategory && sanitizedCategory !== "All") {
+      query.category = sanitizedCategory;
     }
 
     const VALID_PAGE_SIZES = [5, 10, 20, 50, 100];
-    const parsedPage = parseInt(page, 10);
-    const parsedLimit = parseInt(limit, 10);
-    // Use only values from a predefined safe set to satisfy CodeQL taint tracking
-    const safePage = Number.isSafeInteger(parsedPage) && parsedPage >= 1 ? parsedPage : 1;
-    const safeLimit = VALID_PAGE_SIZES.includes(parsedLimit) ? parsedLimit : 20;
+    const rawPage = parseInt(page, 10);
+    const rawLimit = parseInt(limit, 10);
+    // Explicitly sanitize pagination inputs before use in DB operations
+    const safePage = (Number.isSafeInteger(rawPage) && rawPage >= 1) ? rawPage : 1;
+    const safeLimit = VALID_PAGE_SIZES.includes(rawLimit) ? rawLimit : 20;
     const skipVal = (safePage - 1) * safeLimit;
 
     const [flashcards, totalItems] = await Promise.all([

--- a/backend/tests/flashcardController.unit.test.js
+++ b/backend/tests/flashcardController.unit.test.js
@@ -93,7 +93,13 @@ describe("getUserFlashcards controller", () => {
 
   it("fetches flashcards for user", async () => {
     const cards = [{ _id: "c1" }, { _id: "c2" }];
-    Flashcard.find = vi.fn().mockReturnValue({ sort: vi.fn().mockResolvedValue(cards) });
+    const mockFind = {
+      sort: vi.fn().mockReturnValue({
+        skip: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ lean: vi.fn().mockResolvedValue(cards) }) }),
+      }),
+    };
+    Flashcard.find = vi.fn().mockReturnValue(mockFind);
+    Flashcard.countDocuments = vi.fn().mockResolvedValue(2);
 
     const req = makeReq({}, {}, {});
     const res = makeRes();
@@ -101,11 +107,19 @@ describe("getUserFlashcards controller", () => {
     await getUserFlashcards(req, res);
 
     expect(res.status).toHaveBeenCalledWith(200);
-    expect(res.json).toHaveBeenCalledWith({
-      success: true,
-      count: 2,
-      flashcards: cards,
-    });
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        count: 2,
+        flashcards: cards,
+        pagination: expect.objectContaining({
+          totalItems: 2,
+          totalPages: 1,
+          page: 1,
+          hasNextPage: false,
+        }),
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added optional `page` and `limit` query parameters to the `getUserFlashcards` endpoint in `backend/controllers/flashcardController.js`.

- `page`: defaults to 1, must be a positive safe integer
- `limit`: defaults to 20, must be one of [5, 10, 20, 50, 100]

The response now includes a `pagination` object alongside `flashcards`:
```json
{
  "success": true,
  "count": 20,
  "flashcards": [...],
  "pagination": {
    "totalItems": 150,
    "totalPages": 8,
    "page": 1,
    "pageSize": 20,
    "hasNextPage": true
  }
}
```

All query parameters are explicitly validated and sanitized before use in database operations.

## Changes Made

Modified `getUserFlashcards` to use skip/limit pagination with `Promise.all`. Page sizes restricted to a safe set to satisfy CodeQL taint tracking requirements. Corresponding unit test updated.

## Impact it Made

Keeps response payloads bounded for users with large SRS decks. Consistent with pagination pattern in other endpoints.

Closes #1477

Note: Please assign this PR to the `tmdeveloper007` account.