### PR TITLE
fix(difficulty-estimator): connect page to real AI backend endpoint

### DIFF
--- a/backend/Input_validators/ValidateAi.js
+++ b/backend/Input_validators/ValidateAi.js
@@ -20,6 +20,14 @@ const generateInterviewTipsSchema = z.object({
   experience: z.string().min(1, "Experience is required"),
 });
 
+// Schema for difficulty estimation request
+const estimateDifficultySchema = z.object({
+  question: z
+    .string()
+    .min(1, "Question is required")
+    .max(5000, "Question must be under 5000 characters"),
+});
+
 
 const validateGenerateInterviewQuestions = (req,res,next)=>{
 
@@ -49,8 +57,18 @@ const validateGenerateInterviewTips = (req, res, next) => {
   }
 };
 
+const validateEstimateDifficulty = (req, res, next) => {
+  try {
+    estimateDifficultySchema.parse(req.body);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
 module.exports = {
   validateGenerateInterviewQuestions,
   validateGenerateConceptExplanation,
   validateGenerateInterviewTips,
+  validateEstimateDifficulty,
 };

--- a/backend/controllers/aiController.js
+++ b/backend/controllers/aiController.js
@@ -3,6 +3,7 @@ const {
   conceptExplainPrompt,
   questionAnswerPrompt,
   interviewTipsPrompt,
+  difficultyEstimatePrompt,
 } = require("../utils/prompts");
 const Session = require("../models/Session");
 const Question = require("../models/Question");
@@ -278,4 +279,83 @@ const generateInterviewTips = async (req, res) => {
   }
 };
 
-module.exports = { generateInterviewQuestions, generateConceptExplanation, generateInterviewTips };
+/**
+ * Estimate the difficulty of an interview question using the Gemini AI service.
+ * @route POST /api/ai/estimate-difficulty
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ * @throws {Error} When the question is missing or Gemini generation fails.
+ * @example
+ * POST /api/ai/estimate-difficulty
+ * Authorization: Bearer eyJhb...
+ * {
+ *   "question": "Explain how to find the longest palindromic substring in a string."
+ * }
+ * @example
+ * 200 {
+ *   "model": "models/gemini-2.5-flash",
+ *   "difficulty": "Hard",
+ *   "confidence": 87,
+ *   "estimatedTime": "45 Minutes",
+ *   "prerequisites": ["Dynamic Programming", "String Manipulation"]
+ * }
+ */
+const estimateDifficulty = async (req, res) => {
+  try {
+    const { question } = req.body;
+
+    const prompt = difficultyEstimatePrompt(question);
+
+    const { result, usedModel } = await generateWithFallback(
+      process.env.GEMINI_API_KEY,
+      [prompt]
+    );
+
+    const rawText = await result.response.text();
+    let cleanedText = rawText
+      .replace(/^(\s*```json\s*|\s*```\s*)+/i, "")
+      .replace(/(\s*```\s*)+$/i, "")
+      .trim();
+
+    try {
+      const data = JSON.parse(cleanedText);
+
+      // Validate Gemini response structure
+      const difficultySchema = z.object({
+        difficulty: z.enum(["Easy", "Medium", "Hard", "Expert"]),
+        confidence: z.number().int().min(0).max(100),
+        estimatedTime: z.string(),
+        prerequisites: z.array(z.string()),
+      });
+      const parsed = difficultySchema.safeParse(data);
+      if (!parsed.success) {
+        return res.status(500).json({ message: "Invalid AI response format", details: parsed.error.issues[0]?.message });
+      }
+
+      res.status(200).json({ model: usedModel, ...parsed.data });
+    } catch (err) {
+      console.error("Gemini returned invalid JSON:", cleanedText);
+      res.status(500).json({
+        message: "Gemini returned invalid JSON",
+      });
+    }
+  } catch (error) {
+    console.error("Gemini API Error:", error);
+
+    if (error.status === 429) {
+      return res.status(429).json({ message: "Gemini API quota exceeded. Please try again later." });
+    }
+    if (error.status === 401 || (error.message && error.message.includes("API key not valid"))) {
+      return res.status(401).json({ message: "Invalid Gemini API Key configured." });
+    }
+    if (error.message && (error.message.includes("timeout") || error.message.includes("network"))) {
+      return res.status(504).json({ message: "Network timeout communicating with AI service." });
+    }
+    res.status(500).json({
+      message: "Failed to estimate difficulty",
+    });
+  }
+};
+
+module.exports = { generateInterviewQuestions, generateConceptExplanation, generateInterviewTips, estimateDifficulty };

--- a/backend/server.js
+++ b/backend/server.js
@@ -15,6 +15,7 @@ const {
   generateInterviewQuestions,
   generateConceptExplanation,
   generateInterviewTips,
+  estimateDifficulty,
 } = require("./controllers/aiController");
 const { protect } = require("./middlewares/authMiddleware");
 const authRoutes = require("./routes/authRoutes");
@@ -104,7 +105,7 @@ app.use("/api/user", generalLimiter, userSheetProgressRoutes);
 const achievementRoutes = require("./routes/achievementRoutes");
 app.use("/api/user", generalLimiter, achievementRoutes);
 const booksRoutes = require("./routes/booksRoutes");
-const { validateGenerateInterviewQuestions, validateGenerateConceptExplanation, validateGenerateInterviewTips } = require("./Input_validators/ValidateAi.js");
+const { validateGenerateInterviewQuestions, validateGenerateConceptExplanation, validateGenerateInterviewTips, validateEstimateDifficulty } = require("./Input_validators/ValidateAi.js");
 app.use("/api/resume", generalLimiter, resumeRoutes);
 const notesSummaryRoutes = require("./routes/notesSummaryRoutes");
 app.use("/api/notes-summary", generalLimiter, notesSummaryRoutes);
@@ -135,6 +136,15 @@ app.post(
   protect,
   validateGenerateInterviewTips,      // Zod validator
   generateInterviewTips               // Controller
+);
+
+app.post(
+  "/api/ai/estimate-difficulty",
+  sensitiveRouteHeaders,
+  aiLimiter,
+  protect,
+  validateEstimateDifficulty,          // Zod validator
+  estimateDifficulty                   // Controller
 );
 
 

--- a/backend/utils/prompts.js
+++ b/backend/utils/prompts.js
@@ -111,4 +111,26 @@ Important: Do NOT add any extra text outside the JSON format. Only return valid 
 `;
 };
 
-module.exports = { questionAnswerPrompt, conceptExplainPrompt, interviewTipsPrompt, sanitizeRole, ALLOWED_ROLES };
+const difficultyEstimatePrompt = (question) => (`
+You are an expert technical interviewer. Analyze the following interview question and estimate its difficulty.
+
+Question: "${question}"
+
+Return ONLY a valid JSON object with this exact structure and nothing else:
+{
+  "difficulty": "Easy" | "Medium" | "Hard" | "Expert",
+  "confidence": <integer between 0 and 100>,
+  "estimatedTime": "<number> Minutes",
+  "prerequisites": [<array of up to 5 prerequisite topic strings>]
+}
+
+Difficulty guidelines:
+- Easy: Simple logic, O(n) or O(1), basic data structures
+- Medium: Moderate complexity, O(n log n), multiple data structures
+- Hard: Complex algorithms, advanced concepts required
+- Expert: Very complex, optimal solution requires expert-level knowledge
+
+Important: Do NOT add any extra text. Only return valid JSON.
+`);
+
+module.exports = { questionAnswerPrompt, conceptExplainPrompt, interviewTipsPrompt, difficultyEstimatePrompt, sanitizeRole, ALLOWED_ROLES };

--- a/frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx
+++ b/frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx
@@ -1,18 +1,41 @@
 import React, { useState } from "react";
-import { Brain, Sparkles, Send, BookOpen } from "lucide-react";
+import { Brain, Sparkles, Send, BookOpen, Loader } from "lucide-react";
+import axiosInstance from "../../utils/axiosinstance";
+import { API_PATHS } from "../../utils/apiPaths";
+
+const difficultyColors = {
+  Easy: "bg-green-100 text-green-700",
+  Medium: "bg-yellow-100 text-yellow-700",
+  Hard: "bg-red-100 text-red-700",
+  Expert: "bg-purple-100 text-purple-700",
+};
 
 const DifficultyEstimator = () => {
   const [question, setQuestion] = useState("");
   const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
-  const analyzeQuestion = () => {
+  const analyzeQuestion = async () => {
     if (!question.trim()) return;
-    setResult({
-      difficulty: "Hard",
-      confidence: 94,
-      estimatedTime: "35 Minutes",
-      prerequisites: ["Binary Trees", "Depth First Search", "Recursion", "Dynamic Programming"],
-    });
+
+    setLoading(true);
+    setError("");
+    try {
+      const res = await axiosInstance.post(API_PATHS.AI.ESTIMATE_DIFFICULTY, {
+        question: question.trim(),
+      });
+      setResult(res.data);
+    } catch (err) {
+      setResult(null);
+      setError(
+        err.response?.data?.message ||
+          err.response?.data?.error ||
+          "Failed to analyze the question. Please try again."
+      );
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -47,11 +70,22 @@ const DifficultyEstimator = () => {
           />
           <button
             onClick={analyzeQuestion}
-            className="mt-6 flex items-center gap-2 bg-violet-600 hover:bg-violet-700 text-white px-6 py-3 rounded-xl font-semibold transition"
+            disabled={loading}
+            className="mt-6 flex items-center gap-2 bg-violet-600 hover:bg-violet-700 disabled:opacity-50 disabled:cursor-not-allowed text-white px-6 py-3 rounded-xl font-semibold transition"
           >
-            <Send size={18} />
-            Analyze Question
+            {loading ? (
+              <Loader size={18} className="animate-spin" />
+            ) : (
+              <Send size={18} />
+            )}
+            {loading ? "Analyzing..." : "Analyze Question"}
           </button>
+
+          {error && (
+            <div className="mt-6 rounded-2xl border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-5 text-red-700 dark:text-red-300">
+              {error}
+            </div>
+          )}
         </div>
 
         {/* Results */}
@@ -63,7 +97,7 @@ const DifficultyEstimator = () => {
               <div className="bg-white dark:bg-[#111827] rounded-3xl shadow border border-gray-200 dark:border-white/10 p-8 text-center">
                 <Sparkles size={32} className="mx-auto text-violet-600 mb-5" />
                 <h3 className="text-gray-500 mb-3">Difficulty Level</h3>
-                <span className="inline-flex px-6 py-3 rounded-full bg-red-100 text-red-700 text-xl font-bold">
+                <span className={`inline-flex px-6 py-3 rounded-full text-xl font-bold ${difficultyColors[result.difficulty] || difficultyColors.Hard}`}>
                   {result.difficulty}
                 </span>
               </div>
@@ -84,9 +118,15 @@ const DifficultyEstimator = () => {
               <h2 className="text-2xl font-bold mb-6">AI Analysis</h2>
               <p className="leading-8 text-gray-600 dark:text-gray-300">
                 This interview question has been classified as{" "}
-                <span className="font-bold text-red-600">Hard</span>{" "}
-                because it requires multiple algorithmic concepts, efficient optimization techniques, and strong problem-solving skills.
-                Candidates should have a solid understanding of data structures and algorithm design before attempting this question.
+                <span className="font-bold text-red-600">
+                  {result.difficulty}
+                </span>{" "}
+                with an estimated solving time of{" "}
+                <span className="font-bold">{result.estimatedTime}</span> and
+                an AI confidence of{" "}
+                <span className="font-bold">{result.confidence}%</span>.
+                Candidates should have a solid understanding of the recommended
+                prerequisite topics before attempting this question.
               </p>
             </div>
 
@@ -147,8 +187,10 @@ const DifficultyEstimator = () => {
             <div className="bg-white dark:bg-[#111827] rounded-3xl shadow border border-gray-200 dark:border-white/10 p-8">
               <h2 className="text-2xl font-bold mb-6">AI Recommendation</h2>
               <p className="leading-8 text-gray-600 dark:text-gray-300">
-                Before attempting this question, strengthen your understanding of Trees, DFS, Recursion, and Dynamic Programming.
-                Practice a few Medium-level questions first, then return to this problem to improve your confidence and problem-solving speed.
+                Before attempting this question, strengthen your understanding of{" "}
+                {result.prerequisites.join(", ")}. Practice a few easier
+                questions first, then return to this problem to improve your
+                confidence and problem-solving speed.
               </p>
             </div>
 
@@ -165,7 +207,7 @@ const DifficultyEstimator = () => {
                 <div className="text-center">
                   <div className="text-6xl">🧠</div>
                   <h3 className="mt-4 text-2xl font-bold">AI Ready</h3>
-                  <p className="text-4xl font-black">94%</p>
+                  <p className="text-4xl font-black">{result.confidence}%</p>
                 </div>
               </div>
             </div>

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -21,6 +21,7 @@ export const API_PATHS = {
     AI: {
         GENERATE_QUESTIONS: "/api/ai/generate-questions", // Generate interview questions and answers using Gemini
         GENERATE_EXPLANATION: "/api/ai/generate-explanation", // Generate concept explanation using Gemini
+        ESTIMATE_DIFFICULTY: "/api/ai/estimate-difficulty", // Estimate interview question difficulty using Gemini
     },
     SESSION: {
         CREATE: "/api/sessions/create", // Create a new interview session with questions


### PR DESCRIPTION
## Problem

The DifficultyEstimator page (`frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx`) returns a fully hardcoded analysis for every question:

```js
setResult({
  difficulty: "Hard",
  confidence: 94,
  estimatedTime: "35 Minutes",
  prerequisites: ["Binary Trees", "Depth First Search", "Recursion", "Dynamic Programming"],
});
```

Regardless of what the user types, the page always reports `Hard`, `94%`, `35 Minutes`, and the same four prerequisites. No `/api/ai/estimate-difficulty` endpoint exists, so the page can never produce a genuine estimate.

## Fix

- Added `POST /api/ai/estimate-difficulty` in `backend/server.js` with `sensitiveRouteHeaders`, `aiLimiter`, `protect`, a Zod validator, and the new `estimateDifficulty` controller.
- Added `estimateDifficultySchema` in `backend/Input_validators/ValidateAi.js` (question required, capped at 5000 characters) so the request is validated before reaching Gemini.
- Added `difficultyEstimatePrompt` in `backend/utils/prompts.js` and the `estimateDifficulty` handler in `backend/controllers/aiController.js`, which calls the Gemini layer via `generateWithFallback` (same as the other aiController endpoints) and validates the AI JSON response with Zod.
- Wired `analyzeQuestion` in the frontend to `POST /api/ai/estimate-difficulty` via `axiosInstance` / `API_PATHS.AI.ESTIMATE_DIFFICULTY`, removed the hardcoded result object, and added loading and error states.
- The results section now renders the real returned values: dynamic difficulty badge color, dynamic AI Analysis text, dynamic AI Recommendation, and the live confidence in the Motivation card.

## Files changed

- `backend/controllers/aiController.js`
- `backend/Input_validators/ValidateAi.js`
- `backend/server.js`
- `backend/utils/prompts.js`
- `frontend/src/utils/apiPaths.js`
- `frontend/src/pages/DifficultyEstimator/DifficultyEstimator.jsx`

## Testing

- Backend suite: `cd backend && npm test` — 5 test files, 59 tests passing.
- Frontend production build: `cd frontend && npm run build` — succeeds.
- Manual flow: submitting a question calls `POST /api/ai/estimate-difficulty`; missing/oversized question returns 400 via Zod; the button shows a loading state and errors are displayed when the AI call fails.

Closes #1574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->