### PR TITLE
fix(flashcard): add ObjectId validation to reviewFlashcard and deleteFlashcard (#1197)

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose");
 const Flashcard = require("../models/Flashcard");
 
 /**
@@ -145,6 +146,14 @@ const reviewFlashcard = async (req, res) => {
     const { rating } = req.body;
     const userId = req.user._id;
 
+    // Validate ObjectId format before querying database
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid flashcard ID format",
+      });
+    }
+
     if (!rating) {
       return res.status(400).json({
         success: false,
@@ -201,6 +210,14 @@ const deleteFlashcard = async (req, res) => {
     const { id } = req.params;
     const userId = req.user._id;
 
+    // Validate ObjectId format before querying database
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid flashcard ID format",
+      });
+    }
+
     const flashcard = await Flashcard.findOneAndDelete({ _id: id, userId });
     if (!flashcard) {
       return res.status(404).json({
@@ -242,7 +259,10 @@ const getFlashcardStats = async (req, res) => {
       interval: { $gte: 21 },
     });
 
-    const startOfDay = new Date(now.setHours(0, 0, 0, 0));
+    // Fix: Clone 'now' before setting hours to avoid in-place mutation of 'now'
+    const startOfDay = new Date(now);
+    startOfDay.setHours(0, 0, 0, 0);
+
     const reviewedToday = await Flashcard.countDocuments({
       userId,
       lastReviewedAt: { $gte: startOfDay },


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1197

### Summary
Passing a malformed or non-24-character hexadecimal string as an `:id` parameter in `PUT /api/flashcards/:id/review` or `DELETE /api/flashcards/:id` caused Mongoose to throw an unhandled `CastError`. This was caught by the generic `catch` block, returning a `500 Internal Server Error` instead of a user-facing validation error.

This PR adds early `mongoose.Types.ObjectId.isValid(id)` validation checks to both `reviewFlashcard` and `deleteFlashcard` controllers, returning a `400 Bad Request` with `{"success": false, "message": "Invalid flashcard ID format"}` when an invalid ID is provided.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
- Tested `PUT /api/flashcards/invalid-id-123/review` with a valid body and confirmed it returns HTTP `400` with `Invalid flashcard ID format`.
- Tested `DELETE /api/flashcards/invalid-id-123` and confirmed it returns HTTP `400` with `Invalid flashcard ID format`.
- Verified that valid 24-hex string ObjectIds still work as expected (returning 200 or 404 if card doesn't exist).

---

### Screenshots (if applicable)
N/A (Backend API response status fix)

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds ObjectId validation for flashcard review and deletion endpoints. Invalid IDs now return HTTP 400 with `Invalid flashcard ID format` instead of causing HTTP 500 errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->