### PR TITLE
fix: flashcard review messages match accepted rating values

### DIFF
--- a/backend/Input_validators/ValidateFlashcard.js
+++ b/backend/Input_validators/ValidateFlashcard.js
@@ -9,11 +9,10 @@ const createFlashcardSchema = z.object({
 });
 
 const reviewFlashcardSchema = z.object({
-  rating: z.enum(["again", "hard", "medium", "good", "easy", "1", "2", "3", "4"], {
-    errorMap: () => ({
-      message: "Rating must be one of: again, hard, medium (or good), easy, or numbers 1-4",
-    }),
-  }),
+  rating: z.enum(
+    ["again", "hard", "medium", "good", "easy", "1", "2", "3", "4"],
+    { error: "Rating must be one of: again, hard, medium, good, easy, or numbers 1-4" }
+  ),
 });
 
 const validateCreateFlashcard = (req, res, next) => {

--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -172,7 +172,7 @@ const reviewFlashcard = async (req, res) => {
     if (!rating) {
       return res.status(400).json({
         success: false,
-        message: "Rating is required. Supported values: 'again', 'hard', 'good', 'easy'.",
+        message: "Rating is required. Supported values: 'again', 'hard', 'medium', 'good', 'easy', or numbers 1-4.",
       });
     }
 


### PR DESCRIPTION
## Problem

The flashcard review error messages advertised fewer accepted ratings than the validator actually accepts:

- `backend/controllers/flashcardController.js` said `"Rating is required. Supported values: 'again', 'hard', 'good', 'easy'."` — omitting `"medium"` and the numeric aliases `"1"`–`"4"` that the validator and SM-2 mapper support.
- `backend/Input_validators/ValidateFlashcard.js` used zod v3-style `errorMap`, which zod v4 (installed: `4.4.3`) ignores, so the confusing `"medium (or good)"` message never even reached clients — zod's generic fallback was shown.

## Fix

- `backend/controllers/flashcardController.js`: list the exact accepted values in the missing-rating message — `'again', 'hard', 'medium', 'good', 'easy', or numbers 1-4`.
- `backend/Input_validators/ValidateFlashcard.js`: replace the dead `errorMap` with zod v4's `error` param so the intended message is actually returned, phrased to match the enum exactly: `"Rating must be one of: again, hard, medium, good, easy, or numbers 1-4"`.

## Files changed

- `backend/controllers/flashcardController.js`
- `backend/Input_validators/ValidateFlashcard.js`

## Testing

- Manual verification via `validateReviewFlashcard`:
  - `rating: 'great'` → `400` with `errors[0].message = "Rating must be one of: again, hard, medium, good, easy, or numbers 1-4"`
  - `rating: 'medium'` and `rating: '4'` → accepted
- Vitest suite (`npx vitest run`): 95 tests, all pass.

Closes #1629
