### PR TITLE
Fix #1512: Add max limit to numberOfQuestions to prevent DoS

### DIFF
--- a/backend/Input_validators/ValidateAi.js
+++ b/backend/Input_validators/ValidateAi.js
@@ -6,7 +6,7 @@ const generateInterviewQuestionsSchema = z.object({
   role: z.string().min(1, "Role is required"),
   experience: z.string().min(1, "Experience is required"),
   topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
-  numberOfQuestions: z.number().int().positive("Number of questions must be positive"),
+  numberOfQuestions: z.number().int().positive("Number of questions must be positive").max(50, "Number of questions cannot exceed 50"),
 });
 
 // Schema for concept explanation request


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1512

### Summary
Added an upper bound (`.max(50)`) to the `numberOfQuestions` parameter in `generateInterviewQuestionsSchema`. This prevents malicious or unintended requests from asking for an unreasonably high number of questions, mitigating the risk of Denial of Service (DoS) attacks and AI API quota exhaustion.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other (please describe) ______

---

### How Has This Been Tested?
- Verified that the `generateInterviewQuestionsSchema` successfully validates when `numberOfQuestions` is ≤ 50.
- Confirmed that requests with `numberOfQuestions` > 50 will now be rejected by the validation middleware and return a 400 Bad Request error.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds a maximum value of 50 for `numberOfQuestions` in `generateInterviewQuestionsSchema`.

Requests above 50 now fail validation with a 400 Bad Request response. This reduces excessive AI API usage, quota exhaustion, and denial-of-service risk.

## Review

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->