### PR TITLE
fix: relax role sanitization instead of strict allow-list

### DIFF
--- a/backend/utils/prompts.js
+++ b/backend/utils/prompts.js
@@ -1,37 +1,23 @@
-const ALLOWED_ROLES = new Set([
-  'frontend developer',
-  'backend developer',
-  'full stack developer',
-  'react developer',
-  'node.js developer',
-  'python developer',
-  'java developer',
-  'devops engineer',
-  'cloud engineer',
-  'data scientist',
-  'machine learning engineer',
-  'systems engineer',
-  'software engineer',
-  'qa engineer',
-  'database administrator',
-  'web developer',
-  'mobile developer',
-  'ios developer',
-  'android developer',
-  'product manager',
-  'tech lead',
-  'solution architect',
-  'security engineer'
-]);
+const MAX_ROLE_LENGTH = 100;
 
 const sanitizeRole = (role) => {
   if (!role || typeof role !== 'string') {
     throw new Error('Role must be a non-empty string');
   }
-  const trimmedRole = role.trim().toLowerCase();
-  if (!ALLOWED_ROLES.has(trimmedRole)) {
-    throw new Error(`Invalid role. Allowed roles: ${Array.from(ALLOWED_ROLES).join(', ')}`);
+  const trimmedRole = role
+    .trim()
+    .toLowerCase()
+    .replace(/[\u0000-\u001f\u007f]/g, '')
+    .replace(/\s+/g, ' ');
+
+  if (trimmedRole.length === 0) {
+    throw new Error('Role must be a non-empty string');
   }
+
+  if (trimmedRole.length > MAX_ROLE_LENGTH) {
+    throw new Error(`Role must be at most ${MAX_ROLE_LENGTH} characters`);
+  }
+
   return trimmedRole;
 };
 
@@ -111,4 +97,4 @@ Important: Do NOT add any extra text outside the JSON format. Only return valid 
 `;
 };
 
-module.exports = { questionAnswerPrompt, conceptExplainPrompt, interviewTipsPrompt, sanitizeRole, ALLOWED_ROLES };
+module.exports = { questionAnswerPrompt, conceptExplainPrompt, interviewTipsPrompt, sanitizeRole };


### PR DESCRIPTION
## Problem

`sanitizeRole` in `backend/utils/prompts.js` rejects any role not in a hard-coded 23-entry `ALLOWED_ROLES` set, even though the Create Session form is a free-text input whose placeholder suggests roles like "UI/UX Designer" and "Frontend Developer". Users following the placeholder get `400 { message: "Invalid role. Allowed roles: ..." }`.

## Fix

Relax `sanitizeRole` to a length/sanitization check instead of an exact allow-list match (the third option suggested in the issue):

- trims, lowercases, strips control characters, and collapses whitespace runs,
- rejects empty roles and roles longer than 100 characters,
- accepts any other role, including the placeholder examples ("UI/UX Designer", "Data Analyst", "Engineering Manager", etc.).

The now-unused `ALLOWED_ROLES` set and its export are removed.

## Files changed

- `backend/utils/prompts.js`

## Testing

- Manual check of `sanitizeRole`:
  - `"UI/UX Designer"` → `"ui/ux designer"` (accepted)
  - `"Data Analyst"` → `"data analyst"` (accepted)
  - `"  Frontend   Developer "` → `"frontend developer"` (accepted)
  - 101-char role → throws `Role must be at most 100 characters`
  - empty role → throws `Role must be a non-empty string`
- Vitest suite (`npx vitest run`): 9 test files, 95 tests, all pass.

Closes #1626


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->