### PR TITLE
Fix #1515: Add input validation middleware for PUT /api/auth/profile

### DIFF
--- a/backend/Input_validators/ValidateQuestions.js
+++ b/backend/Input_validators/ValidateQuestions.js
@@ -8,7 +8,7 @@ const addQuestionToSessionSchema = z.object({
       question: z.string().min(1, "Question text is required"),
       answer: z.string().min(1, "Answer text is required"),
     })
-  ).min(1, "At least one question is required"),
+  ).min(1, "At least one question is required").max(50, "Maximum 50 questions allowed"),
 });
 
 // Schema for toggling pin (params only)
@@ -18,7 +18,7 @@ const togglePinQuestionSchema = z.object({
 
 // Schema for updating note
 const updateQuestionNoteSchema = z.object({
-  note: z.string(),
+  note: z.string().max(2000, "Note cannot exceed 2000 characters"),
 });
 
 

--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -12,7 +12,7 @@ const createSessionSchema = z.object({
       question: z.string().min(1, "Question text is required"),
       answer: z.string().min(1, "Answer text is required"),
     })
-  ).optional(),
+  ).max(50, "Maximum 50 questions allowed").optional(),
 });
 
 // Schema for getting a session by ID (params)


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1516

### Summary
Added upper bounds (`.max()`) to the validation schemas for questions and notes to prevent potential Denial-of-Service (DoS) risks. Previously, unbounded arrays and strings could allow excessively large payloads, leading to memory exhaustion or database inflation. 

Specifically:
- Enforced a maximum limit of 50 questions for `addQuestionToSessionSchema` and `createSessionSchema`.
- Enforced a maximum string length of 2000 characters for `updateQuestionNoteSchema`.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Verified that requests payload containing over 50 questions in the array fail schema validation.
- Verified that `note` strings exceeding 2000 characters fail schema validation.
- Ensured normal, reasonably-sized requests still pass validation successfully.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->