### PR TITLE
fix: correct SM-2 quality mapping for medium/good and numeric ratings

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -6,11 +6,14 @@ const Flashcard = require("../models/Flashcard");
  * Returns updated { interval, repetition, efactor, dueDate }
  */
 const calculateSM2 = ({ interval = 0, repetition = 0, efactor = 2.5 }, rating) => {
+  // Map ratings to the standard SM-2 quality scale (0-5):
+  //   again/1 -> 1, hard/2 -> 2, medium/3 -> 3, good/4 -> 4, easy/5 -> 5
   let score = 3;
   if (rating === "again" || rating === "1") score = 1;
   else if (rating === "hard" || rating === "2") score = 2;
-  else if (rating === "medium" || rating === "good" || rating === "3") score = 4;
-  else if (rating === "easy" || rating === "4") score = 5;
+  else if (rating === "medium" || rating === "3") score = 3;
+  else if (rating === "good" || rating === "4") score = 4;
+  else if (rating === "easy" || rating === "5") score = 5;
 
   let newRepetition = repetition;
   let newInterval = interval;
@@ -27,13 +30,16 @@ const calculateSM2 = ({ interval = 0, repetition = 0, efactor = 2.5 }, rating) =
       newInterval = repetition <= 1 ? 1 : Math.max(1, Math.round(interval * 1.2));
     }
   } else {
-    // Successful recall (Medium / Easy)
+    // Successful recall (Medium / Good / Easy). Scale interval growth with the
+    // score so "medium" (3) schedules shorter than "good" (4), which is shorter
+    // than "easy" (5).
     if (repetition === 0) {
-      newInterval = score === 5 ? 2 : 1;
+      newInterval = score >= 4 ? 2 : 1;
     } else if (repetition === 1) {
-      newInterval = score === 5 ? 7 : 6;
+      newInterval = score >= 4 ? 6 : 3;
     } else {
-      const multiplier = score === 5 ? newEFactor * 1.3 : newEFactor;
+      const multiplier =
+        score === 5 ? newEFactor * 1.3 : score === 4 ? newEFactor : newEFactor * 0.8;
       newInterval = Math.max(1, Math.round(interval * multiplier));
     }
     newRepetition += 1;

--- a/backend/tests/flashcardController.sm2.unit.test.js
+++ b/backend/tests/flashcardController.sm2.unit.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+
+const { calculateSM2 } = require('../controllers/flashcardController');
+
+describe('calculateSM2 rating mapping (issue #1627)', () => {
+  it('maps again/1 -> quality 1 and resets repetition', () => {
+    const result = calculateSM2({ interval: 30, repetition: 5, efactor: 2.5 }, 'again');
+    expect(result.repetition).toBe(0);
+    expect(result.interval).toBe(1);
+  });
+
+  it('maps hard/2 -> quality 2 (failure branch, repetition not incremented)', () => {
+    const result = calculateSM2({ interval: 30, repetition: 5, efactor: 2.5 }, 'hard');
+    expect(result.repetition).toBe(5);
+    expect(result.repetition).not.toBe(6);
+  });
+
+  it('maps medium/3 -> quality 3 (success branch)', () => {
+    const result = calculateSM2({ interval: 0, repetition: 0, efactor: 2.5 }, 'medium');
+    expect(result.repetition).toBe(1);
+    expect(result.interval).toBe(1);
+  });
+
+  it('maps good/4 -> quality 4 (success branch)', () => {
+    const result = calculateSM2({ interval: 0, repetition: 0, efactor: 2.5 }, 'good');
+    expect(result.repetition).toBe(1);
+    expect(result.interval).toBe(2);
+  });
+
+  it('maps easy/5 -> quality 5 (success branch)', () => {
+    const result = calculateSM2({ interval: 0, repetition: 0, efactor: 2.5 }, 'easy');
+    expect(result.repetition).toBe(1);
+    expect(result.interval).toBe(2);
+  });
+
+  it('maps numeric ratings onto the same scale as words', () => {
+    const byNumber3 = calculateSM2({ interval: 0, repetition: 0, efactor: 2.5 }, '3');
+    const byNumber4 = calculateSM2({ interval: 0, repetition: 0, efactor: 2.5 }, '4');
+    expect(byNumber3.repetition).toBe(1);
+    expect(byNumber4.repetition).toBe(1);
+    expect(byNumber3.interval).toBe(1); // medium
+    expect(byNumber4.interval).toBe(2); // good
+  });
+
+  it('does not treat medium and good identically at repetition 1', () => {
+    const medium = calculateSM2({ interval: 1, repetition: 1, efactor: 2.5 }, 'medium');
+    const good = calculateSM2({ interval: 1, repetition: 1, efactor: 2.5 }, 'good');
+    expect(medium.interval).toBe(3);
+    expect(good.interval).toBe(6);
+    expect(medium.interval).toBeLessThan(good.interval);
+  });
+
+  it('schedules medium shorter than good at higher repetitions', () => {
+    const medium = calculateSM2({ interval: 10, repetition: 2, efactor: 2.5 }, 'medium');
+    const good = calculateSM2({ interval: 10, repetition: 2, efactor: 2.5 }, 'good');
+    expect(medium.interval).toBeLessThan(good.interval);
+  });
+
+  it('keeps the pass/fail boundary at score >= 3', () => {
+    const fail = calculateSM2({ interval: 10, repetition: 2, efactor: 2.5 }, 'hard');
+    const pass = calculateSM2({ interval: 10, repetition: 2, efactor: 2.5 }, 'medium');
+    expect(fail.repetition).toBe(2); // not incremented
+    expect(pass.repetition).toBe(3); // incremented
+  });
+});


### PR DESCRIPTION
## Problem

The SM-2 quality mapping in `backend/controllers/flashcardController.js` treated `"medium"` and `"good"` identically (both -> quality 4) and shifted the numeric ratings off-by-one (`"3"` -> 4, `"4"` -> 5). Quality 3 was never produced, so medium-grade reviews were scheduled with the same intervals as good ones and the harder numeric grades were treated more leniently than intended.

## Fix

Map ratings to the standard SM-2 0-5 quality scale, exactly as suggested in the issue:

```
again/1 -> 1, hard/2 -> 2, medium/3 -> 3, good/4 -> 4, easy/5 -> 5
```

The interval logic now also scales with the quality score so the pass/fail boundary (`score >= 3`) is honored and `"medium"` (3) schedules shorter intervals than `"good"` (4), which schedules shorter than `"easy"` (5):

- repetition 0: medium -> 1 day, good/easy -> 2 days
- repetition 1: medium -> 3 days, good/easy -> 6 days
- repetition >= 2: multiplier is `EF * 1.3` (easy), `EF` (good), or `EF * 0.8` (medium)

Added a unit test (`backend/tests/flashcardController.sm2.unit.test.js`) covering every rating (words and numbers), the medium-vs-good distinction, and the pass/fail boundary.

## Files changed

- `backend/controllers/flashcardController.js`
- `backend/tests/flashcardController.sm2.unit.test.js`

## Testing

- `npx vitest run`: 9 test files + new SM-2 suite, 104 tests, all pass. (One pre-existing empty file, `tests/achievementController.unit.test.js`, fails to load on `origin/main` itself and is untouched here.)

Closes #1627
