### PR TITLE
fix: validate profileImageUrl as http(s) URL on register and profile update

### DIFF
--- a/backend/Input_validators/ValidateAuth.js
+++ b/backend/Input_validators/ValidateAuth.js
@@ -3,6 +3,30 @@ const { handleValidationError } = require("./ValidateQuestions");
 
 // ── Schemas ───────────────────────────────────────────────
 
+// Profile image URLs must point at a remote http(s) resource. z.string().url()
+// alone accepts any scheme (e.g. "javascript:..."), so restrict to http/https
+// to avoid stored XSS, tracking pixels, or data: payloads. Empty string and
+// null are allowed so callers can leave the field unset or clear the image.
+const profileImageUrlSchema = z.union([
+  z.literal(""),
+  z.null(),
+  z
+    .string()
+    .trim()
+    .max(2048, "Profile image URL must be at most 2048 characters")
+    .refine(
+      (value) => {
+        try {
+          const parsed = new URL(value);
+          return parsed.protocol === "http:" || parsed.protocol === "https:";
+        } catch {
+          return false;
+        }
+      },
+      "Profile image URL must be a valid http(s) URL"
+    ),
+]);
+
 const registerUserZod = z.object({
   name: z.string().min(4, "Name must be at least 4 characters").trim(),
   email: z.string().email("Enter a valid email").trim(),
@@ -13,8 +37,16 @@ const registerUserZod = z.object({
     .regex(/[a-z]/, "Password must contain at least one lowercase letter")
     .regex(/[0-9]/, "Password must contain at least one number")
     .regex(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~]/, "Password must contain at least one special character"),
-  profileImageUrl: z.string().url("Enter a valid URL").trim().optional().or(z.literal("")),
+  profileImageUrl: profileImageUrlSchema.optional(),
 });
+
+// PUT /api/auth/profile accepts many fields; validate only the fields we know
+// how to constrain and preserve the rest via passthrough().
+const updateProfileZod = z
+  .object({
+    profileImageUrl: profileImageUrlSchema.optional(),
+  })
+  .passthrough();
 
 const loginUserZod = z.object({
   email: z.string().email("Enter a valid email"),
@@ -29,7 +61,16 @@ const resendVerificationZod = z.object({
 
 const validateUserSignup = (req, res, next) => {
   try {
-    registerUserZod.parse(req.body);
+    req.body = registerUserZod.parse(req.body);
+    next();
+  } catch (err) {
+    return handleValidationError(res, err);
+  }
+};
+
+const validateUpdateProfile = (req, res, next) => {
+  try {
+    req.body = updateProfileZod.parse(req.body);
     next();
   } catch (err) {
     return handleValidationError(res, err);
@@ -67,4 +108,5 @@ module.exports = {
   validateUserSignup,
   validateRefreshToken,
   validateResendEmail,
+  validateUpdateProfile,
 };

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -2,7 +2,7 @@ const express = require("express");
 const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserProfile, updateUserProfile, changePassword, deleteUserAccount, refreshToken, logoutUser } = require("../controllers/authController");
 const { protect } = require("../middlewares/authMiddleware");
 const { upload, validateImageUpload } = require("../middlewares/uploadMiddleware");
-const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
+const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail, validateUpdateProfile } = require("../Input_validators/ValidateAuth");
 const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
 const router = express.Router();
 
@@ -31,7 +31,7 @@ router.get("/csrf-token", generalLimiter, (req, res) => {
 router.post("/refresh", authLimiter, csrfHeaderCheck, validateRefreshToken, refreshToken);
 router.post("/logout", authLimiter, csrfHeaderCheck, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
-router.put("/profile", protect, generalLimiter, updateUserProfile);
+router.put("/profile", protect, generalLimiter, validateUpdateProfile, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);
 router.delete("/delete-account", protect, sensitiveAuthLimiter, deleteUserAccount);
 router.post("/resend-verification", authLimiter,  validateResendEmail, resendVerificationEmail);

--- a/backend/tests/validateAuth.profileImageUrl.unit.test.js
+++ b/backend/tests/validateAuth.profileImageUrl.unit.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, beforeAll } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Issue #1631: profileImageUrl must be validated on write. z.string().url()
+// alone accepts non-http schemes (e.g. "javascript:..."), and PUT /api/auth/
+// profile previously had no validator at all. Both the register and profile
+// update paths must now accept only http(s) URLs (plus "" / null).
+// ---------------------------------------------------------------------------
+
+let authValidators;
+
+beforeAll(async () => {
+  const mod = await import("../Input_validators/ValidateAuth.js");
+  authValidators = mod;
+});
+
+function run(mw, req) {
+  let passed = false;
+  let statusCode = null;
+  let body = null;
+  const res = {
+    status: (code) => {
+      statusCode = code;
+      return res;
+    },
+    json: (payload) => {
+      body = payload;
+      return res;
+    },
+  };
+  mw(req, res, () => {
+    passed = true;
+  });
+  return { passed, statusCode, body };
+}
+
+const VALID_SIGNUP = {
+  name: "Test User",
+  email: "test@example.com",
+  password: "Password123!",
+};
+
+describe("register (validateUserSignup) profileImageUrl validation", () => {
+  it("accepts a valid https URL and writes the trimmed value to req.body", () => {
+    const req = { body: { ...VALID_SIGNUP, profileImageUrl: "  https://cdn.example.com/img.png  " } };
+    const result = run(authValidators.validateUserSignup, req);
+    expect(result.passed).toBe(true);
+    expect(result.statusCode).toBe(null);
+    expect(req.body.profileImageUrl).toBe("https://cdn.example.com/img.png");
+  });
+
+  it("accepts a valid http URL", () => {
+    const req = { body: { ...VALID_SIGNUP, profileImageUrl: "http://x.com/a.png" } };
+    expect(run(authValidators.validateUserSignup, req).passed).toBe(true);
+  });
+
+  it("accepts an empty string and a missing field", () => {
+    expect(run(authValidators.validateUserSignup, { body: { ...VALID_SIGNUP, profileImageUrl: "" } }).passed).toBe(true);
+    expect(run(authValidators.validateUserSignup, { body: { ...VALID_SIGNUP } }).passed).toBe(true);
+  });
+
+  it.each([
+    ["javascript:alert(1)", "javascript scheme"],
+    ["data:text/html,<script>alert(1)</script>", "data scheme"],
+    ["ftp://x.com/img.png", "ftp scheme"],
+    ["not a url", "plain string"],
+  ])("rejects %s (%s) with 400", (value) => {
+    const req = { body: { ...VALID_SIGNUP, profileImageUrl: value } };
+    const result = run(authValidators.validateUserSignup, req);
+    expect(result.passed).toBe(false);
+    expect(result.statusCode).toBe(400);
+    expect(result.body.success).toBe(false);
+    expect(result.body.errors.some((e) => e.field === "profileImageUrl")).toBe(true);
+  });
+
+  it("rejects a URL longer than 2048 characters", () => {
+    const req = { body: { ...VALID_SIGNUP, profileImageUrl: `https://x.com/${"a".repeat(2050)}` } };
+    const result = run(authValidators.validateUserSignup, req);
+    expect(result.passed).toBe(false);
+    expect(result.statusCode).toBe(400);
+  });
+});
+
+describe("update profile (validateUpdateProfile) profileImageUrl validation", () => {
+  it("accepts a valid https URL and preserves unrelated fields via passthrough", () => {
+    const req = { body: { profileImageUrl: "https://cdn.example.com/me.png", firstName: "Ada", bio: "hi" } };
+    const result = run(authValidators.validateUpdateProfile, req);
+    expect(result.passed).toBe(true);
+    expect(req.body.firstName).toBe("Ada");
+    expect(req.body.bio).toBe("hi");
+  });
+
+  it("accepts empty string and null so the image can be cleared", () => {
+    expect(run(authValidators.validateUpdateProfile, { body: { profileImageUrl: "" } }).passed).toBe(true);
+    expect(run(authValidators.validateUpdateProfile, { body: { profileImageUrl: null } }).passed).toBe(true);
+  });
+
+  it.each(["javascript:alert(1)", "data:image/png;base64,AAAA", "ftp://x.com/a.png", "not a url"])(
+    "rejects %s with 400",
+    (value) => {
+      const req = { body: { profileImageUrl: value } };
+      const result = run(authValidators.validateUpdateProfile, req);
+      expect(result.passed).toBe(false);
+      expect(result.statusCode).toBe(400);
+      expect(result.body.errors.some((e) => e.field === "profileImageUrl")).toBe(true);
+    }
+  );
+
+  it("rejects a URL longer than 2048 characters", () => {
+    const req = { body: { profileImageUrl: `http://x.com/${"b".repeat(2050)}` } };
+    const result = run(authValidators.validateUpdateProfile, req);
+    expect(result.passed).toBe(false);
+    expect(result.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
## Problem

`profileImageUrl` is persisted without proper URL validation:

- `POST /api/auth/register` (authController.js:125) — zod's `z.string().url()` runs, but it accepts **any** URL scheme, including `javascript:`, `data:`, and `ftp:` payloads, so stored-XSS / tracking-pixel / `data:` injection values pass through. The parsed (trimmed) body was also never written back to `req.body`.
- `PUT /api/auth/profile` (authController.js:455) — had **no validator at all** (`protect, generalLimiter, updateUserProfile`), so arbitrary strings were stored directly on the user document.

## Fix

Restrict profile image URLs to remote `http:`/`https:` resources on both write paths.

- `backend/Input_validators/ValidateAuth.js`
  - New shared `profileImageUrlSchema` (`z.union` of `""`, `null`, and a trimmed string ≤ 2048 chars that must parse via `new URL()` with protocol `http:` or `https:`).
  - `registerUserZod.profileImageUrl` now uses this schema, and `validateUserSignup` assigns the parsed body back (`req.body = registerUserZod.parse(req.body)`) so the trimmed/validated value is what gets stored.
  - New `updateProfileZod` (`.passthrough()` so unrelated profile fields like `firstName`, `bio`, etc. are preserved) plus `validateUpdateProfile` middleware.
- `backend/routes/authRoutes.js`
  - `PUT /api/auth/profile` now runs `validateUpdateProfile` before the controller.

`javascript:alert(1)`, `data:...`, `ftp://...`, plain strings, and URLs > 2048 chars are rejected with `400`; empty string and `null` are allowed so callers can leave the field unset or clear the image.

## Files changed

- `backend/Input_validators/ValidateAuth.js`
- `backend/routes/authRoutes.js`
- `backend/tests/validateAuth.profileImageUrl.unit.test.js` (new, 15 tests)

## Testing

- New unit test file `backend/tests/validateAuth.profileImageUrl.unit.test.js` covering valid http(s) URLs, trimming, `""`/`null`/missing, passthrough of unrelated profile fields, and rejection of `javascript:`, `data:`, `ftp:`, plain strings, and > 2048-char URLs — for both register and profile-update validators.
- Full backend suite: `npx vitest run --root backend --exclude "tests/achievementController.unit.test.js"` → 110 passed (95 existing + 15 new). The excluded file is a pre-existing empty file on main that fails vitest suite discovery.

Closes #1631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared `profileImageUrl` validation for registration and profile updates.
- Allowed trimmed `http:` and `https:` URLs up to 2048 characters, plus `""` and `null`.
- Added profile update validation middleware.
- Preserved unrelated profile fields during updates.
- Added 15 unit tests for valid and invalid inputs.
- Backend tests pass: 110 tests, excluding one pre-existing empty test file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->