### PR TITLE
fix(security): allowlist http(s) in AI markdown links/images

### DIFF
--- a/frontend/src/pages/InterviewPrep/components/AIResponsePreview.jsx
+++ b/frontend/src/pages/InterviewPrep/components/AIResponsePreview.jsx
@@ -4,6 +4,7 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
 import React, { useState } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { sanitizeMarkdownUrl } from "../../../utils/sanitizeMarkdownUrl";
 
 const AIResponsePreview = ({ content }) => {
     const [copied, setCopied] = useState(false);
@@ -65,7 +66,22 @@ const copyResponse = async () => {
                         h2({children}){ return <h2 className='text-2xl font-bold mt-7 mb-3 text-gray-900 dark:text-white'>{children}</h2>; },
                         h3({children}){ return <h3 className='text-lg font-bold mt-6 mb-2 text-violet-700 dark:text-violet-400'>{children}</h3>; },
                         h4({children}){ return <h4 className='text-base font-bold mt-5 mb-2 text-gray-900 dark:text-gray-200'>{children}</h4>; },
-                        a({children, href}){ return <a href={href} className='text-fuchsia-600 dark:text-fuchsia-400 hover:underline font-medium'>{children}</a>; },
+                        a({children, href}){
+                            const safeHref = sanitizeMarkdownUrl(href);
+                            if (!safeHref) {
+                                return <span className="font-medium">{children}</span>;
+                            }
+                            return (
+                                <a
+                                    href={safeHref}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-fuchsia-600 dark:text-fuchsia-400 hover:underline font-medium"
+                                >
+                                    {children}
+                                </a>
+                            );
+                        },
                         table({children}){
                             return(
                                 <div className='overflow-x-auto my-6 rounded-xl border border-gray-200 dark:border-white/10 shadow-sm'>
@@ -81,7 +97,17 @@ const copyResponse = async () => {
                         th({children}){ return <th className='px-4 py-3 text-left text-xs font-bold text-gray-500 dark:text-gray-400 uppercase tracking-wider'>{children}</th>; },
                         td({children}){ return <td className='px-4 py-3 whitespace-nowrap text-sm text-gray-700 dark:text-gray-300'>{children}</td>; },
                         hr(){ return <hr className='my-8 border-gray-200 dark:border-white/10'></hr>; },
-                        img({src,alt}){ return <img src={src} alt={alt} className='my-6 max-w-full rounded-xl shadow-md border border-gray-100 dark:border-white/10'></img>; }
+                        img({src,alt}){
+                            const safeSrc = sanitizeMarkdownUrl(src);
+                            if (!safeSrc) return null;
+                            return (
+                                <img
+                                    src={safeSrc}
+                                    alt={alt || ""}
+                                    className="my-6 max-w-full rounded-xl shadow-md border border-gray-100 dark:border-white/10"
+                                />
+                            );
+                        }
                     }}
                 >
                     {content}

--- a/frontend/src/utils/sanitizeMarkdownUrl.js
+++ b/frontend/src/utils/sanitizeMarkdownUrl.js
@@ -1,0 +1,38 @@
+/**
+ * Allow only http(s) URLs from model-rendered markdown.
+ * Blocks javascript:, data:, and other unsafe schemes.
+ * @param {string | undefined | null} url
+ * @returns {string | undefined}
+ */
+export function sanitizeMarkdownUrl(url) {
+  if (!url || typeof url !== "string") return undefined;
+
+  const trimmed = url.trim();
+  if (!trimmed) return undefined;
+
+  // Protocol-relative and scheme-relative unsafe forms
+  const lower = trimmed.toLowerCase();
+  if (
+    lower.startsWith("javascript:") ||
+    lower.startsWith("data:") ||
+    lower.startsWith("vbscript:") ||
+    lower.startsWith("file:")
+  ) {
+    return undefined;
+  }
+
+  try {
+    const base =
+      typeof window !== "undefined" && window.location?.origin
+        ? window.location.origin
+        : "https://example.com";
+    const parsed = new URL(trimmed, base);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}

--- a/frontend/src/utils/sanitizeMarkdownUrl.unit.test.js
+++ b/frontend/src/utils/sanitizeMarkdownUrl.unit.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { sanitizeMarkdownUrl } from "./sanitizeMarkdownUrl";
+
+describe("sanitizeMarkdownUrl", () => {
+  it("allows https and http URLs", () => {
+    expect(sanitizeMarkdownUrl("https://example.com/path")).toBe(
+      "https://example.com/path"
+    );
+    expect(sanitizeMarkdownUrl("http://example.com")).toBe("http://example.com/");
+  });
+
+  it("blocks javascript and data schemes", () => {
+    expect(sanitizeMarkdownUrl("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeMarkdownUrl("JavaScript:alert(1)")).toBeUndefined();
+    expect(sanitizeMarkdownUrl("data:text/html,<h1>x</h1>")).toBeUndefined();
+    expect(sanitizeMarkdownUrl("vbscript:msgbox(1)")).toBeUndefined();
+  });
+
+  it("rejects empty and non-string values", () => {
+    expect(sanitizeMarkdownUrl("")).toBeUndefined();
+    expect(sanitizeMarkdownUrl(null)).toBeUndefined();
+    expect(sanitizeMarkdownUrl(undefined)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #1598
Related to #1396

### Summary
AIResponsePreview passed model `href`/`src` straight through. Added `sanitizeMarkdownUrl` to allow only http(s), drop javascript/data/etc, and set `rel="noopener noreferrer"` on links.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- `npm test -- src/utils/sanitizeMarkdownUrl.unit.test.js` in frontend — pass

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue

Made with [Cursor](https://cursor.com)