### PR TITLE
fix(security): enable helmet and limit express.json to 1mb

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const validateEnv = require("./config/validateEnv.js");
 validateEnv();
 const express = require("express");
+const helmet = require("helmet");
 
 // Global unhandled promise rejection handler
 process.on("unhandledRejection", (err) => {
@@ -30,6 +31,13 @@ const { uploadsStaticHeaders } = require("./middlewares/uploadMiddleware");
 const app = express();
 
 app.set("trust proxy", 1);
+// Helmet for API hardening; CSP stays in generalHeaders / SPA layer.
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+    crossOriginEmbedderPolicy: false,
+  })
+);
 app.use(generalHeaders);
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [
@@ -88,7 +96,7 @@ connectDB()
   });
 
 // Middleware
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 app.use(cookieParser());
 
 //Routes


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #1588
Related to #1399

### Summary
`helmet` was installed but never wired up, and `express.json()` had no size cap. Applied helmet for API hardening (CSP left to existing `generalHeaders` / SPA) and set `express.json({ limit: '1mb' })`.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Backend vitest suite (`npm test` in backend) — pass

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue

Made with [Cursor](https://cursor.com)