### PR TITLE
feat: implement global caching for notes summary via contentHash (fixes #1521)

### DIFF
--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -140,6 +140,27 @@ const summarizeNotes = async (req, res) => {
     const readingTime = computeReadingTime(pdfStats);
     const contentHash = crypto.createHash("sha256").update(buffer).digest("hex");
 
+    const existingSummary = await NotesSummary.findOne({ contentHash });
+    if (existingSummary) {
+      return res.status(200).json({
+        success: true,
+        fileName,
+        fileSize: buffer.length,
+        sourceType,
+        sourceUrl,
+        pageCount: pdfStats.numPages,
+        wordCount: pdfStats.wordCount,
+        contentHash,
+        summary: existingSummary.summary,
+        topics: existingSummary.topics,
+        prerequisites: existingSummary.prerequisites,
+        difficulty: existingSummary.difficulty,
+        readingTime,
+        learningOutcomes: existingSummary.learningOutcomes,
+        generatedAt: new Date().toISOString(),
+      });
+    }
+
     const prompt = `You are an expert academic tutor helping a student decide whether a set of study notes is useful before they read it.
 
 The attached PDF has ${pdfStats.numPages} page(s) and roughly ${pdfStats.wordCount} extractable word(s)${pdfStats.isLikelyScanned ? " (it appears to be mostly scanned/image content, so rely on what you can visually infer)" : ""}.


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1521

### Summary
Introduces global caching for the NotesSummary feature by checking for an existing `contentHash`. 

Before calling the Gemini AI API, the backend now queries the `NotesSummary` collection to see if a summary for the given PDF already exists globally. If it does, it immediately returns the cached summary, bypassing the Gemini API entirely. This prevents redundant API generation, saves API quota and costs, and drastically improves response times for already-processed files.

---

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Verified the logic in `notesSummaryController.js` correctly queries `NotesSummary.findOne({ contentHash })` before the AI call.
- Confirmed that when an existing summary is found, the system successfully returns the exact expected payload shape (`summary`, `topics`, `prerequisites`, `difficulty`, `learningOutcomes`, etc.) mapping to the cached data.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors