### PR TITLE
fix(notesSummary): reject invalid ObjectId in deleteSummary route parameter

### DIFF
--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -1,5 +1,6 @@
 const axios = require("axios");
 const crypto = require("crypto");
+const mongoose = require("mongoose");
 const { generateWithFallback } = require("../utils/geminiHelper");
 const {
   inspectPdfBuffer,
@@ -380,6 +381,10 @@ const getMySummaries = async (req, res) => {
  */
 const deleteSummary = async (req, res) => {
   try {
+    if (!mongoose.isValidObjectId(req.params.id)) {
+      return res.status(400).json({ success: false, message: "Invalid summary ID" });
+    }
+
     const summary = await NotesSummary.findOneAndDelete({
       _id: req.params.id,
       user: req.user._id,


### PR DESCRIPTION
## Summary of What Has Been Done

Added a mongoose ObjectId validation check at the top of the `deleteSummary` handler in `backend/controllers/notesSummaryController.js`. An invalid ObjectId in the route parameter now returns a clean 400 Bad Request instead of propagating a CastError that results in a 500 Internal Server Error.

## Changes Made

1. Added `const mongoose = require("mongoose");` import.
2. Added validation guard in `deleteSummary`:
```js
if (!mongoose.isValidObjectId(req.params.id)) {
  return res.status(400).json({ success: false, message: "Invalid summary ID" });
}
```

## Impact it Made

Returns a semantically correct 400 Bad Request when a malformed ID is passed. Prevents unhandled CastError exceptions from leaking as 500 errors. Consistent with how other routes handle invalid IDs.

Closes #1475

Note: Please assign this PR to the `tmdeveloper007` account.