### PR TITLE
feat: add render.yaml for SPA route fallback support

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: PrepPilot
+    runtime: static
+    buildCommand: cd frontend && npm install && npm run build
+    staticPublishPath: frontend/dist
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
## Problem

PrepPilot works correctly when opened from the homepage, but direct navigation or browser refresh on frontend routes returns a Render 404.

Affected routes:
- /dashboard
- /login
- /signup
- /resume-builder
- /question-bank
- /interview-experiences

Since PrepPilot is a Vite + React Router single-page app, these routes are handled on the client side. Render currently looks for real server files at those paths and returns 404.

## Solution

Added a render.yaml (Render Blueprint) at the repo root that:
- Configures the service as a static site
- Sets the build command to cd frontend && npm install && npm run build
- Sets the publish directory to frontend/dist
- Adds a catch-all rewrite rule: /* -> /index.html (status 200)

This ensures all unmatched frontend routes are served by index.html, allowing React Router to handle routing on the client side.

## Changes
- [NEW] render.yaml - Render Blueprint configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a root-level `render.yaml` configuration for SPA route fallback support. It builds and publishes the frontend static site and rewrites all routes to `index.html`, allowing React Router routes to load directly without Render 404 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->