### PR TITLE
fix : added max length guard on unlockedAchievements array items

### DIFF
--- a/backend/Input_validators/ValidateAchievement.js
+++ b/backend/Input_validators/ValidateAchievement.js
@@ -2,10 +2,13 @@ const { z } = require('zod');
 const { handleValidationError } = require('./ValidateQuestions');
 
 const savedAchievementsSchema = z.object({
-  unlockedAchievements: z.array(z.string(), {
-    required_error: "unlockedAchievements must be an array",
-    invalid_type_error: "unlockedAchievements must be an array of strings",
-  }),
+  unlockedAchievements: z.array(
+    z.string().max(100, "Each achievement must be at most 100 characters"),
+    {
+      required_error: "unlockedAchievements must be an array",
+      invalid_type_error: "unlockedAchievements must be an array of strings",
+    }
+  ),
 });
 
 const validateSavedAchievements = (req, res, next) => {


### PR DESCRIPTION
## Summary of What Has Been Done

Added a max length constraint of 100 characters to each `unlockedAchievements` array item in `backend/Input_validators/ValidateAchievement.js`. Previously `z.string()` was used without any `.max()` guard.

## Changes Made

Modified `backend/Input_validators/ValidateAchievement.js`:
- Changed `z.array(z.string(), ...)` to `z.array(z.string().max(100, "Each achievement must be at most 100 characters"), ...)`

## Impact it Made

- Prevents excessively long achievement strings from being stored in MongoDB
- Consistent with other validators in the codebase that apply `.max()` guards
- Protects against malformed payloads in the achievement save endpoint

Closes #1539

**Note: Please assign this PR to the `tmdeveloper007` account.