### PR TITLE
fix: require authentication for Gemini generate/solve routes

### DIFF
--- a/backend/routes/aiRoutes.js
+++ b/backend/routes/aiRoutes.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const { GoogleGenerativeAI } = require("@google/generative-ai");
 const { generateChatWithFallback } = require('../utils/geminiHelper');
 const { aiLimiter } = require('../middlewares/rateLimiter');
+const { protect } = require('../middlewares/authMiddleware');
 const { validateAiPrompt } = require('../middlewares/validateAiPrompt');
 const sanitizeAiPrompt = require('../middlewares/sanitizeAiPrompt');
 const { sanitizePromptText } = sanitizeAiPrompt;
@@ -237,12 +238,12 @@ async function generateHandler(req, res) {
 }
 
 // Primary route used by frontend
-router.post('/generate', aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
+router.post('/generate', aiLimiter, protect, validateAiPrompt, sanitizeAiPrompt, generateHandler);
 // Alias under /ai for consistency if needed later (/api/ai/generate)
-router.post('/ai/generate', aiLimiter, validateAiPrompt, sanitizeAiPrompt, generateHandler);
+router.post('/ai/generate', aiLimiter, protect, validateAiPrompt, sanitizeAiPrompt, generateHandler);
 
 // Structured problem-solving route
-router.post('/solve', aiLimiter, sanitizeAiPrompt, validateProblemSolve, solveHandler);
+router.post('/solve', aiLimiter, protect, sanitizeAiPrompt, validateProblemSolve, solveHandler);
 
 // List available models
 /**

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -183,9 +183,11 @@ const App = () => {
                   <Route
                     path="/ai-helper"
                     element={
-                      <PageTransition>
-                        <AIHelper />
-                      </PageTransition>
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <AIHelper />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   <Route
@@ -249,17 +251,21 @@ const App = () => {
                   <Route
                     path="/ai-insight"
                     element={
-                      <PageTransition>
-                        <AIHelper />
-                      </PageTransition>
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <AIHelper />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   <Route
                     path="/ai-assistance"
                     element={
-                      <PageTransition>
-                        <AIHelper />
-                      </PageTransition>
+                      <ProtectedRoute>
+                        <PageTransition>
+                          <AIHelper />
+                        </PageTransition>
+                      </ProtectedRoute>
                     }
                   />
                   <Route

--- a/frontend/src/components/AIHepler.jsx
+++ b/frontend/src/components/AIHepler.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useContext } from "react";
 import { UserContext } from "../context/userContext";
 import { Bot, User as UserIcon, Send, Sparkles, Trash2 } from "lucide-react";
-import { BASE_URL } from "../utils/apiPaths";
+import { BASE_URL, getAuthHeaders } from "../utils/apiPaths";
 import AIResponsePreview from "../pages/InterviewPrep/components/AIResponsePreview";
 
 export default function AIHelper() {
@@ -28,7 +28,7 @@ export default function AIHelper() {
       `${BASE_URL}/api/generate`,
       {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ prompt, history }),
       }
     );

--- a/frontend/src/pages/ProblemSolver/ProblemSolver.jsx
+++ b/frontend/src/pages/ProblemSolver/ProblemSolver.jsx
@@ -13,7 +13,7 @@ import {
   Gauge,
   Terminal,
 } from "lucide-react";
-import { BASE_URL } from "../../utils/apiPaths";
+import { BASE_URL, getAuthHeaders } from "../../utils/apiPaths";
 
 const LANGUAGES = [
   { value: "python", label: "Python" },
@@ -140,7 +140,7 @@ export default function ProblemSolver() {
     try {
       const res = await fetch(`${BASE_URL}/api/solve`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ problem, language, constraints }),
       });
 

--- a/frontend/src/pages/ProjectIdeas/ProjectIdeas.jsx
+++ b/frontend/src/pages/ProjectIdeas/ProjectIdeas.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { BASE_URL } from "../../utils/apiPaths";
+import { BASE_URL, getAuthHeaders } from "../../utils/apiPaths";
 import {
   Lightbulb,
   Layers,
@@ -350,7 +350,7 @@ const ProjectIdeas = () => {
 
       const res = await fetch(`${BASE_URL}/api/generate`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ 
           prompt,
           systemInstruction: "You are an API that ONLY returns valid JSON arrays. Do not include any conversational text, greetings, or formatting outside the JSON array."

--- a/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
+++ b/frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 import { Map, Sparkles, Save, RefreshCw, X, LogIn } from "lucide-react";
-import { BASE_URL, API_PATHS } from "../../utils/apiPaths";
+import { BASE_URL, API_PATHS, getAuthHeaders } from "../../utils/apiPaths";
 import axiosInstance from "../../utils/axiosinstance";
 import { UserContext } from "../../context/userContext";
 
@@ -75,7 +75,7 @@ const ProjectRoadmap = () => {
       const prompt = buildRoadmapPrompt(finalIdea, finalAnswers);
       const res = await fetch(`${BASE_URL}/api/generate`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ prompt, systemInstruction: ROADMAP_SYSTEM_INSTRUCTION }),
       });
       if (!res.ok) throw new Error(`Server error ${res.status}`);
@@ -225,7 +225,7 @@ const ProjectRoadmap = () => {
       );
       const res = await fetch(`${BASE_URL}/api/generate`, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...getAuthHeaders() },
         body: JSON.stringify({ prompt, systemInstruction: ROADMAP_SYSTEM_INSTRUCTION }),
       });
       if (!res.ok) throw new Error(`Server error ${res.status}`);

--- a/frontend/src/utils/apiPaths.js
+++ b/frontend/src/utils/apiPaths.js
@@ -2,6 +2,14 @@
 export const BASE_URL =
     import.meta.env.VITE_BACKEND_URL?.trim() || "http://localhost:8000";
 
+// Build auth headers for raw fetch() calls (axiosInstance attaches the same
+// token automatically). Returns an empty object when no token is present.
+export const getAuthHeaders = () => {
+    const token =
+        localStorage.getItem("token") || sessionStorage.getItem("token");
+    return token ? { Authorization: `Bearer ${token}` } : {};
+};
+
 export const API_PATHS = {
     AUTH: {
     REGISTER: "/api/auth/register",


### PR DESCRIPTION
## Problem

Three Gemini-backed endpoints were public — `POST /api/generate`, `POST /api/ai/generate`, and `POST /api/solve` had only an IP-based `aiLimiter`, no authentication. Any anonymous caller could spend the app's Gemini quota (up to `MAX_COMBINED_CHARS = 16000` per request) and rotate IPs to evade the limiter.

## Fix

Follow the issue's primary suggested fix — require a valid access token on all three routes:

- `backend/routes/aiRoutes.js`: add the existing `protect` middleware to `/generate`, `/ai/generate`, and `/solve` (imported from `backend/middlewares/authMiddleware.js`).
- `frontend/src/utils/apiPaths.js`: add a shared `getAuthHeaders()` helper that attaches `Authorization: Bearer <token>` (same token source as `axiosinstance.js`).
- Update all five raw `fetch` callers to send the token: `AIHepler.jsx`, `ProjectRoadmap.jsx` (2 calls), `ProblemSolver.jsx`, `ProjectIdeas.jsx`.
- `frontend/src/App.jsx`: wrap the `/ai-helper`, `/ai-insight`, and `/ai-assistance` routes in the existing `ProtectedRoute` so unauthenticated visitors are redirected to login instead of hitting a 401 on the AI chat.

## Files changed

- `backend/routes/aiRoutes.js`
- `frontend/src/utils/apiPaths.js`
- `frontend/src/components/AIHepler.jsx`
- `frontend/src/pages/ProjectRoadmap/ProjectRoadmap.jsx`
- `frontend/src/pages/ProblemSolver/ProblemSolver.jsx`
- `frontend/src/pages/ProjectIdeas/ProjectIdeas.jsx`
- `frontend/src/App.jsx`

## Testing

- Backend: `node -e "require('./routes/aiRoutes')"` passes; vitest suite 95 tests pass.
- Frontend: `eslint` clean on all modified files except three pre-existing `no-unused-vars` warnings in `AIHepler.jsx` (untouched code — unused `user` and `err` catch params).

Closes #1630


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Require authentication for the Gemini-backed `/api/generate`, `/api/ai/generate`, and `/api/solve` routes.
- Add shared bearer-token headers for frontend API requests.
- Protect the related AI frontend routes with `ProtectedRoute`.
- Backend module loading and the Vitest suite pass.
- ESLint is clean for modified files, except for three pre-existing `no-unused-vars` warnings in `AIHepler.jsx`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->