### PR TITLE
fix(server): block startup until MongoDB connects; exit on failure (#1303)

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -71,18 +71,46 @@ app.use((req, res, next) => {
   next();
 });
 
-connectDB()
-  .then((success) => {
-    if (success) {
+// ── Graceful startup: block app.listen() until MongoDB is reachable ────────
+// Previously connectDB() was fire-and-forget and the server started
+// regardless, leaving every endpoint to fail with cryptic errors when the
+// DB was down. Now we await the connection and exit(1) in production if it
+// fails, while still allowing a dev server to start for route debugging.
+async function startServer() {
+  let dbConnected = false;
+  try {
+    dbConnected = await connectDB();
+    if (dbConnected) {
       console.log("MongoDB connected successfully");
     } else {
+      if (process.env.NODE_ENV === "production") {
+        console.error(
+          "FATAL: Cannot connect to MongoDB — database is required in production. Exiting.",
+        );
+        process.exit(1);
+      }
       console.warn(
-        "⚠️ Failed to connect to MongoDB - server will run without database connection",
+        "⚠️ Failed to connect to MongoDB - server will run without database connection (dev mode only)",
       );
     }
-  })
-  .catch((err) => {
+  } catch (err) {
+    if (process.env.NODE_ENV === "production") {
+      console.error("FATAL: Database connection error:", err.message);
+      process.exit(1);
+    }
     console.error("Database connection error:", err.message);
+  }
+
+  // Lightweight health probe so load balancers / orchestrators can tell a
+  // degraded instance from a healthy one.
+  app.get("/api/health", (req, res) => {
+    const mongoose = require("mongoose");
+    const ready = dbConnected && mongoose.connection.readyState === 1;
+    res.status(ready ? 200 : 503).json({
+      status: ready ? "ok" : "degraded",
+      database: ready ? "connected" : "disconnected",
+      timestamp: new Date().toISOString(),
+    });
   });
 
 // middleware
@@ -223,16 +251,19 @@ if (process.env.ADZUNA_APP_ID && process.env.ADZUNA_API_KEY) {
 // Start Server
 const PORT = process.env.PORT || 5000;
 const server = app.listen(PORT, "0.0.0.0", () => {
-  console.log(`Server connected and running on port ${PORT}`);
-  if (process.env.NODE_ENV === "production") {
-    console.log("Allowed CORS origins (production):");
-  } else {
-    console.log("Allowed CORS origins (development):");
-  }
-  for (const o of allowedOrigins) {
-    console.log("  -", o);
-  }
+    console.log(`Server connected and running on port ${PORT}`);
+    if (process.env.NODE_ENV === "production") {
+        console.log("Allowed CORS origins (production):");
+    } else {
+        console.log("Allowed CORS origins (development):");
+    }
+    for (const o of allowedOrigins) {
+        console.log("  -", o);
+    }
 });
+}
+
+startServer();
 
 server.on("error", (err) => {
   if (err.code === "EADDRINUSE") {


### PR DESCRIPTION
Previously `connectDB()` was fire-and-forget and `app.listen()` started independently, so the server ran with every endpoint failing cryptically when the DB was down — a **HIGH**-severity reliability bug.

Wrapped startup in `startServer()` which:
- awaits `connectDB()` before calling `app.listen()`
- `process.exit(1)` in production when the DB cannot be reached
- still allows a dev server to start for route debugging
- adds a `/api/health` probe reporting DB connection state (200 ok / 503 degraded) so load balancers can detect degraded instances

Closes #1303

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._