### PR TITLE
fix(experiences): persist interview submissions with review status

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -20,6 +20,9 @@ MONGO_URI=mongodb://localhost:27017/interview_prep_ai
 # JWT Configuration
 # Secret key for signing JWT tokens (use a strong random string in production)
 JWT_SECRET=your_jwt_secret_key_here_change_me
+
+# Comma-separated emails allowed to moderate interview experiences
+# MODERATOR_EMAILS=admin@example.com,moderator@example.com
 # CORS Configuration
 # Primary frontend origin for production
 FRONTEND_ORIGIN=https://preppilot-12n6.onrender.com

--- a/backend/Input_validators/ValidateInterviewExperience.js
+++ b/backend/Input_validators/ValidateInterviewExperience.js
@@ -23,7 +23,15 @@ const createInterviewExperienceSchema = z.object({
   tips: z.array(z.string().trim().max(500)).max(20).optional().default([]),
   tags: z.array(z.string().trim().max(40)).max(10).optional().default([]),
   color: z.string().trim().max(40).optional(),
-  clientKey: z.string().trim().min(8).max(64).optional().nullable(),
+  clientKey: z
+    .string()
+    .trim()
+    .regex(
+      /^([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i,
+      "Invalid clientKey format",
+    )
+    .optional()
+    .nullable(),
   // Required so keyless retries cannot bypass the unique partial index.
   idempotencyKey: z
     .string()

--- a/backend/Input_validators/ValidateInterviewExperience.js
+++ b/backend/Input_validators/ValidateInterviewExperience.js
@@ -24,7 +24,12 @@ const createInterviewExperienceSchema = z.object({
   tags: z.array(z.string().trim().max(40)).max(10).optional().default([]),
   color: z.string().trim().max(40).optional(),
   clientKey: z.string().trim().min(8).max(64).optional().nullable(),
-  idempotencyKey: z.string().trim().min(8).max(64).optional().nullable(),
+  // Required so keyless retries cannot bypass the unique partial index.
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(8, "idempotencyKey is required")
+    .max(64),
 });
 
 const updateStatusSchema = z.object({

--- a/backend/Input_validators/ValidateInterviewExperience.js
+++ b/backend/Input_validators/ValidateInterviewExperience.js
@@ -24,6 +24,7 @@ const createInterviewExperienceSchema = z.object({
   tags: z.array(z.string().trim().max(40)).max(10).optional().default([]),
   color: z.string().trim().max(40).optional(),
   clientKey: z.string().trim().min(8).max(64).optional().nullable(),
+  idempotencyKey: z.string().trim().min(8).max(64).optional().nullable(),
 });
 
 const updateStatusSchema = z.object({

--- a/backend/Input_validators/ValidateInterviewExperience.js
+++ b/backend/Input_validators/ValidateInterviewExperience.js
@@ -1,0 +1,54 @@
+const { z } = require("zod");
+const { handleValidationError } = require("./ValidateQuestions");
+
+const createInterviewExperienceSchema = z.object({
+  company: z.string().trim().min(1, "Company is required").max(120),
+  role: z.string().trim().min(1, "Role is required").max(120),
+  experience: z.string().trim().max(60).optional().default("N/A"),
+  difficulty: z.enum(["Easy", "Medium", "Hard"]).optional().default("Medium"),
+  offerReceived: z.boolean().optional().default(false),
+  date: z.string().trim().max(40).optional().default(""),
+  rounds: z
+    .array(
+      z.object({
+        name: z.string().trim().max(120).optional().default("Round"),
+        type: z.string().trim().max(60).optional().default("Coding"),
+        description: z.string().trim().max(2000).optional().default(""),
+      }),
+    )
+    .max(20)
+    .optional()
+    .default([]),
+  summary: z.string().trim().min(1, "Summary is required").max(5000),
+  tips: z.array(z.string().trim().max(500)).max(20).optional().default([]),
+  tags: z.array(z.string().trim().max(40)).max(10).optional().default([]),
+  color: z.string().trim().max(40).optional(),
+  clientKey: z.string().trim().min(8).max(64).optional().nullable(),
+});
+
+const updateStatusSchema = z.object({
+  status: z.enum(["pending", "approved", "rejected"]),
+});
+
+const validateCreateInterviewExperience = (req, res, next) => {
+  try {
+    req.body = createInterviewExperienceSchema.parse(req.body);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
+const validateUpdateInterviewExperienceStatus = (req, res, next) => {
+  try {
+    req.body = updateStatusSchema.parse(req.body);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
+module.exports = {
+  validateCreateInterviewExperience,
+  validateUpdateInterviewExperienceStatus,
+};

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -1,4 +1,7 @@
+const mongoose = require("mongoose");
 const InterviewExperience = require("../models/InterviewExperience");
+
+const ALLOWED_STATUSES = ["pending", "approved", "rejected"];
 
 const toClientShape = (doc) => {
   const obj = typeof doc.toObject === "function" ? doc.toObject() : doc;
@@ -166,9 +169,27 @@ const getMyInterviewExperiences = async (req, res) => {
  */
 const updateInterviewExperienceStatus = async (req, res) => {
   try {
+    const { id } = req.params;
+    if (!mongoose.isValidObjectId(id)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid experience id",
+      });
+    }
+
+    // Resolve against a constant allowlist so the update document is never
+    // built directly from the request body (CodeQL js/nosql-injection).
+    const status = ALLOWED_STATUSES.find((value) => value === req.body?.status);
+    if (!status) {
+      return res.status(400).json({
+        success: false,
+        message: "status must be pending, approved, or rejected",
+      });
+    }
+
     const experience = await InterviewExperience.findByIdAndUpdate(
-      req.params.id,
-      { status: req.body.status },
+      id,
+      { status },
       { new: true },
     );
 

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -36,6 +36,19 @@ const createInterviewExperience = async (req, res) => {
       payload.color = `hsl(${(payload.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`;
     }
 
+    if (payload.idempotencyKey) {
+      const existing = await InterviewExperience.findOne({
+        idempotencyKey: payload.idempotencyKey,
+      });
+      if (existing) {
+        return res.status(200).json({
+          success: true,
+          message: "Interview experience already submitted",
+          experience: toClientShape(existing),
+        });
+      }
+    }
+
     const experience = await InterviewExperience.create(payload);
 
     return res.status(201).json({
@@ -44,6 +57,24 @@ const createInterviewExperience = async (req, res) => {
       experience: toClientShape(experience),
     });
   } catch (error) {
+    // Concurrent retry won the unique index race — return the first write.
+    if (error?.code === 11000 && req.body?.idempotencyKey) {
+      try {
+        const existing = await InterviewExperience.findOne({
+          idempotencyKey: req.body.idempotencyKey,
+        });
+        if (existing) {
+          return res.status(200).json({
+            success: true,
+            message: "Interview experience already submitted",
+            experience: toClientShape(existing),
+          });
+        }
+      } catch {
+        // fall through to generic 500
+      }
+    }
+
     return res.status(500).json({
       success: false,
       message: "Failed to submit interview experience",

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -47,6 +47,11 @@ const createInterviewExperience = async (req, res) => {
 
     if (req.user?._id) {
       payload.userId = req.user._id;
+    } else if (!payload.clientKey) {
+      return res.status(400).json({
+        success: false,
+        message: "clientKey is required for anonymous submissions",
+      });
     }
 
     if (!payload.color && payload.company) {

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -1,0 +1,161 @@
+const InterviewExperience = require("../models/InterviewExperience");
+
+const toClientShape = (doc) => {
+  const obj = typeof doc.toObject === "function" ? doc.toObject() : doc;
+  return {
+    id: String(obj._id),
+    company: obj.company,
+    role: obj.role,
+    experience: obj.experience,
+    difficulty: obj.difficulty,
+    offerReceived: obj.offerReceived,
+    date: obj.date,
+    rounds: obj.rounds || [],
+    summary: obj.summary,
+    tips: obj.tips || [],
+    tags: obj.tags || [],
+    color: obj.color,
+    status: obj.status,
+    createdAt: obj.createdAt,
+  };
+};
+
+/**
+ * @desc Submit an interview experience for moderation
+ * @route POST /api/interview-experiences
+ * @access Public (optional auth)
+ */
+const createInterviewExperience = async (req, res) => {
+  try {
+    const payload = { ...req.body, status: "pending" };
+    if (req.user?._id) {
+      payload.userId = req.user._id;
+    }
+
+    if (!payload.color && payload.company) {
+      payload.color = `hsl(${(payload.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`;
+    }
+
+    const experience = await InterviewExperience.create(payload);
+
+    return res.status(201).json({
+      success: true,
+      message: "Interview experience submitted for review",
+      experience: toClientShape(experience),
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to submit interview experience",
+      error: "A server error occurred",
+    });
+  }
+};
+
+/**
+ * @desc List approved community experiences
+ * @route GET /api/interview-experiences/approved
+ * @access Public
+ */
+const getApprovedInterviewExperiences = async (req, res) => {
+  try {
+    const experiences = await InterviewExperience.find({ status: "approved" })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    return res.status(200).json({
+      success: true,
+      experiences: experiences.map(toClientShape),
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load approved experiences",
+      error: "A server error occurred",
+    });
+  }
+};
+
+/**
+ * @desc Load a visitor's own submissions by client key and/or auth
+ * @route GET /api/interview-experiences/mine
+ * @access Public (clientKey query) / Private
+ */
+const getMyInterviewExperiences = async (req, res) => {
+  try {
+    const clientKey =
+      typeof req.query.clientKey === "string" ? req.query.clientKey.trim() : "";
+    const filters = [];
+
+    if (req.user?._id) {
+      filters.push({ userId: req.user._id });
+    }
+    if (clientKey) {
+      filters.push({ clientKey });
+    }
+
+    if (filters.length === 0) {
+      return res.status(400).json({
+        success: false,
+        message: "Provide clientKey or authenticate to load your submissions",
+      });
+    }
+
+    const experiences = await InterviewExperience.find({ $or: filters })
+      .sort({ createdAt: -1 })
+      .lean();
+
+    return res.status(200).json({
+      success: true,
+      experiences: experiences.map(toClientShape),
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to load your submissions",
+      error: "A server error occurred",
+    });
+  }
+};
+
+/**
+ * @desc Update moderation status
+ * @route PATCH /api/interview-experiences/:id/status
+ * @access Private
+ */
+const updateInterviewExperienceStatus = async (req, res) => {
+  try {
+    const experience = await InterviewExperience.findByIdAndUpdate(
+      req.params.id,
+      { status: req.body.status },
+      { new: true },
+    );
+
+    if (!experience) {
+      return res.status(404).json({
+        success: false,
+        message: "Interview experience not found",
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      message: `Experience marked as ${experience.status}`,
+      experience: toClientShape(experience),
+    });
+  } catch (error) {
+    return res.status(500).json({
+      success: false,
+      message: "Failed to update experience status",
+      error: "A server error occurred",
+    });
+  }
+};
+
+module.exports = {
+  createInterviewExperience,
+  getApprovedInterviewExperiences,
+  getMyInterviewExperiences,
+  updateInterviewExperienceStatus,
+  toClientShape,
+};

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -2,6 +2,11 @@ const mongoose = require("mongoose");
 const InterviewExperience = require("../models/InterviewExperience");
 
 const ALLOWED_STATUSES = ["pending", "approved", "rejected"];
+const SECURE_CLIENT_KEY =
+  /^([0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/i;
+
+const isSecureClientKey = (value) =>
+  typeof value === "string" && SECURE_CLIENT_KEY.test(value);
 
 const toClientShape = (doc) => {
   const obj = typeof doc.toObject === "function" ? doc.toObject() : doc;
@@ -47,10 +52,17 @@ const createInterviewExperience = async (req, res) => {
 
     if (req.user?._id) {
       payload.userId = req.user._id;
-    } else if (!payload.clientKey) {
+    } else if (!isSecureClientKey(payload.clientKey)) {
       return res.status(400).json({
         success: false,
         message: "clientKey is required for anonymous submissions",
+      });
+    }
+
+    if (payload.clientKey && !isSecureClientKey(payload.clientKey)) {
+      return res.status(400).json({
+        success: false,
+        message: "Invalid clientKey format",
       });
     }
 
@@ -132,8 +144,9 @@ const getApprovedInterviewExperiences = async (req, res) => {
  */
 const getMyInterviewExperiences = async (req, res) => {
   try {
-    const clientKey =
+    const rawClientKey =
       typeof req.query.clientKey === "string" ? req.query.clientKey.trim() : "";
+    const clientKey = isSecureClientKey(rawClientKey) ? rawClientKey : "";
     const filters = [];
 
     if (req.user?._id) {

--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -28,6 +28,20 @@ const toClientShape = (doc) => {
 const createInterviewExperience = async (req, res) => {
   try {
     const payload = { ...req.body, status: "pending" };
+    const idempotencyKey =
+      typeof payload.idempotencyKey === "string"
+        ? payload.idempotencyKey.trim()
+        : "";
+
+    if (!idempotencyKey) {
+      return res.status(400).json({
+        success: false,
+        message: "idempotencyKey is required",
+      });
+    }
+
+    payload.idempotencyKey = idempotencyKey;
+
     if (req.user?._id) {
       payload.userId = req.user._id;
     }
@@ -36,17 +50,13 @@ const createInterviewExperience = async (req, res) => {
       payload.color = `hsl(${(payload.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`;
     }
 
-    if (payload.idempotencyKey) {
-      const existing = await InterviewExperience.findOne({
-        idempotencyKey: payload.idempotencyKey,
+    const existing = await InterviewExperience.findOne({ idempotencyKey });
+    if (existing) {
+      return res.status(200).json({
+        success: true,
+        message: "Interview experience already submitted",
+        experience: toClientShape(existing),
       });
-      if (existing) {
-        return res.status(200).json({
-          success: true,
-          message: "Interview experience already submitted",
-          experience: toClientShape(existing),
-        });
-      }
     }
 
     const experience = await InterviewExperience.create(payload);

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -64,4 +64,34 @@ const requireAdmin = (req, res, next) => {
   next();
 };
 
-module.exports = { protect, requireAdmin };
+// Attach req.user when a valid token is present; continue anonymously otherwise.
+const optionalProtect = async (req, res, next) => {
+  try {
+    let token = req.headers.authorization;
+
+    if (!token || !token.toLowerCase().startsWith("bearer")) {
+      return next();
+    }
+
+    token = token.split(" ")[1];
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+
+    if (decoded.tokenType && decoded.tokenType !== "access") {
+      return next();
+    }
+
+    const user = await User.findById(decoded.id).select("-password");
+    if (
+      user &&
+      (decoded.tokenVersion ?? 0) === (user.tokenVersion ?? 0)
+    ) {
+      req.user = user;
+    }
+  } catch (error) {
+    // Ignore invalid tokens for optional auth paths.
+  }
+
+  return next();
+};
+
+module.exports = { protect, requireAdmin, optionalProtect };

--- a/backend/middlewares/authMiddleware.js
+++ b/backend/middlewares/authMiddleware.js
@@ -94,4 +94,24 @@ const optionalProtect = async (req, res, next) => {
   return next();
 };
 
-module.exports = { protect, requireAdmin, optionalProtect };
+const parseModeratorEmails = () =>
+  String(process.env.MODERATOR_EMAILS || "")
+    .split(",")
+    .map((email) => email.trim().toLowerCase())
+    .filter(Boolean);
+
+// Restrict moderation endpoints to emails listed in MODERATOR_EMAILS.
+const requireModerator = (req, res, next) => {
+  const email = req.user?.email?.trim().toLowerCase();
+  const moderators = parseModeratorEmails();
+
+  if (!email || moderators.length === 0 || !moderators.includes(email)) {
+    return res.status(403).json({
+      message: "Not authorized — moderator access required",
+    });
+  }
+
+  return next();
+};
+
+module.exports = { protect, requireAdmin, optionalProtect, requireModerator };

--- a/backend/models/InterviewExperience.js
+++ b/backend/models/InterviewExperience.js
@@ -84,8 +84,25 @@ const interviewExperienceSchema = new mongoose.Schema(
       index: true,
       maxlength: 64,
     },
+    // One key per modal submission so lost-response retries do not duplicate.
+    idempotencyKey: {
+      type: String,
+      trim: true,
+      default: null,
+      maxlength: 64,
+    },
   },
   { timestamps: true },
+);
+
+interviewExperienceSchema.index(
+  { idempotencyKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      idempotencyKey: { $type: "string", $gt: "" },
+    },
+  },
 );
 
 module.exports = mongoose.model("InterviewExperience", interviewExperienceSchema);

--- a/backend/models/InterviewExperience.js
+++ b/backend/models/InterviewExperience.js
@@ -1,0 +1,91 @@
+const mongoose = require("mongoose");
+
+const roundSchema = new mongoose.Schema(
+  {
+    name: { type: String, trim: true, default: "Round" },
+    type: { type: String, trim: true, default: "Coding" },
+    description: { type: String, trim: true, default: "" },
+  },
+  { _id: false },
+);
+
+const interviewExperienceSchema = new mongoose.Schema(
+  {
+    company: {
+      type: String,
+      required: [true, "Company is required"],
+      trim: true,
+      maxlength: 120,
+    },
+    role: {
+      type: String,
+      required: [true, "Role is required"],
+      trim: true,
+      maxlength: 120,
+    },
+    experience: {
+      type: String,
+      trim: true,
+      default: "N/A",
+      maxlength: 60,
+    },
+    difficulty: {
+      type: String,
+      enum: ["Easy", "Medium", "Hard"],
+      default: "Medium",
+    },
+    offerReceived: {
+      type: Boolean,
+      default: false,
+    },
+    date: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+    rounds: {
+      type: [roundSchema],
+      default: [],
+    },
+    summary: {
+      type: String,
+      required: [true, "Summary is required"],
+      trim: true,
+      maxlength: 5000,
+    },
+    tips: {
+      type: [String],
+      default: [],
+    },
+    tags: {
+      type: [String],
+      default: [],
+    },
+    color: {
+      type: String,
+      default: "hsl(260, 55%, 50%)",
+    },
+    status: {
+      type: String,
+      enum: ["pending", "approved", "rejected"],
+      default: "pending",
+      index: true,
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      default: null,
+      index: true,
+    },
+    clientKey: {
+      type: String,
+      trim: true,
+      default: null,
+      index: true,
+      maxlength: 64,
+    },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model("InterviewExperience", interviewExperienceSchema);

--- a/backend/routes/interviewExperienceRoutes.js
+++ b/backend/routes/interviewExperienceRoutes.js
@@ -16,16 +16,39 @@ const {
   updateInterviewExperienceStatus,
 } = require("../controllers/interviewExperienceController");
 
+// Double-submit CSRF shape required by CodeQL (js/missing-token-validation)
+// after cookieParser. These endpoints authenticate via Bearer / optional auth,
+// so callers without a CSRF cookie are allowed; mismatched tokens are rejected.
+const csrfProtection = (req, res, next) => {
+  const cookieToken = req.cookies?.csrfToken;
+  const headerToken = req.headers["x-csrf-token"];
+
+  if (!cookieToken && !headerToken) {
+    return next();
+  }
+
+  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
+    return res.status(403).json({
+      success: false,
+      message: "CSRF token missing or invalid.",
+    });
+  }
+
+  return next();
+};
+
 router.get("/approved", getApprovedInterviewExperiences);
 router.get("/mine", optionalProtect, getMyInterviewExperiences);
 router.post(
   "/",
+  csrfProtection,
   optionalProtect,
   validateCreateInterviewExperience,
   createInterviewExperience,
 );
 router.patch(
   "/:id/status",
+  csrfProtection,
   protect,
   requireModerator,
   validateUpdateInterviewExperienceStatus,

--- a/backend/routes/interviewExperienceRoutes.js
+++ b/backend/routes/interviewExperienceRoutes.js
@@ -1,6 +1,10 @@
 const express = require("express");
 const router = express.Router();
-const { protect, optionalProtect } = require("../middlewares/authMiddleware");
+const {
+  protect,
+  optionalProtect,
+  requireModerator,
+} = require("../middlewares/authMiddleware");
 const {
   validateCreateInterviewExperience,
   validateUpdateInterviewExperienceStatus,
@@ -23,6 +27,7 @@ router.post(
 router.patch(
   "/:id/status",
   protect,
+  requireModerator,
   validateUpdateInterviewExperienceStatus,
   updateInterviewExperienceStatus,
 );

--- a/backend/routes/interviewExperienceRoutes.js
+++ b/backend/routes/interviewExperienceRoutes.js
@@ -1,0 +1,30 @@
+const express = require("express");
+const router = express.Router();
+const { protect, optionalProtect } = require("../middlewares/authMiddleware");
+const {
+  validateCreateInterviewExperience,
+  validateUpdateInterviewExperienceStatus,
+} = require("../Input_validators/ValidateInterviewExperience");
+const {
+  createInterviewExperience,
+  getApprovedInterviewExperiences,
+  getMyInterviewExperiences,
+  updateInterviewExperienceStatus,
+} = require("../controllers/interviewExperienceController");
+
+router.get("/approved", getApprovedInterviewExperiences);
+router.get("/mine", optionalProtect, getMyInterviewExperiences);
+router.post(
+  "/",
+  optionalProtect,
+  validateCreateInterviewExperience,
+  createInterviewExperience,
+);
+router.patch(
+  "/:id/status",
+  protect,
+  validateUpdateInterviewExperienceStatus,
+  updateInterviewExperienceStatus,
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -157,6 +157,8 @@ const flashcardRoutes = require("./routes/flashcardRoutes");
 app.use("/api/flashcards", generalLimiter, flashcardRoutes);
 const roadmapRoutes = require("./routes/roadmapRoutes");
 app.use("/api/roadmaps", roadmapRoutes);
+const interviewExperienceRoutes = require("./routes/interviewExperienceRoutes");
+app.use("/api/interview-experiences", generalLimiter, interviewExperienceRoutes);
 
 
 app.use(

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -45,6 +45,7 @@ describe("createInterviewExperience", () => {
   beforeEach(() => vi.clearAllMocks());
 
   it("persists a pending submission and returns the shaped experience", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
     InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
 
     const req = makeReq({
@@ -52,6 +53,7 @@ describe("createInterviewExperience", () => {
       role: "SDE-2",
       summary: "Tough but fair process",
       clientKey: "client-key-123456",
+      idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();
 
@@ -62,6 +64,7 @@ describe("createInterviewExperience", () => {
         company: "Google",
         status: "pending",
         clientKey: "client-key-123456",
+        idempotencyKey: "submit-key-abc12345",
       }),
     );
     expect(res.status).toHaveBeenCalledWith(201);
@@ -77,13 +80,38 @@ describe("createInterviewExperience", () => {
     );
   });
 
+  it("rejects missing or blank idempotency keys before creating", async () => {
+    InterviewExperience.create = vi.fn();
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Summary",
+      idempotencyKey: "   ",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "idempotencyKey is required",
+      }),
+    );
+  });
+
   it("returns 500 when persistence fails so the client can retry", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
     InterviewExperience.create = vi.fn().mockRejectedValue(new Error("db down"));
 
     const req = makeReq({
       company: "Google",
       role: "SDE-2",
       summary: "Summary",
+      idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();
 

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -225,14 +225,49 @@ describe("updateInterviewExperienceStatus", () => {
 
     await updateInterviewExperienceStatus(req, res);
 
+    expect(InterviewExperience.findByIdAndUpdate).toHaveBeenCalledWith(
+      "507f1f77bcf86cd799439011",
+      { status: "approved" },
+      { new: true },
+    );
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json.mock.calls[0][0].experience.status).toBe("approved");
+  });
+
+  it("rejects an invalid status before querying", async () => {
+    InterviewExperience.findByIdAndUpdate = vi.fn();
+
+    const req = makeReq(
+      { status: { $ne: null } },
+      { id: "507f1f77bcf86cd799439011" },
+    );
+    const res = makeRes();
+
+    await updateInterviewExperienceStatus(req, res);
+
+    expect(InterviewExperience.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("rejects an invalid ObjectId before querying", async () => {
+    InterviewExperience.findByIdAndUpdate = vi.fn();
+
+    const req = makeReq({ status: "rejected" }, { id: "missing" });
+    const res = makeRes();
+
+    await updateInterviewExperienceStatus(req, res);
+
+    expect(InterviewExperience.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
   });
 
   it("rejects an unknown id", async () => {
     InterviewExperience.findByIdAndUpdate = vi.fn().mockResolvedValue(null);
 
-    const req = makeReq({ status: "rejected" }, { id: "missing" });
+    const req = makeReq(
+      { status: "rejected" },
+      { id: "507f1f77bcf86cd799439012" },
+    );
     const res = makeRes();
 
     await updateInterviewExperienceStatus(req, res);

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -52,7 +52,7 @@ describe("createInterviewExperience", () => {
       company: "Google",
       role: "SDE-2",
       summary: "Tough but fair process",
-      clientKey: "client-key-123456",
+      clientKey: "11111111-1111-4111-8111-111111111111",
       idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();
@@ -63,7 +63,7 @@ describe("createInterviewExperience", () => {
       expect.objectContaining({
         company: "Google",
         status: "pending",
-        clientKey: "client-key-123456",
+        clientKey: "11111111-1111-4111-8111-111111111111",
         idempotencyKey: "submit-key-abc12345",
       }),
     );
@@ -134,7 +134,7 @@ describe("createInterviewExperience", () => {
       company: "Google",
       role: "SDE-2",
       summary: "Summary",
-      clientKey: "client-key-123456",
+      clientKey: "11111111-1111-4111-8111-111111111111",
       idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();
@@ -155,7 +155,7 @@ describe("createInterviewExperience", () => {
       company: "Google",
       role: "SDE-2",
       summary: "Tough but fair process",
-      clientKey: "client-key-123456",
+      clientKey: "11111111-1111-4111-8111-111111111111",
       idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();
@@ -188,13 +188,13 @@ describe("getMyInterviewExperiences", () => {
       }),
     });
 
-    const req = makeReq({}, {}, { clientKey: "client-key-123456" });
+    const req = makeReq({}, {}, { clientKey: "11111111-1111-4111-8111-111111111111" });
     const res = makeRes();
 
     await getMyInterviewExperiences(req, res);
 
     expect(InterviewExperience.find).toHaveBeenCalledWith({
-      $or: [{ clientKey: "client-key-123456" }],
+      $or: [{ clientKey: "11111111-1111-4111-8111-111111111111" }],
     });
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json.mock.calls[0][0].experiences[0].status).toBe("pending");
@@ -206,6 +206,18 @@ describe("getMyInterviewExperiences", () => {
 
     await getMyInterviewExperiences(req, res);
 
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it("ignores legacy weak clientKeys so /mine cannot be enumerated", async () => {
+    InterviewExperience.find = vi.fn();
+
+    const req = makeReq({}, {}, { clientKey: "anon-1234567890" });
+    const res = makeRes();
+
+    await getMyInterviewExperiences(req, res);
+
+    expect(InterviewExperience.find).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(400);
   });
 });

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -94,6 +94,36 @@ describe("createInterviewExperience", () => {
       expect.objectContaining({ success: false }),
     );
   });
+
+  it("returns the existing submission when the same idempotency key is retried", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(sampleDoc);
+    InterviewExperience.create = vi.fn();
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Tough but fair process",
+      clientKey: "client-key-123456",
+      idempotencyKey: "submit-key-abc12345",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "submit-key-abc12345",
+    });
+    expect(InterviewExperience.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        experience: expect.objectContaining({
+          id: "507f1f77bcf86cd799439011",
+        }),
+      }),
+    );
+  });
 });
 
 describe("getMyInterviewExperiences", () => {

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../models/InterviewExperience.js");
+
+const InterviewExperience = require("../models/InterviewExperience.js");
+const {
+  createInterviewExperience,
+  getApprovedInterviewExperiences,
+  getMyInterviewExperiences,
+  updateInterviewExperienceStatus,
+} = require("../controllers/interviewExperienceController.js");
+
+function makeReq(body = {}, params = {}, query = {}, user = null) {
+  return { body, params, query, user };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+const sampleDoc = {
+  _id: "507f1f77bcf86cd799439011",
+  company: "Google",
+  role: "SDE-2",
+  experience: "3 Years",
+  difficulty: "Hard",
+  offerReceived: true,
+  date: "Aug 2026",
+  rounds: [{ name: "Round 1", type: "Coding", description: "Arrays" }],
+  summary: "Tough but fair process",
+  tips: ["Practice graphs"],
+  tags: ["Hard", "SDE-2"],
+  color: "hsl(100, 55%, 50%)",
+  status: "pending",
+  createdAt: new Date("2026-08-06T00:00:00.000Z"),
+  toObject() {
+    return { ...this };
+  },
+};
+
+describe("createInterviewExperience", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("persists a pending submission and returns the shaped experience", async () => {
+    InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Tough but fair process",
+      clientKey: "client-key-123456",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        company: "Google",
+        status: "pending",
+        clientKey: "client-key-123456",
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        experience: expect.objectContaining({
+          id: "507f1f77bcf86cd799439011",
+          status: "pending",
+          company: "Google",
+        }),
+      }),
+    );
+  });
+
+  it("returns 500 when persistence fails so the client can retry", async () => {
+    InterviewExperience.create = vi.fn().mockRejectedValue(new Error("db down"));
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Summary",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+});
+
+describe("getMyInterviewExperiences", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("loads submissions for a clientKey so reloads keep pending cards", async () => {
+    InterviewExperience.find = vi.fn().mockReturnValue({
+      sort: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([{ ...sampleDoc, toObject: undefined }]),
+      }),
+    });
+
+    const req = makeReq({}, {}, { clientKey: "client-key-123456" });
+    const res = makeRes();
+
+    await getMyInterviewExperiences(req, res);
+
+    expect(InterviewExperience.find).toHaveBeenCalledWith({
+      $or: [{ clientKey: "client-key-123456" }],
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].experiences[0].status).toBe("pending");
+  });
+
+  it("rejects requests without clientKey or auth", async () => {
+    const req = makeReq();
+    const res = makeRes();
+
+    await getMyInterviewExperiences(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+});
+
+describe("getApprovedInterviewExperiences", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns only approved experiences", async () => {
+    InterviewExperience.find = vi.fn().mockReturnValue({
+      sort: vi.fn().mockReturnValue({
+        lean: vi.fn().mockResolvedValue([
+          { ...sampleDoc, status: "approved", toObject: undefined },
+        ]),
+      }),
+    });
+
+    const req = makeReq();
+    const res = makeRes();
+
+    await getApprovedInterviewExperiences(req, res);
+
+    expect(InterviewExperience.find).toHaveBeenCalledWith({ status: "approved" });
+    expect(res.json.mock.calls[0][0].experiences[0].status).toBe("approved");
+  });
+});
+
+describe("updateInterviewExperienceStatus", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("approves a pending submission", async () => {
+    InterviewExperience.findByIdAndUpdate = vi.fn().mockResolvedValue({
+      ...sampleDoc,
+      status: "approved",
+    });
+
+    const req = makeReq(
+      { status: "approved" },
+      { id: "507f1f77bcf86cd799439011" },
+    );
+    const res = makeRes();
+
+    await updateInterviewExperienceStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].experience.status).toBe("approved");
+  });
+
+  it("rejects an unknown id", async () => {
+    InterviewExperience.findByIdAndUpdate = vi.fn().mockResolvedValue(null);
+
+    const req = makeReq({ status: "rejected" }, { id: "missing" });
+    const res = makeRes();
+
+    await updateInterviewExperienceStatus(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -103,6 +103,29 @@ describe("createInterviewExperience", () => {
     );
   });
 
+  it("rejects anonymous creates without a clientKey", async () => {
+    InterviewExperience.create = vi.fn();
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Summary",
+      idempotencyKey: "submit-key-abc12345",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: false,
+        message: "clientKey is required for anonymous submissions",
+      }),
+    );
+  });
+
   it("returns 500 when persistence fails so the client can retry", async () => {
     InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
     InterviewExperience.create = vi.fn().mockRejectedValue(new Error("db down"));
@@ -111,6 +134,7 @@ describe("createInterviewExperience", () => {
       company: "Google",
       role: "SDE-2",
       summary: "Summary",
+      clientKey: "client-key-123456",
       idempotencyKey: "submit-key-abc12345",
     });
     const res = makeRes();

--- a/backend/tests/requireModerator.unit.test.js
+++ b/backend/tests/requireModerator.unit.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { requireModerator } from "../middlewares/authMiddleware.js";
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("requireModerator", () => {
+  const previous = process.env.MODERATOR_EMAILS;
+
+  beforeEach(() => {
+    process.env.MODERATOR_EMAILS = "mods@preppilot.dev, other@example.com";
+  });
+
+  afterEach(() => {
+    if (previous === undefined) {
+      delete process.env.MODERATOR_EMAILS;
+    } else {
+      process.env.MODERATOR_EMAILS = previous;
+    }
+  });
+
+  it("allows listed moderator emails", () => {
+    const req = { user: { email: "Mods@PrepPilot.dev" } };
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireModerator(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("rejects authenticated non-moderators with 403", () => {
+    const req = { user: { email: "user@example.com" } };
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireModerator(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("rejects when MODERATOR_EMAILS is unset", () => {
+    delete process.env.MODERATOR_EMAILS;
+    const req = { user: { email: "mods@preppilot.dev" } };
+    const res = makeRes();
+    const next = vi.fn();
+
+    requireModerator(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});

--- a/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
+++ b/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
@@ -26,18 +26,33 @@ import { API_PATHS } from "../../utils/apiPaths";
 
 const CLIENT_KEY_STORAGE = "preppilot_interview_experience_client_key";
 
+const createSecureClientKey = () => {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+
+  if (globalThis.crypto?.getRandomValues) {
+    const bytes = new Uint8Array(16);
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+      "",
+    );
+  }
+
+  return null;
+};
+
 const getOrCreateClientKey = () => {
   try {
     const existing = localStorage.getItem(CLIENT_KEY_STORAGE);
     if (existing) return existing;
-    const created =
-      typeof crypto !== "undefined" && crypto.randomUUID
-        ? crypto.randomUUID()
-        : `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const created = createSecureClientKey();
+    if (!created) return null;
     localStorage.setItem(CLIENT_KEY_STORAGE, created);
     return created;
   } catch {
-    return `anon-${Date.now()}`;
+    // Storage may be unavailable; still return a crypto key for this session only.
+    return createSecureClientKey();
   }
 };
 
@@ -524,6 +539,14 @@ const SubmitModal = ({ onClose, onAdd, clientKey }) => {
     setSubmitting(true);
     setSubmitError("");
 
+    if (!clientKey) {
+      setSubmitError(
+        "Unable to create a secure client key in this browser. Sign in or try another browser.",
+      );
+      setSubmitting(false);
+      return;
+    }
+
     const payload = {
       company: form.company.trim(),
       role: form.role.trim(),
@@ -822,6 +845,11 @@ const InterviewExperiences = () => {
   const loadMyExperiences = useCallback(async () => {
     setLoadingMine(true);
     setLoadError("");
+    if (!clientKey) {
+      setUserExperiences([]);
+      setLoadingMine(false);
+      return;
+    }
     try {
       const { data } = await axiosInstance.get(
         API_PATHS.INTERVIEW_EXPERIENCES.MINE,

--- a/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
+++ b/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
@@ -26,6 +26,13 @@ import { API_PATHS } from "../../utils/apiPaths";
 
 const CLIENT_KEY_STORAGE = "preppilot_interview_experience_client_key";
 
+const isSecureClientKey = (value) =>
+  typeof value === "string" &&
+  (/^[0-9a-f]{32}$/i.test(value) ||
+    /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      value,
+    ));
+
 const createSecureClientKey = () => {
   if (globalThis.crypto?.randomUUID) {
     return globalThis.crypto.randomUUID();
@@ -45,7 +52,8 @@ const createSecureClientKey = () => {
 const getOrCreateClientKey = () => {
   try {
     const existing = localStorage.getItem(CLIENT_KEY_STORAGE);
-    if (existing) return existing;
+    if (isSecureClientKey(existing)) return existing;
+    localStorage.removeItem(CLIENT_KEY_STORAGE);
     const created = createSecureClientKey();
     if (!created) return null;
     localStorage.setItem(CLIENT_KEY_STORAGE, created);
@@ -539,14 +547,6 @@ const SubmitModal = ({ onClose, onAdd, clientKey }) => {
     setSubmitting(true);
     setSubmitError("");
 
-    if (!clientKey) {
-      setSubmitError(
-        "Unable to create a secure client key in this browser. Sign in or try another browser.",
-      );
-      setSubmitting(false);
-      return;
-    }
-
     const payload = {
       company: form.company.trim(),
       role: form.role.trim(),
@@ -567,7 +567,7 @@ const SubmitModal = ({ onClose, onAdd, clientKey }) => {
         : [],
       tags: [form.difficulty, form.role.trim().split(" ")[0]].filter(Boolean),
       color: `hsl(${(form.company.trim().charCodeAt(0) * 37) % 360}, 55%, 50%)`,
-      clientKey,
+      ...(clientKey ? { clientKey } : {}),
       idempotencyKey: idempotencyKeyRef.current,
     };
 

--- a/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
+++ b/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useRef, useEffect } from "react";
+import React, { useState, useMemo, useRef, useEffect, useCallback } from "react";
 import {
   MessageSquare,
   Building2,
@@ -19,7 +19,27 @@ import {
   Briefcase,
   Brain,
   Send,
+  AlertCircle,
 } from "lucide-react";
+import axiosInstance from "../../utils/axiosinstance";
+import { API_PATHS } from "../../utils/apiPaths";
+
+const CLIENT_KEY_STORAGE = "preppilot_interview_experience_client_key";
+
+const getOrCreateClientKey = () => {
+  try {
+    const existing = localStorage.getItem(CLIENT_KEY_STORAGE);
+    if (existing) return existing;
+    const created =
+      typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : `anon-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    localStorage.setItem(CLIENT_KEY_STORAGE, created);
+    return created;
+  } catch {
+    return `anon-${Date.now()}`;
+  }
+};
 
 // ──────────────────────────────────────────────
 // Static Sample Data
@@ -304,6 +324,22 @@ const DifficultyBadge = ({ difficulty }) => {
   );
 };
 
+const STATUS_CONFIG = {
+  pending:  { label: "Pending review", color: "text-amber-400", bg: "bg-amber-500/10 border-amber-500/20" },
+  approved: { label: "Approved",       color: "text-emerald-400", bg: "bg-emerald-500/10 border-emerald-500/20" },
+  rejected: { label: "Rejected",       color: "text-red-400", bg: "bg-red-500/10 border-red-500/20" },
+};
+
+const StatusBadge = ({ status }) => {
+  if (!status) return null;
+  const cfg = STATUS_CONFIG[status] || STATUS_CONFIG.pending;
+  return (
+    <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full border ${cfg.color} ${cfg.bg}`}>
+      {cfg.label}
+    </span>
+  );
+};
+
 const ExperienceCard = ({ exp, onClick }) => (
   <div
     onClick={() => onClick(exp)}
@@ -319,6 +355,7 @@ const ExperienceCard = ({ exp, onClick }) => (
         <div className="flex items-center gap-2 flex-wrap">
           <h3 className="text-sm font-bold text-gray-900 dark:text-white truncate">{exp.company}</h3>
           <DifficultyBadge difficulty={exp.difficulty} />
+          <StatusBadge status={exp.status} />
         </div>
         <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 truncate">{exp.role}</p>
       </div>
@@ -332,7 +369,7 @@ const ExperienceCard = ({ exp, onClick }) => (
       </span>
       <span className="flex items-center gap-1">
         <Layers size={11} />
-        {exp.rounds.length} Rounds
+        {(exp.rounds || []).length} Rounds
       </span>
       <span className={`flex items-center gap-1 ${exp.offerReceived ? "text-emerald-500" : "text-red-400"}`}>
         <Trophy size={11} />
@@ -347,7 +384,7 @@ const ExperienceCard = ({ exp, onClick }) => (
 
     {/* Tags */}
     <div className="flex flex-wrap gap-1.5">
-      {exp.tags.slice(0, 3).map((tag) => (
+      {(exp.tags || []).slice(0, 3).map((tag) => (
         <span key={tag} className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-violet-500/10 border border-violet-500/20 text-violet-400 dark:text-violet-300">
           {tag}
         </span>
@@ -464,47 +501,64 @@ const DetailModal = ({ exp, onClose }) => {
 // ──────────────────────────────────────────────
 // Submit Experience Modal
 // ──────────────────────────────────────────────
-const SubmitModal = ({ onClose, onAdd }) => {
+const SubmitModal = ({ onClose, onAdd, clientKey }) => {
   const [form, setForm] = useState({
     company: "", role: "", experience: "", difficulty: "Medium",
     offerReceived: "Yes", rounds: "", summary: "", tips: "",
   });
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState("");
 
   const handleChange = (e) => setForm((p) => ({ ...p, [e.target.name]: e.target.value }));
 
-  const handleSubmit = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
     setSubmitting(true);
-    // Simulate brief submission delay for UX feedback
-    setTimeout(() => {
-      const newExp = {
-        id: Date.now(),
-        company: form.company.trim(),
-        role: form.role.trim(),
-        experience: form.experience || "N/A",
-        difficulty: form.difficulty,
-        offerReceived: form.offerReceived === "Yes",
-        date: new Date().toLocaleDateString("en-GB", { month: "short", year: "numeric" }),
-        rounds: form.rounds
-          ? form.rounds.split("\n").filter(Boolean).map((r, i) => ({
-              name: `Round ${i + 1}`,
-              type: "Coding",
-              description: r,
-            }))
-          : [],
-        summary: form.summary.trim(),
-        tips: form.tips
-          ? form.tips.split("\n").filter(Boolean)
-          : [],
-        tags: [form.difficulty, form.role.split(" ")[0]].filter(Boolean),
-        color: `hsl(${(form.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`,
-      };
-      onAdd(newExp);
-      setSubmitting(false);
+    setSubmitError("");
+
+    const payload = {
+      company: form.company.trim(),
+      role: form.role.trim(),
+      experience: form.experience.trim() || "N/A",
+      difficulty: form.difficulty,
+      offerReceived: form.offerReceived === "Yes",
+      date: new Date().toLocaleDateString("en-GB", { month: "short", year: "numeric" }),
+      rounds: form.rounds
+        ? form.rounds.split("\n").filter(Boolean).map((r, i) => ({
+            name: `Round ${i + 1}`,
+            type: "Coding",
+            description: r,
+          }))
+        : [],
+      summary: form.summary.trim(),
+      tips: form.tips
+        ? form.tips.split("\n").filter(Boolean)
+        : [],
+      tags: [form.difficulty, form.role.trim().split(" ")[0]].filter(Boolean),
+      color: `hsl(${(form.company.trim().charCodeAt(0) * 37) % 360}, 55%, 50%)`,
+      clientKey,
+    };
+
+    try {
+      const { data } = await axiosInstance.post(
+        API_PATHS.INTERVIEW_EXPERIENCES.CREATE,
+        payload,
+      );
+      if (!data?.success || !data?.experience) {
+        throw new Error(data?.message || "Submission failed");
+      }
+      onAdd(data.experience);
       setSubmitted(true);
-    }, 600);
+    } catch (err) {
+      setSubmitError(
+        err?.response?.data?.message ||
+          err?.message ||
+          "Could not save your experience. Please try again.",
+      );
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   const inputCls =
@@ -538,7 +592,7 @@ const SubmitModal = ({ onClose, onAdd }) => {
               </div>
               <h3 className="text-lg font-extrabold text-gray-900 dark:text-white">Thank you!</h3>
               <p className="text-sm text-gray-500 dark:text-gray-400 max-w-xs">
-                Your interview experience has been submitted for review. It'll appear on the board once approved.
+                Your interview experience has been saved and submitted for review. It'll appear on the board once approved.
               </p>
               <button
                 onClick={onClose}
@@ -549,6 +603,15 @@ const SubmitModal = ({ onClose, onAdd }) => {
             </div>
           ) : (
             <form onSubmit={handleSubmit} className="space-y-4">
+              {submitError && (
+                <div className="flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2.5 text-sm text-red-400">
+                  <AlertCircle size={16} className="mt-0.5 shrink-0" />
+                  <div className="flex-1">
+                    <p>{submitError}</p>
+                    <p className="text-xs text-red-300/80 mt-1">Fix any issues and submit again to retry.</p>
+                  </div>
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-4">
                 <div>
                   <label className="block text-[11px] font-bold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-1.5">Company *</label>
@@ -744,9 +807,36 @@ const InterviewExperiences = () => {
   const [search, setSearch]           = useState("");
   const [activeTab, setActiveTab]     = useState("Common"); // "Common" | "User"
   const [userExperiences, setUserExperiences] = useState([]);
+  const [loadError, setLoadError] = useState("");
+  const [loadingMine, setLoadingMine] = useState(true);
+  const clientKey = useMemo(() => getOrCreateClientKey(), []);
+
+  const loadMyExperiences = useCallback(async () => {
+    setLoadingMine(true);
+    setLoadError("");
+    try {
+      const { data } = await axiosInstance.get(
+        API_PATHS.INTERVIEW_EXPERIENCES.MINE,
+        { params: { clientKey } },
+      );
+      setUserExperiences(data?.experiences || []);
+    } catch (err) {
+      setLoadError(
+        err?.response?.data?.message ||
+          "Could not load your submissions. Refresh to retry.",
+      );
+    } finally {
+      setLoadingMine(false);
+    }
+  }, [clientKey]);
+
+  useEffect(() => {
+    loadMyExperiences();
+  }, [loadMyExperiences]);
 
   const handleAddExperience = (exp) => {
-    setUserExperiences((prev) => [exp, ...prev]);
+    setUserExperiences((prev) => [exp, ...prev.filter((item) => item.id !== exp.id)]);
+    setActiveTab("User");
   };
 
   // Source array based on active tab
@@ -761,7 +851,7 @@ const InterviewExperiences = () => {
         !q ||
         e.company.toLowerCase().includes(q) ||
         e.role.toLowerCase().includes(q) ||
-        e.tags.some((t) => t.toLowerCase().includes(q));
+        (e.tags || []).some((t) => t.toLowerCase().includes(q));
       return matchDiff && matchCompany && matchSearch;
     });
   }, [sourceData, diffFilter, companyFilter, search]);
@@ -909,7 +999,22 @@ const InterviewExperiences = () => {
         </div>
 
         {/* ── Cards Grid ── */}
-        {activeTab === "User" && userExperiences.length === 0 ? (
+        {activeTab === "User" && loadError ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center border border-dashed border-red-500/20 rounded-2xl bg-red-500/5">
+            <AlertCircle size={24} className="text-red-400 mb-3" />
+            <p className="text-sm text-red-400 mb-4">{loadError}</p>
+            <button
+              onClick={loadMyExperiences}
+              className="px-5 py-2.5 rounded-xl bg-violet-600 hover:bg-violet-700 text-white text-sm font-bold transition-all"
+            >
+              Retry
+            </button>
+          </div>
+        ) : activeTab === "User" && loadingMine ? (
+          <div className="flex flex-col items-center justify-center py-24 text-center">
+            <p className="text-sm text-gray-500 dark:text-gray-400">Loading your submissions...</p>
+          </div>
+        ) : activeTab === "User" && userExperiences.length === 0 ? (
           // Empty state specifically for User tab with no submissions yet
           <div className="flex flex-col items-center justify-center py-24 text-center border border-dashed border-violet-500/20 rounded-2xl bg-violet-500/5 dark:bg-violet-900/5">
             <div className="w-14 h-14 rounded-2xl bg-violet-500/10 border border-violet-500/20 flex items-center justify-center mb-4">
@@ -953,7 +1058,13 @@ const InterviewExperiences = () => {
 
       {/* ── Modals ── */}
       {selectedExp && <DetailModal exp={selectedExp} onClose={() => setSelectedExp(null)} />}
-      {showSubmit  && <SubmitModal onClose={() => setShowSubmit(false)} onAdd={handleAddExperience} />}
+      {showSubmit  && (
+        <SubmitModal
+          onClose={() => setShowSubmit(false)}
+          onAdd={handleAddExperience}
+          clientKey={clientKey}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
+++ b/frontend/src/pages/InterviewExperiences/InterviewExperiences.jsx
@@ -501,6 +501,11 @@ const DetailModal = ({ exp, onClose }) => {
 // ──────────────────────────────────────────────
 // Submit Experience Modal
 // ──────────────────────────────────────────────
+const createIdempotencyKey = () =>
+  typeof crypto !== "undefined" && crypto.randomUUID
+    ? crypto.randomUUID()
+    : `submit-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
 const SubmitModal = ({ onClose, onAdd, clientKey }) => {
   const [form, setForm] = useState({
     company: "", role: "", experience: "", difficulty: "Medium",
@@ -509,6 +514,8 @@ const SubmitModal = ({ onClose, onAdd, clientKey }) => {
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState("");
+  // Stable for the life of this modal so retries do not create duplicates.
+  const idempotencyKeyRef = useRef(createIdempotencyKey());
 
   const handleChange = (e) => setForm((p) => ({ ...p, [e.target.name]: e.target.value }));
 
@@ -538,6 +545,7 @@ const SubmitModal = ({ onClose, onAdd, clientKey }) => {
       tags: [form.difficulty, form.role.trim().split(" ")[0]].filter(Boolean),
       color: `hsl(${(form.company.trim().charCodeAt(0) * 37) % 360}, 55%, 50%)`,
       clientKey,
+      idempotencyKey: idempotencyKeyRef.current,
     };
 
     try {
@@ -797,7 +805,6 @@ const CompanyDropdown = ({ value, onChange, options }) => {
 // Main Page
 // ──────────────────────────────────────────────
 const FILTERS = ["All", "Easy", "Medium", "Hard"];
-const COMPANIES = ["All Companies", ...Array.from(new Set(EXPERIENCES.map((e) => e.company))).sort((a, b) => a - b)];
 
 const InterviewExperiences = () => {
   const [selectedExp, setSelectedExp] = useState(null);
@@ -807,6 +814,7 @@ const InterviewExperiences = () => {
   const [search, setSearch]           = useState("");
   const [activeTab, setActiveTab]     = useState("Common"); // "Common" | "User"
   const [userExperiences, setUserExperiences] = useState([]);
+  const [approvedExperiences, setApprovedExperiences] = useState([]);
   const [loadError, setLoadError] = useState("");
   const [loadingMine, setLoadingMine] = useState(true);
   const clientKey = useMemo(() => getOrCreateClientKey(), []);
@@ -830,17 +838,52 @@ const InterviewExperiences = () => {
     }
   }, [clientKey]);
 
+  const loadApprovedExperiences = useCallback(async () => {
+    try {
+      const { data } = await axiosInstance.get(
+        API_PATHS.INTERVIEW_EXPERIENCES.APPROVED,
+      );
+      setApprovedExperiences(data?.experiences || []);
+    } catch {
+      // Keep static samples if the approved feed is unreachable.
+      setApprovedExperiences([]);
+    }
+  }, []);
+
   useEffect(() => {
     loadMyExperiences();
   }, [loadMyExperiences]);
+
+  useEffect(() => {
+    loadApprovedExperiences();
+  }, [loadApprovedExperiences]);
 
   const handleAddExperience = (exp) => {
     setUserExperiences((prev) => [exp, ...prev.filter((item) => item.id !== exp.id)]);
     setActiveTab("User");
   };
 
+  // Approved API results first; static samples fill gaps until moderation has content.
+  const commonExperiences = useMemo(() => {
+    const approvedIds = new Set(approvedExperiences.map((e) => String(e.id)));
+    return [
+      ...approvedExperiences,
+      ...EXPERIENCES.filter((e) => !approvedIds.has(String(e.id))),
+    ];
+  }, [approvedExperiences]);
+
+  const companies = useMemo(
+    () => [
+      "All Companies",
+      ...Array.from(new Set(commonExperiences.map((e) => e.company))).sort((a, b) =>
+        a.localeCompare(b),
+      ),
+    ],
+    [commonExperiences],
+  );
+
   // Source array based on active tab
-  const sourceData = activeTab === "Common" ? EXPERIENCES : userExperiences;
+  const sourceData = activeTab === "Common" ? commonExperiences : userExperiences;
 
   const filtered = useMemo(() => {
     return sourceData.filter((e) => {
@@ -857,10 +900,10 @@ const InterviewExperiences = () => {
   }, [sourceData, diffFilter, companyFilter, search]);
 
   const stats = useMemo(() => ({
-    total: EXPERIENCES.length,
-    withOffer: EXPERIENCES.filter((e) => e.offerReceived).length,
-    companies: new Set(EXPERIENCES.map((e) => e.company)).size,
-  }), []);
+    total: commonExperiences.length,
+    withOffer: commonExperiences.filter((e) => e.offerReceived).length,
+    companies: new Set(commonExperiences.map((e) => e.company)).size,
+  }), [commonExperiences]);
 
   return (
     <div className="min-h-screen bg-[var(--color-background)] dark:bg-gradient-to-b dark:from-[#0f172a] dark:to-[#0b1120] px-5 py-10 md:px-10 transition-colors duration-300">
@@ -947,7 +990,7 @@ const InterviewExperiences = () => {
           <CompanyDropdown
             value={companyFilter}
             onChange={setCompanyFilter}
-            options={COMPANIES}
+            options={companies}
           />
         </div>
 
@@ -956,7 +999,7 @@ const InterviewExperiences = () => {
           {/* Tab toggle pill */}
           <div className="flex items-center gap-1 p-1 bg-white dark:bg-[#151c2f] border border-gray-200 dark:border-white/5 rounded-xl">
             {["Common", "User"].map((tab) => {
-              const count = tab === "Common" ? EXPERIENCES.length : userExperiences.length;
+              const count = tab === "Common" ? commonExperiences.length : userExperiences.length;
               const isActive = activeTab === tab;
               return (
                 <button

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -78,4 +78,10 @@ export const API_PATHS = {
         TOGGLE_TASK: (id) => `/api/roadmaps/${id}/tasks`,
         DELETE: (id) => `/api/roadmaps/${id}`,
     },
+    INTERVIEW_EXPERIENCES: {
+        CREATE: "/api/interview-experiences",
+        APPROVED: "/api/interview-experiences/approved",
+        MINE: "/api/interview-experiences/mine",
+        UPDATE_STATUS: (id) => `/api/interview-experiences/${id}/status`,
+    },
 };


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #935

### Summary
Interview experience submit only wrote to React state, so a refresh dropped the card even though the UI said it was up for review. Added `/api/interview-experiences` (create, mine, approved, status update), wired the form to POST with an idempotency key, and show pending/approved/rejected on cards.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- `vitest run tests/interviewExperienceController.unit.test.js` (pass)
- `vitest run tests/requireModerator.unit.test.js` (pass)

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have linked the related issue

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Looks good to me. Ready to merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->