### PR TITLE
fix: add mandatory field validation for question and answer in createFlashcard (#1198)

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -65,6 +65,21 @@ const createFlashcard = async (req, res) => {
     const { question, answer, category, sourceId } = req.body;
     const userId = req.user._id;
 
+    // Validate presence and type of mandatory fields
+    if (
+      !question ||
+      typeof question !== "string" ||
+      !question.trim() ||
+      !answer ||
+      typeof answer !== "string" ||
+      !answer.trim()
+    ) {
+      return res.status(400).json({
+        success: false,
+        message: "Question and answer are required non-empty string fields",
+      });
+    }
+
     // Check if card with exact sourceId already exists for this user
     if (sourceId) {
       const existingCard = await Flashcard.findOne({ userId, sourceId });
@@ -79,8 +94,8 @@ const createFlashcard = async (req, res) => {
 
     const flashcard = await Flashcard.create({
       userId,
-      question,
-      answer,
+      question: question.trim(),
+      answer: answer.trim(),
       category: category || "General",
       sourceId: sourceId || null,
       dueDate: new Date(),


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1198

### Summary
Added early payload validation in `createFlashcard` to check for missing, empty, or non-string `question` and `answer` fields before processing. Previously, invalid or whitespace-only inputs bypassed controller checks and led to unhandled Mongoose schema errors or malformed entries. The endpoint now returns an explicit `400 Bad Request` and sanitizes valid inputs using `.trim()`.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
- Sent `POST /api/flashcards` with an empty body `{}` and verified a `400 Bad Request` response.
- Sent payloads with whitespace strings like `{"question": "   ", "answer": ""}` and confirmed a `400 Bad Request` response.
- Sent valid string payloads and verified `201 Created` with trimmed input fields.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors