### PR TITLE
data: Add free Cyber Security & Ethical Hacking certifications (#632)

### DIFF
--- a/backend/data/allcourses.json
+++ b/backend/data/allcourses.json
@@ -1065,6 +1065,36 @@
         "name": "TryHackMe - Pre-Security Learning Path (Free)",
         "source": "TryHackMe",
         "link": "https://tryhackme.com/path/outline/presecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "Cisco Cybersecurity Essentials (Free)",
+        "source": "Cisco Networking Academy",
+        "link": "https://skillsforall.com/course/cybersecurity-essentials"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "TryHackMe - Intro to Cyber Security Learning Path (Free)",
+        "source": "TryHackMe",
+        "link": "https://tryhackme.com/path/outline/introtosecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "SANS Cyber Aces Online",
+        "source": "SANS Institute",
+        "link": "https://www.sans.org/mlp/free-cyber-security-training/"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "Google Cybersecurity Professional Certificate",
+        "source": "Coursera",
+        "link": "https://www.coursera.org/professional-certificates/google-cybersecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "EC Council Code Red - Digital Forensics Essentials (DFE)",
+        "source": "EC Council",
+        "link": "https://codered.eccouncil.org/course/digital-forensics-essentials"
       }
     ]
   },
@@ -1386,6 +1416,24 @@
         "name": "Ethical Hacking Essentials(EHE)",
         "source": "Coursera",
         "link": "https://www.coursera.org/learn/ethical-hacking-essentials-ehe"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "TryHackMe - Jr Penetration Tester Learning Path (Free)",
+        "source": "TryHackMe",
+        "link": "https://tryhackme.com/path/outline/jrpenetrationtester"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "Cisco Ethical Hacker (Free)",
+        "source": "Cisco Networking Academy",
+        "link": "https://skillsforall.com/course/ethical-hacker"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "Penetration Testing, Incident Response and Forensics",
+        "source": "Coursera",
+        "link": "https://www.coursera.org/learn/ibm-penetration-testing-incident-response-forensics"
       }
     ]
   },

--- a/frontend/src/data/allcourses.json
+++ b/frontend/src/data/allcourses.json
@@ -1065,6 +1065,36 @@
         "name": "TryHackMe - Pre-Security Learning Path (Free)",
         "source": "TryHackMe",
         "link": "https://tryhackme.com/path/outline/presecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "Cisco Cybersecurity Essentials (Free)",
+        "source": "Cisco Networking Academy",
+        "link": "https://skillsforall.com/course/cybersecurity-essentials"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "TryHackMe - Intro to Cyber Security Learning Path (Free)",
+        "source": "TryHackMe",
+        "link": "https://tryhackme.com/path/outline/introtosecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "SANS Cyber Aces Online",
+        "source": "SANS Institute",
+        "link": "https://www.sans.org/mlp/free-cyber-security-training/"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "Google Cybersecurity Professional Certificate",
+        "source": "Coursera",
+        "link": "https://www.coursera.org/professional-certificates/google-cybersecurity"
+      },
+      {
+        "icon": "fa-solid fa-shield-halved",
+        "name": "EC Council Code Red - Digital Forensics Essentials (DFE)",
+        "source": "EC Council",
+        "link": "https://codered.eccouncil.org/course/digital-forensics-essentials"
       }
     ]
   },
@@ -1386,6 +1416,24 @@
         "name": "Ethical Hacking Essentials(EHE)",
         "source": "Coursera",
         "link": "https://www.coursera.org/learn/ethical-hacking-essentials-ehe"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "TryHackMe - Jr Penetration Tester Learning Path (Free)",
+        "source": "TryHackMe",
+        "link": "https://tryhackme.com/path/outline/jrpenetrationtester"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "Cisco Ethical Hacker (Free)",
+        "source": "Cisco Networking Academy",
+        "link": "https://skillsforall.com/course/ethical-hacker"
+      },
+      {
+        "icon": "fa-solid fa-user-secret",
+        "name": "Penetration Testing, Incident Response and Forensics",
+        "source": "Coursera",
+        "link": "https://www.coursera.org/learn/ibm-penetration-testing-incident-response-forensics"
       }
     ]
   },


### PR DESCRIPTION
## Summary

This PR expands the Free Courses section by adding new free certification resources for Cyber Security and Ethical Hacking.

### Changes Made

- Added new free certification resources to:
  - `backend/data/allcourses.json`
  - `frontend/src/data/allcourses.json`
- Included resources from:
  - Cisco Networking Academy
  - TryHackMe (Free Learning Paths)
  - SANS Cyber Aces
  - EC-Council Essentials / CodeRed
  - Coursera (Audit Mode)
- Preserved the existing JSON schema.
- Avoided duplicate entries.
- Kept backend and frontend datasets synchronized.

Fixes #632

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->