### PR TITLE
fix(ci): fail pipeline on backend test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       run: cd frontend && npm run build
       
     - name: Run Tests (Backend)
-      run: cd backend && npm test || echo "No tests configured yet"
+      run: cd backend && npm test


### PR DESCRIPTION
## Problem

The backend test step in `.github/workflows/ci.yml` suppresses the test runner's exit code:

```yaml
- name: Run Tests (Backend)
  run: cd backend && npm test || echo "No tests configured yet"
```

`npm test` runs `vitest run` (`backend/package.json`). When tests fail, vitest exits non-zero, but the `|| echo "No tests configured yet"` fallback makes the shell return 0, so the step — and the whole workflow — stays green even while tests are failing. This masks any future regression.

## Fix

Removed the `|| echo "No tests configured yet"` fallback so the step surfaces the real exit code:

```yaml
- name: Run Tests (Backend)
  run: cd backend && npm test
```

The check now turns red when any backend test fails and stays green when all tests pass.

## Files changed

- `.github/workflows/ci.yml`

## Testing

- Verified `cd backend && npm test` passes on the current test suite (5 test files, 59 tests passing), so the step remains green on success and now correctly fails the pipeline on any test failure.

Closes #1576


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the fallback that masked backend test failures.
- CI now propagates the `npm test` exit code.
- Verified 59 passing tests across 5 test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->