### PR TITLE
fix(security): enable helmet and limit express.json to 1mb

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -2,6 +2,7 @@ require("dotenv").config();
 const validateEnv = require("./config/validateEnv.js");
 validateEnv();
 const express = require("express");
+const helmet = require("helmet");
 
 // Global unhandled promise rejection handler
 process.on("unhandledRejection", (err) => {
@@ -41,6 +42,13 @@ const reverseProxyCidrs = (process.env.REVERSE_PROXY_CIDR || "")
 if (reverseProxyCidrs.length > 0) {
   app.set("trust proxy", reverseProxyCidrs);
 }
+// Helmet for API hardening; CSP stays in generalHeaders / SPA layer.
+app.use(
+  helmet({
+    contentSecurityPolicy: false,
+    crossOriginEmbedderPolicy: false,
+  })
+);
 app.use(generalHeaders);
 const isDev = process.env.NODE_ENV !== "production";
 const originEnvList = [
@@ -99,7 +107,7 @@ connectDB()
   });
 
 // Middleware
-app.use(express.json());
+app.use(express.json({ limit: "1mb" }));
 app.use(cookieParser());
 
 //Routes


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #1588

### Summary
`helmet` was in deps but never mounted, and `express.json()` had no size cap. Wired helmet (CSP left to existing headers/SPA) and set `express.json({ limit: '1mb' })`. Left the reverse-proxy CIDR trust logic alone.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Backend vitest suite still green for existing auth/middleware tests
- Confirmed `helmet` import + `limit: "1mb"` in `server.js`

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `helmet` middleware with CSP and cross-origin embedder policy disabled.
- Limited `express.json()` request bodies to `1mb`.
- Preserved existing SPA CSP handling and reverse-proxy CIDR trust logic.
- Existing backend Vitest auth and middleware tests remain green.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->