### PR TITLE
feat: add reset progress button for DSA sheets (#1510)

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -150,6 +150,46 @@ exports.getProgress = async (req, res) => {
 };
 
 /**
+ * Reset (clear) progress for a specific sheet for the authenticated user.
+ * @route DELETE /api/user/sheet-progress/:sheetId
+ */
+exports.resetProgress = async (req, res) => {
+  const { sheetId } = req.params;
+  const userId = req.user._id;
+
+  if (
+    typeof sheetId !== "string" ||
+    sheetId.trim().length === 0 ||
+    sheetId.length > 100
+  ) {
+    return res.status(400).json({
+      success: false,
+      error: "Invalid sheetId",
+    });
+  }
+
+  const validatedSheetId = sheetId.trim();
+
+  try {
+    const progress = await UserSheetProgress.findOneAndUpdate(
+      { userId, sheetId: validatedSheetId },
+      { $set: { completedTopics: {}, percentage: 0 } },
+      { new: true }
+    );
+
+    return res.json({
+      success: true,
+      progress: progress || null,
+    });
+  } catch (err) {
+    return res.status(500).json({
+      success: false,
+      error: "Internal server error occurred",
+    });
+  }
+};
+
+/**
  * Export all sheet progress for the authenticated user as a JSON file.
  * @route GET /api/user/sheet-progress/export
  */

--- a/backend/routes/userSheetProgressRoutes.js
+++ b/backend/routes/userSheetProgressRoutes.js
@@ -5,6 +5,7 @@ const {
   getAllProgress,
   exportProgress,
   importProgress,
+  resetProgress,
 } = require('../controllers/userSheetProgressController');
 const { protect } = require('../middlewares/authMiddleware');
 const { validateSaveProgress, validateGetProgress } = require('../Input_validators/ValidateUserSheetProgress');
@@ -35,6 +36,12 @@ router.post('/sheet-progress/import', importProgress);
  * @route GET /api/user/sheet-progress/:sheetId
  */
 router.get('/sheet-progress/:sheetId', validateGetProgress, getProgress);
+
+/**
+ * Reset progress for a specific sheet for the authenticated user.
+ * @route DELETE /api/user/sheet-progress/:sheetId
+ */
+router.delete('/sheet-progress/:sheetId', validateGetProgress, resetProgress);
 
 /**
  * Get all sheet progress records for the authenticated user.

--- a/frontend/src/components/SheetDetailsPage.jsx
+++ b/frontend/src/components/SheetDetailsPage.jsx
@@ -100,8 +100,6 @@ function SheetDetail() {
 
   const handleResetProgress = async () => {
     setResetting(true);
-
-    // Prevent a stale debounced auto-save from overwriting the reset
     clearTimeout(saveTimeoutRef.current);
     saveAbortControllerRef.current?.abort();
 
@@ -117,6 +115,10 @@ function SheetDetail() {
       setShowResetModal(false);
     } catch (err) {
       console.error("Failed to reset progress:", err);
+      // Reset failed — the pending/in-flight save we just cancelled would have
+      // persisted the user's current progress. Re-persist it now so it isn't
+      // silently lost on reload.
+      persistProgress(completedTopics, followed);
     } finally {
       setResetting(false);
     }
@@ -168,38 +170,41 @@ function SheetDetail() {
   useEffect(() => {
     if (!followed) return;
 
-    const percentage =
-      totalSubtopics > 0
-        ? Math.round((completedCount / totalSubtopics) * 100)
-        : 0;
-
     saveTimeoutRef.current = setTimeout(() => {
-      localStorage.setItem(
-        `${id}-progress`,
-        JSON.stringify({ followed: true, completedTopics, percentage })
-      );
-      localStorage.setItem("sheet-last-update", Date.now().toString());
-
-      // Abort any still-in-flight save before starting a new one
-      saveAbortControllerRef.current?.abort();
-      const controller = new AbortController();
-      saveAbortControllerRef.current = controller;
-
-      axiosInstance.post(
-        "/api/user/sheet-progress",
-        { sheetId: id, followed: true, completedTopics, percentage },
-        { signal: controller.signal }
-      )
-        .then(() => refreshSheetProgress?.())
-        .catch((err) => {
-          if (err.name !== "CanceledError" && err.code !== "ERR_CANCELED") {
-            console.error("Failed to sync progress to backend:", err);
-          }
-        });
+      persistProgress(completedTopics, true);
     }, 500);
 
     return () => clearTimeout(saveTimeoutRef.current);
-  }, [completedTopics, followed, completedCount, id, refreshSheetProgress, totalSubtopics]);
+  }, [completedTopics, followed, persistProgress]);
+
+  const persistProgress = useCallback((topicsToSave, followedState) => {
+    const percentage =
+      totalSubtopics > 0
+        ? Math.round((Object.values(topicsToSave).filter(Boolean).length / totalSubtopics) * 100)
+        : 0;
+
+    localStorage.setItem(
+      `${id}-progress`,
+      JSON.stringify({ followed: followedState, completedTopics: topicsToSave, percentage })
+    );
+    localStorage.setItem("sheet-last-update", Date.now().toString());
+
+    saveAbortControllerRef.current?.abort();
+    const controller = new AbortController();
+    saveAbortControllerRef.current = controller;
+
+    return axiosInstance.post(
+      "/api/user/sheet-progress",
+      { sheetId: id, followed: followedState, completedTopics: topicsToSave, percentage },
+      { signal: controller.signal }
+    )
+      .then(() => refreshSheetProgress?.())
+      .catch((err) => {
+        if (err.name !== "CanceledError" && err.code !== "ERR_CANCELED") {
+          console.error("Failed to sync progress to backend:", err);
+        }
+      });
+  }, [id, totalSubtopics, refreshSheetProgress]);
 
   const handleCompleteToggle = useCallback((sectionIdx, topicIdx, subIdx) => {
     if (!followed) return;

--- a/frontend/src/components/SheetDetailsPage.jsx
+++ b/frontend/src/components/SheetDetailsPage.jsx
@@ -2,7 +2,7 @@ import { useParams } from "react-router-dom";
 import gfg from "../assets/gfg.svg";
 import leetcode from "../assets/leetcode.svg";
 import youtube from "../assets/youtube.svg";
-import React, { useState, useEffect, useCallback, memo, useContext } from "react";
+import React, { useState, useEffect, useCallback, useRef, memo, useContext } from "react";
 import Modal from "./Loader/Modal";
 
 import { BASE_URL } from "../utils/apiPaths";
@@ -95,9 +95,16 @@ function SheetDetail() {
   const [followed, setFollowed] = useState(false);
   const [showResetModal, setShowResetModal] = useState(false);
   const [resetting, setResetting] = useState(false);
+  const saveTimeoutRef = useRef(null);
+  const saveAbortControllerRef = useRef(null);
 
   const handleResetProgress = async () => {
     setResetting(true);
+
+    // Prevent a stale debounced auto-save from overwriting the reset
+    clearTimeout(saveTimeoutRef.current);
+    saveAbortControllerRef.current?.abort();
+
     try {
       await axiosInstance.delete(`/api/user/sheet-progress/${id}`);
       setCompletedTopics({});
@@ -166,21 +173,32 @@ function SheetDetail() {
         ? Math.round((completedCount / totalSubtopics) * 100)
         : 0;
 
-    const saveToStorage = setTimeout(() => {
+    saveTimeoutRef.current = setTimeout(() => {
       localStorage.setItem(
         `${id}-progress`,
         JSON.stringify({ followed: true, completedTopics, percentage })
       );
       localStorage.setItem("sheet-last-update", Date.now().toString());
 
-      axiosInstance.post("/api/user/sheet-progress", {
-        sheetId: id,
-        followed: true,
-        completedTopics,
-        percentage,
-      }).then(() => refreshSheetProgress?.()).catch(err => console.error("Failed to sync progress to backend:", err));    }, 500);
+      // Abort any still-in-flight save before starting a new one
+      saveAbortControllerRef.current?.abort();
+      const controller = new AbortController();
+      saveAbortControllerRef.current = controller;
 
-    return () => clearTimeout(saveToStorage);
+      axiosInstance.post(
+        "/api/user/sheet-progress",
+        { sheetId: id, followed: true, completedTopics, percentage },
+        { signal: controller.signal }
+      )
+        .then(() => refreshSheetProgress?.())
+        .catch((err) => {
+          if (err.name !== "CanceledError" && err.code !== "ERR_CANCELED") {
+            console.error("Failed to sync progress to backend:", err);
+          }
+        });
+    }, 500);
+
+    return () => clearTimeout(saveTimeoutRef.current);
   }, [completedTopics, followed, completedCount, id, refreshSheetProgress, totalSubtopics]);
 
   const handleCompleteToggle = useCallback((sectionIdx, topicIdx, subIdx) => {

--- a/frontend/src/components/SheetDetailsPage.jsx
+++ b/frontend/src/components/SheetDetailsPage.jsx
@@ -3,11 +3,12 @@ import gfg from "../assets/gfg.svg";
 import leetcode from "../assets/leetcode.svg";
 import youtube from "../assets/youtube.svg";
 import React, { useState, useEffect, useCallback, memo, useContext } from "react";
+import Modal from "./Loader/Modal";
 
 import { BASE_URL } from "../utils/apiPaths";
 import axiosInstance from "../utils/axiosinstance";
 import { UserContext } from "../context/userContext";
-import { CheckCircle2, Circle, AlertCircle, BookOpen, Users, CheckSquare } from "lucide-react";
+import { CheckCircle2, Circle, AlertCircle, BookOpen, Users, CheckSquare, RotateCcw } from "lucide-react";
 
 const SubtopicRow = memo(({ sub, sectionIdx, topicIdx, subIdx, completed, followed, onToggle }) => {
   let diffColor = "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300";
@@ -92,6 +93,27 @@ function SheetDetail() {
   const [loading, setLoading] = useState(true);
   const [completedTopics, setCompletedTopics] = useState({});
   const [followed, setFollowed] = useState(false);
+  const [showResetModal, setShowResetModal] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  const handleResetProgress = async () => {
+    setResetting(true);
+    try {
+      await axiosInstance.delete(`/api/user/sheet-progress/${id}`);
+      setCompletedTopics({});
+      localStorage.setItem(
+        `${id}-progress`,
+        JSON.stringify({ followed, completedTopics: {}, percentage: 0 })
+      );
+      localStorage.setItem("sheet-last-update", Date.now().toString());
+      refreshSheetProgress?.();
+      setShowResetModal(false);
+    } catch (err) {
+      console.error("Failed to reset progress:", err);
+    } finally {
+      setResetting(false);
+    }
+  };
 
   useEffect(() => {
     fetch(`${BASE_URL}/api/sheets/${id}`)
@@ -270,7 +292,18 @@ function SheetDetail() {
           <div className="mt-6 pt-5 border-t border-gray-200 dark:border-white/10">
             <div className="flex justify-between items-end mb-2">
               <span className="text-xs font-medium text-gray-600 dark:text-gray-400">Overall Progress</span>
-              <span className="text-sm font-bold text-violet-600 dark:text-violet-400">{progressPercent}%</span>
+              <div className="flex items-center gap-3">
+                {followed && completedCount > 0 && (
+                  <button
+                    onClick={() => setShowResetModal(true)}
+                    className="flex items-center gap-1 text-[11px] font-semibold text-gray-500 hover:text-red-500 dark:text-gray-400 dark:hover:text-red-400 transition-colors"
+                    title="Reset progress for this sheet"
+                  >
+                    <RotateCcw size={12} /> Reset
+                  </button>
+                )}
+                <span className="text-sm font-bold text-violet-600 dark:text-violet-400">{progressPercent}%</span>
+              </div>
             </div>
             <div className="w-full bg-gray-200 dark:bg-white/10 h-2 rounded-full overflow-hidden shadow-inner flex">
               <div
@@ -334,6 +367,36 @@ function SheetDetail() {
           </div>
         )}
       </div>
+
+      <Modal
+        isOpen={showResetModal}
+        onClose={() => setShowResetModal(false)}
+        title="Reset Progress"
+      >
+        <div className="text-sm text-gray-300">
+          <p className="mb-6">
+            This will clear your progress on{" "}
+            <span className="font-semibold text-white">{sheet.title}</span>. This can't be undone.
+          </p>
+          <div className="flex justify-end gap-3">
+            <button
+              onClick={() => setShowResetModal(false)}
+              disabled={resetting}
+              className="px-4 py-2 rounded-lg text-sm font-medium text-gray-300 hover:bg-white/5"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleResetProgress}
+              disabled={resetting}
+              className="px-4 py-2 rounded-lg text-sm font-bold bg-red-600 hover:bg-red-700 text-white disabled:opacity-50"
+            >
+              {resetting ? "Resetting..." : "Reset Progress"}
+            </button>
+          </div>
+        </div>
+      </Modal>
+
     </>
   );
 }


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #1510

### Summary
Adds a "Reset Progress" button on the sheet details page, letting a user clear their completed topics/percentage for a specific DSA sheet without unfollowing it. Backend exposes a new `DELETE /api/user/sheet-progress/:sheetId` endpoint that resets `completedTopics` to `{}` and `percentage` to `0` for that user+sheet, while leaving `followed` untouched. Frontend adds a small Reset button next to the progress bar (visible only when the sheet is followed and has at least one completed topic) plus a confirmation modal, since the action can't be undone.

---

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) 

---

### How Has This Been Tested?
- Logged in, followed the "Arrays Practice" sheet, marked several subtopics complete.
- Clicked the new Reset button, confirmed in the modal, and verified progress dropped to 0% and all checkmarks cleared.
- Verified `followed` status stayed `true` after reset (did not unfollow the sheet).
- Confirmed the Reset button is hidden when a sheet has no completed topics or isn't followed yet.
- Verified `DELETE /api/user/sheet-progress/:sheetId` returns `200` with the updated progress object, and correctly returns `401` when unauthenticated.

---

### Screenshots (if applicable)

<img width="1919" height="956" alt="Screenshot 2026-08-07 234836" src="https://github.com/user-attachments/assets/b83947e2-95dd-4088-9284-d3d2aa9a4b6a" />

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds single-sheet progress reset support.

- Adds protected `DELETE /api/user/sheet-progress/:sheetId`.
- Resets `completedTopics` and `percentage` for the authenticated user.
- Adds a confirmation modal and Reset button to sheet details pages.
- Prevents stale debounced saves from overwriting reset progress.
- Updates local and shared progress after reset.
- Shows a resetting state during the request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->