### PR TITLE
fix: persist company from Create Session form

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -351,6 +351,7 @@ Request Body:
 ```json
 {
   "role": "Backend Engineer",
+  "company": "Google",
   "experience": "3 years",
   "topicsToFocus": ["Node.js", "Databases"],
   "description": "Prepare for backend interview",
@@ -364,6 +365,7 @@ Response `201`:
   "session": {
     "_id": "6426c5a5...",
     "role": "Backend Engineer",
+    "company": "Google",
     "experience": "3 years",
     "description": "Prepare for backend interview",
     "questions": ["..."]
@@ -371,7 +373,7 @@ Response `201`:
 }
 ```
 Errors:
-- `403` session limit reached (default max: 50)
+- `400` missing required fields (role, company, experience, topicsToFocus) or session limit reached (default max: 50)
 - `500` server error
 
 ---

--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -11,6 +11,7 @@ const objectId = (label) =>
 // Schema for creating a session
 const createSessionSchema = z.object({
   role: z.string().min(1, "Role is required"),
+  company: z.string().min(1, "Company is required"),
   experience: z.string().min(1, "Experience is required"),
   topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
   description: z.string().optional(),

--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -19,6 +19,7 @@ const MAX_EXPERIENCE = 50;
  * Authorization: Bearer eyJhb...
  * {
  *   "role": "Backend Engineer",
+ *   "company": "Google",
  *   "experience": "3 years",
  *   "topicsToFocus": ["Node.js","Databases"],
  *   "description": "Prepare for backend interview",
@@ -34,7 +35,7 @@ exports.createSession = async (req, res) => {
     try {
         await mongoSession.withTransaction(async () => {
             const userId = req.user._id;
-            const { role, experience, topicsToFocus, description } = req.body;
+            const { role, company, experience, topicsToFocus, description } = req.body;
             const experienceNumber = Number(experience);
  
             if (!role || role.trim() === "") {
@@ -70,6 +71,7 @@ exports.createSession = async (req, res) => {
                     {
                         user: userId,
                         role,
+                        company,
                         experience,
                         topicsToFocus,
                         description,

--- a/backend/models/Session.js
+++ b/backend/models/Session.js
@@ -3,6 +3,7 @@ const Question = require("./Question");
 const sessionSchema = new mongoose.Schema({
     user: { type: mongoose.Schema.Types.ObjectId, ref: "User", index: true },
     role: { type: String, required: true },
+    company: { type: String, required: true },
     experience: { type: String, required: true },
     topicsToFocus: { type: [String], required: true },
     description: String,


### PR DESCRIPTION
## Problem

The Create Session form collects a required `company` value and sends it in the `POST /api/sessions/create` body, but the backend silently drops it: the zod `createSessionSchema` has no `company` field (so `parse()` strips it), the `Session` model has no `company` field, and the controller never reads it. The company is lost even though the frontend treats it as a required field.

## Fix

- `backend/Input_validators/ValidateSession.js`: add required `company` to `createSessionSchema` so it is validated and preserved.
- `backend/models/Session.js`: add required `company` field to the session schema.
- `backend/controllers/sessionController.js`: destructure `company` from the validated body and store it on the created session.
- `API_DOCUMENTATION.md`: document `company` in the create-session request/response examples.

## Files changed

- `backend/Input_validators/ValidateSession.js`
- `backend/models/Session.js`
- `backend/controllers/sessionController.js`
- `API_DOCUMENTATION.md`

## Testing

- Load/syntax check of the validator, model, and controller passes.
- Vitest suite (`npx vitest run`): 9 test files, 95 tests, all pass. (One pre-existing empty file, `tests/achievementController.unit.test.js`, fails to load on `origin/main` itself and is untouched here.)

Closes #1625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->