### PR TITLE
fix(auth): protect dashboard, role-prep, and interview-prep routes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -23,7 +23,7 @@ import CognitiveGamesPage from "./pages/CognitiveGames/CognitiveGamesPage";
 import { useContext } from "react";
 import { UserContext } from "./context/userContext";
 import MainLayout from "./components/Layouts/MainLayout";
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import ResumeTemplates from "./pages/ResumeBuilder/ResumeTemplates";
 import ResumeEditor from "./pages/ResumeBuilder/ResumeEditor";
 import ResumeAnalyzer from "./pages/ResumeBuilder/ResumeAnalyzer";
@@ -51,6 +51,7 @@ import Analytics from "./pages/Analytics";
 import QuestionBank from "./pages/QuestionBank/QuestionBank";
 const ProtectedRoute = ({ children }) => {
   const { user, loading } = useContext(UserContext);
+  const location = useLocation();
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-[var(--color-background)]">
@@ -59,7 +60,7 @@ const ProtectedRoute = ({ children }) => {
     );
   }
   if (!user) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
   return children;
 };
@@ -121,11 +122,13 @@ const App = () => {
                 <Route
                   path="/interview-prep/:sessionId"
                   element={
-                    <ErrorBoundary>
-                      <PageTransition>
-                        <InterviewPrep />
-                      </PageTransition>
-                    </ErrorBoundary>
+                    <ProtectedRoute>
+                      <ErrorBoundary>
+                        <PageTransition>
+                          <InterviewPrep />
+                        </PageTransition>
+                      </ErrorBoundary>
+                    </ProtectedRoute>
                   }
                 />
                 {import.meta.env.DEV && (
@@ -169,9 +172,11 @@ const App = () => {
                   <Route
                     path="/dashboard"
                     element={
-                      <PageTransition>
-                        <ProgressTrackerDashboard />
-                      </PageTransition>
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <ProgressTrackerDashboard />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   {import.meta.env.DEV && (
@@ -221,9 +226,11 @@ const App = () => {
                   <Route
                     path="/role-prep"
                     element={
-                      <PageTransition>
-                        <Dashboard />
-                      </PageTransition>
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <Dashboard />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   <Route

--- a/frontend/src/pages/Auth/AuthPage.jsx
+++ b/frontend/src/pages/Auth/AuthPage.jsx
@@ -30,7 +30,7 @@ const AuthPage = () => {
         {page === "login" ? (
           <Login
             setCurrentPage={setPage}
-            onLoginSuccess={() => navigate(redirectTo)}
+            onLoginSuccess={() => navigate(redirectTo, { replace: true })}
           />
         ) : (
           <SignUp setCurrentPage={setPage} />

--- a/frontend/src/pages/Auth/AuthPage.jsx
+++ b/frontend/src/pages/Auth/AuthPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { useNavigate, Navigate } from "react-router-dom";
+import { useNavigate, Navigate, useLocation } from "react-router-dom";
 import Login from "./Login";
 import SignUp from "./SignUp";
 import { UserContext } from "../../context/userContext";
@@ -13,10 +13,15 @@ const AuthPage = () => {
   const [page, setPage] = useState("login");
   const { user, loading } = useContext(UserContext);
   const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTo =
+    location.state?.from?.pathname && location.state.from.pathname !== "/login"
+      ? `${location.state.from.pathname}${location.state.from.search || ""}`
+      : "/dashboard";
 
-  // Already logged in → go to dashboard
+  // Already logged in → go to return URL or dashboard
   if (!loading && user) {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to={redirectTo} replace />;
   }
 
   return (
@@ -25,7 +30,7 @@ const AuthPage = () => {
         {page === "login" ? (
           <Login
             setCurrentPage={setPage}
-            onLoginSuccess={() => navigate("/dashboard")}
+            onLoginSuccess={() => navigate(redirectTo)}
           />
         ) : (
           <SignUp setCurrentPage={setPage} />

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -78,7 +78,7 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
         if (onLoginSuccess) {
           onLoginSuccess();
         } else {
-          navigate(redirectTo);
+          navigate(redirectTo, { replace: true });
         }
       }
     } catch (error) {

--- a/frontend/src/pages/Auth/Login.jsx
+++ b/frontend/src/pages/Auth/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useContext } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
 import Input from "../../components/Inputs/Input";
 import Button from "../../components/Button/Button";
 import { validateEmail } from "../../utils/helper";
@@ -22,6 +22,11 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
 
   const { updateUser } = useContext(UserContext);
   const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTo =
+    location.state?.from?.pathname && location.state.from.pathname !== "/login"
+      ? `${location.state.from.pathname}${location.state.from.search || ""}`
+      : "/dashboard";
 
   const clearError = () => {
     if (error) {
@@ -73,7 +78,7 @@ const Login = ({ setCurrentPage, onLoginSuccess }) => {
         if (onLoginSuccess) {
           onLoginSuccess();
         } else {
-          navigate("/dashboard");
+          navigate(redirectTo);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #1635

### Summary
`/dashboard`, `/role-prep`, and `/interview-prep/:sessionId` were outside `ProtectedRoute`. Wrapped them and pass `location` via navigate state so login returns to the original path.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Compared route table with other protected pages
- Confirmed AuthPage/Login honor `state.from` after sign-in

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Protects `/dashboard`, `/role-prep`, and `/interview-prep/:sessionId` with `ProtectedRoute`. Preserves the original path and query string during login redirects. Redirects users to the original route after successful authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->