### PR TITLE
fix: validate country parameter against supported Adzuna codes (#1208)

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -7,6 +7,12 @@ const ADZUNA_API_KEY = process.env.ADZUNA_API_KEY;
 const ADZUNA_COUNTRY = process.env.ADZUNA_COUNTRY || "in";
 const CACHE_TTL_MS   = 24 * 60 * 60 * 1000;
 
+// Supported Adzuna ISO country codes
+const ALLOWED_ADZUNA_COUNTRIES = [
+  "at", "au", "be", "br", "ca", "ch", "de", "es", "fr", "gb",
+  "in", "it", "mx", "nl", "nz", "pl", "ru", "sg", "us", "za",
+];
+
 // The Jobs feature is optional: without Adzuna credentials it stays dormant
 // instead of crashing the server or spamming failed API calls.
 const isAdzunaConfigured = () => Boolean(ADZUNA_APP_ID && ADZUNA_API_KEY);
@@ -15,22 +21,22 @@ async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
   const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1`;
   const { data } = await axios.get(url, {
     params: {
-      app_id:   ADZUNA_APP_ID,
-      app_key:  ADZUNA_API_KEY,
-      what:     role,
+      app_id:           ADZUNA_APP_ID,
+      app_key:          ADZUNA_API_KEY,
+      what:             role,
       results_per_page: 10,
     },
   });
   return (data.results || []).map((j) => ({
-    id:          j.id,
-    title:       j.title,
-    company:     j.company?.display_name || "Unknown",
-    location:    j.location?.display_name || "Remote",
-    salary_min:  j.salary_min || null,
-    salary_max:  j.salary_max ?? null,
-    description: j.description ?? "",
+    id:           j.id,
+    title:        j.title,
+    company:      j.company?.display_name || "Unknown",
+    location:     j.location?.display_name || "Remote",
+    salary_min:   j.salary_min || null,
+    salary_max:   j.salary_max ?? null,
+    description:  j.description ?? "",
     redirect_url: j.redirect_url,
-    created:     j.created,
+    created:      j.created,
   }));
 }
 
@@ -52,8 +58,16 @@ exports.getJobs = async (req, res) => {
       .sort({ createdAt: -1 })
       .select("role");
 
-    const role    = req.query.role || latestSession?.role || "software engineer";
-    const country = req.query.country   || ADZUNA_COUNTRY;
+    const role = req.query.role || latestSession?.role || "software engineer";
+    const country = (req.query.country || ADZUNA_COUNTRY).toLowerCase().trim();
+
+    // Validate country against supported Adzuna codes
+    if (!ALLOWED_ADZUNA_COUNTRIES.includes(country)) {
+      return res.status(400).json({
+        message: `Invalid or unsupported country parameter '${country}'. Supported country codes are: ${ALLOWED_ADZUNA_COUNTRIES.join(", ")}`,
+      });
+    }
+
     const cacheKey = `${role.toLowerCase()}|${country}`;
 
     const cached = await JobCache.findOne({ cacheKey });


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1208

### Summary
Added validation for the `country` query parameter in `getJobs` against a predefined list of supported ISO 2-letter country codes for Adzuna (`ALLOWED_ADZUNA_COUNTRIES`). If an invalid country parameter (e.g., `?country=xyz`) is provided, the controller immediately returns a `400 Bad Request` instead of propagating the invalid parameter to the external API and throwing a `500 Internal Server Error`.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
- Sent `GET /api/jobs?country=invalidcode` and confirmed the response returns status `400 Bad Request` with an explicit error message listing allowed country codes.
- Sent `GET /api/jobs?country=gb` and `GET /api/jobs?country=us` to verify supported country codes successfully invoke the API/cache and return `200 OK`.
- Verified default fallback (`ADZUNA_COUNTRY`) works as expected when no `country` query parameter is supplied.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors