### PR TITLE
fix : added max length guard on role and experience fields in ValidateSession

### DIFF
--- a/backend/Input_validators/ValidateAchievement.js
+++ b/backend/Input_validators/ValidateAchievement.js
@@ -2,10 +2,13 @@ const { z } = require('zod');
 const { handleValidationError } = require('./ValidateQuestions');
 
 const savedAchievementsSchema = z.object({
-  unlockedAchievements: z.array(z.string(), {
-    required_error: "unlockedAchievements must be an array",
-    invalid_type_error: "unlockedAchievements must be an array of strings",
-  }),
+  unlockedAchievements: z.array(
+    z.string().max(100, "Each achievement must be at most 100 characters"),
+    {
+      required_error: "unlockedAchievements must be an array",
+      invalid_type_error: "unlockedAchievements must be an array of strings",
+    }
+  ),
 });
 
 const validateSavedAchievements = (req, res, next) => {

--- a/backend/Input_validators/ValidateAchievement.js
+++ b/backend/Input_validators/ValidateAchievement.js
@@ -2,13 +2,10 @@ const { z } = require('zod');
 const { handleValidationError } = require('./ValidateQuestions');
 
 const savedAchievementsSchema = z.object({
-  unlockedAchievements: z.array(
-    z.string().max(100, "Each achievement must be at most 100 characters"),
-    {
-      required_error: "unlockedAchievements must be an array",
-      invalid_type_error: "unlockedAchievements must be an array of strings",
-    }
-  ),
+  unlockedAchievements: z.array(z.string(), {
+    required_error: "unlockedAchievements must be an array",
+    invalid_type_error: "unlockedAchievements must be an array of strings",
+  }),
 });
 
 const validateSavedAchievements = (req, res, next) => {

--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -10,14 +10,14 @@ const objectId = (label) =>
 
 // Schema for creating a session
 const createSessionSchema = z.object({
-  role: z.string().min(1, "Role is required"),
-  experience: z.string().min(1, "Experience is required"),
-  topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
-  description: z.string().optional(),
+  role: z.string().min(1, "Role is required").max(200, "Role must be at most 200 characters"),
+  experience: z.string().min(1, "Experience is required").max(200, "Experience must be at most 200 characters"),
+  topicsToFocus: z.array(z.string().min(1).max(100)).min(1, "At least one topic is required"),
+  description: z.string().max(2000).optional(),
   question: z.array(
     z.object({
-      question: z.string().min(1, "Question text is required"),
-      answer: z.string().min(1, "Answer text is required"),
+      question: z.string().min(1, "Question text is required").max(5000),
+      answer: z.string().min(1, "Answer text is required").max(10000),
     })
   ).max(50, "Maximum 50 questions allowed").optional(),
 });


### PR DESCRIPTION
## Summary of What Has Been Done

Added max length constraints to `role`, `experience`, and `topicsToFocus` fields in `backend/Input_validators/ValidateSession.js`. Also added max length to `description` and embedded `question`/`answer` fields.

## Changes Made

Modified `backend/Input_validators/ValidateSession.js`:
- `role`: added `.max(200)` guard
- `experience`: added `.max(200)` guard
- `topicsToFocus`: changed to `z.array(z.string().min(1).max(100))` with per-item max
- `description`: added `.max(2000)` guard
- Embedded `question`/`answer`: added `.max(5000)` and `.max(10000)` respectively

## Impact it Made

- Prevents excessively long role/experience strings from being stored
- Consistent with other validators in the codebase
- Reduces storage bloat and potential abuse vectors

Closes #1540

**Note: Please assign this PR to the `tmdeveloper007` account.