### PR TITLE
fix: add SPA route fallback for Render deployment

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: preppilot-frontend
+    runtime: static
+    branch: main
+    rootDir: frontend
+    buildCommand: npm run build
+    staticPublishPath: ./dist
+    routes:
+      - type: rewrite
+        source: /*
+        destination: /index.html


### PR DESCRIPTION
## Summary

This PR adds SPA route fallback support for PrepPilot when deployed on Render.

### Changes
- Added `render.yaml` at the repository root.
- Configured the frontend static site with `rootDir: frontend`.
- Added a rewrite rule to serve `index.html` for unmatched routes.

### Why

PrepPilot uses React Router with BrowserRouter. Without a rewrite rule, direct navigation or browser refresh on routes such as `/dashboard`, `/login`, `/signup`, `/resume-builder`, `/question-bank`, and `/interview-experiences` returns a 404 on Render.

This configuration rewrites all unmatched routes to `index.html`, allowing React Router to handle client-side routing correctly.

Closes #1506

---

If this repository is participating in GSSoC 2026, kindly assign the appropriate GSSoC level label to this PR. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds Render SPA fallback support for the PrepPilot frontend. Configures `frontend` as the site root and rewrites unmatched routes to `/index.html`, preventing 404 errors during direct navigation and browser refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->