### PR TITLE
fix: sanitize error message in saveProgress retry exception handler (#1602)

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -93,7 +93,7 @@ exports.saveProgress = async (req, res) => {
       } catch (retryErr) {
         return res.status(500).json({
           success: false,
-          error: retryErr.message,
+          error: "Internal server error occurred",
         });
       }
     }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1602

### Summary
Replaced `error: retryErr.message` in the `saveProgress` retry exception handler with a generic `"Internal server error occurred"` response. This prevents leaking raw database driver error messages and system details to clients when an exception occurs during the race condition retry phase.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Simulated a database query error during the `err.code === 11000` retry block in `saveProgress`.
- Verified that the API returns HTTP 500 with `{ "success": false, "error": "Internal server error occurred" }` instead of raw exception details.
- Verified that existing standard endpoints continue to handle error responses consistently.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevents `saveProgress` from exposing database driver error details during duplicate-key retry failures.
- Returns `"Internal server error occurred"` with HTTP 500 instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->