### PR TITLE
fix: /api/models now queries Gemini REST API (removes genAI.listModels())

### DIFF
--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -1,6 +1,5 @@
 const express = require("express");
 const router = express.Router();
-const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { generateChatWithFallback } = require('../utils/geminiHelper');
 const { aiLimiter } = require('../middlewares/rateLimiter');
 const { validateAiPrompt } = require('../middlewares/validateAiPrompt');
@@ -259,9 +258,26 @@ router.post('/solve', aiLimiter, sanitizeAiPrompt, validateProblemSolve, solveHa
  */
 router.get("/models", async (req, res) => {
   try {
-    const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
-    const models = await genAI.listModels();
-    const modelNames = models.map((m) => m.name.replace("models/", ""));
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return res.status(500).json({ error: "GEMINI_API_KEY not configured on server" });
+    }
+
+    // The @google/generative-ai client exposes no listModels() method, so
+    // query the Gemini REST API directly to return real, key-scoped models.
+    const response = await fetch(
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${encodeURIComponent(apiKey)}`,
+      { signal: AbortSignal.timeout(10000) }
+    );
+
+    if (!response.ok) {
+      console.error("List models error:", response.status, await response.text());
+      return res.status(502).json({ error: "Failed to list models" });
+    }
+
+    const data = await response.json();
+    const modelNames = (data.models || []).map((m) => m.name.replace("models/", ""));
+
     res.json({
       availableModels: modelNames,
       configured: process.env.GEMINI_MODEL || null,


### PR DESCRIPTION
## Problem

`GET /api/models` always returns `500`. The route builds a `GoogleGenerativeAI` instance and calls `genAI.listModels()`, but that method does not exist on the `@google/generative-ai` client. Every request falls into the catch block and returns `{ error: "Failed to list models" }`.

## Fix

Replace the unsupported SDK call with the Gemini `v1beta` REST `models` endpoint (`https://generativelanguage.googleapis.com/v1beta/models`). The handler:

- returns `500` if `GEMINI_API_KEY` is not configured,
- queries the REST API with a 10s timeout,
- normalizes model names (strips the `models/` prefix),
- returns `502` when the upstream call fails and `500` only on unexpected errors,
- keeps the existing `availableModels` / `configured` / `note` response shape.

This also removes the now-unused `GoogleGenerativeAI` import.

## Files changed

- `backend/routes/aiRoutes.js`

## Testing

- Syntax/load check: `node -e "require('./routes/aiRoutes')"` passes.
- Existing vitest suite (`npx vitest run`): 5 test files, 59 tests, all pass.

Closes #1624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `GET /api/models` by replacing the unsupported `genAI.listModels()` call with the Gemini `v1beta` REST API.
- Added API key validation and a 10-second request timeout.
- Normalized model names and preserved the existing response shape.
- Added `502` responses for upstream failures.
- Removed the unused `GoogleGenerativeAI` import.
- Confirmed syntax validation and all 59 Vitest tests pass.

## Review status

Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->