### PR TITLE
fix: validate percentage, completedTopics, and followed in saveProgress (#1603)

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -48,6 +48,34 @@ exports.saveProgress = async (req, res) => {
     });
   }
 
+  // Validate optional update fields if provided
+  if (followed !== undefined && typeof followed !== "boolean") {
+    return res.status(400).json({
+      success: false,
+      error: "Invalid followed field, must be a boolean",
+    });
+  }
+
+  if (completedTopics !== undefined && !Array.isArray(completedTopics)) {
+    return res.status(400).json({
+      success: false,
+      error: "Invalid completedTopics field, must be an array",
+    });
+  }
+
+  if (
+    percentage !== undefined &&
+    (typeof percentage !== "number" ||
+      Number.isNaN(percentage) ||
+      percentage < 0 ||
+      percentage > 100)
+  ) {
+    return res.status(400).json({
+      success: false,
+      error: "Invalid percentage field, must be a number between 0 and 100",
+    });
+  }
+
   const validatedSheetId = sheetId.trim();
 
   // Build update fields only for fields that are explicitly defined in the request.


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1603

### Summary
Added strict request body payload validation for `followed`, `completedTopics`, and `percentage` in `saveProgress`. 

- `followed`: Enforces boolean type if defined.
- `completedTopics`: Enforces array type if defined.
- `percentage`: Enforces a valid number bounded between `0` and `100` (inclusive) if defined.

Requests containing invalid types or out-of-bounds percentages now return an HTTP 400 Bad Request with an appropriate error message prior to executing database queries.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Sent `POST /api/user/sheet-progress` with `{ "sheetId": "sheet123", "percentage": -500 }` and verified HTTP 400 response.
- Sent `POST /api/user/sheet-progress` with `{ "sheetId": "sheet123", "followed": "not-a-boolean" }` and verified HTTP 400 response.
- Sent `POST /api/user/sheet-progress` with `{ "sheetId": "sheet123", "completedTopics": "not-an-array" }` and verified HTTP 400 response.
- Confirmed valid updates (`percentage`: 85, `followed`: true, `completedTopics`: ['topic1']) save successfully.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds strict validation for `followed`, `completedTopics`, and `percentage` in `saveProgress`. Invalid requests return HTTP 400 before database queries execute. Valid updates continue to save successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->