### PR TITLE
Fix NoSQL Injection in verifyEmail #1551

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -322,8 +322,8 @@ const verifyEmail = async (req, res) => {
     try {
         const { token } = req.query;
 
-        if (!token) {
-            return res.status(400).json({ success: false, message: "Verification token is missing." });
+        if (!token || typeof token !== "string") {
+            return res.status(400).json({ success: false, message: "Verification token is missing or invalid." });
         }
 
         // Find user with matching token that hasn't expired yet


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1551

### Summary
Fixes a critical NoSQL injection vulnerability in the `/api/auth/verify-email` endpoint. The `token` query parameter is now strictly validated to ensure it is a primitive string type before being used in the MongoDB `User.findOne` query. This prevents object injection attacks (e.g., `?token[$ne]=null`) that previously allowed bypassing email verification by blindly matching any account where the verification token was not null.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Confirmed that sending a GET request with an injected object payload (e.g. `/api/auth/verify-email?token[$ne]=null`) correctly returns a `400 Bad Request` with an appropriate error message instead of executing the database query.
- Ensured that valid verification token strings continue to correctly verify user accounts.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixes NoSQL injection in `/api/auth/verify-email`.
- Rejects missing or non-string `token` values with `400 Bad Request`.
- Preserves valid email verification token handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->