### PR TITLE
fix(auth): prevent email enumeration on resend-verification (#1414)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -318,27 +318,30 @@ const resendVerificationEmail = async (req, res) => {
             return res.status(400).json({ success: false, message: "Email is required." });
         }
 
+        // Generic response returned for every non-error path so the endpoint
+        // cannot be used to enumerate which emails are registered or already
+        // verified. The email is only actually sent when a matching unverified
+        // user exists.
+        const GENERIC_RESPONSE = {
+            success: true,
+            message: "If this email is registered and unverified, a verification link has been sent.",
+        };
+
         const user = await User.findOne({ email });
 
-        // Return success even if user not found — avoids exposing which emails are registered
-        if (!user) {
-            return res.json({ success: true, message: "If this email is registered, a verification link has been sent." });
+        if (user && !user.isEmailVerified) {
+            // Generate a fresh token and reset expiry to 24 hours from now
+            user.emailVerificationToken = crypto.randomBytes(32).toString("hex");
+            user.emailVerificationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000);
+            await user.save();
+
+            const verificationUrl = `${process.env.FRONTEND_URL}/verify-email?token=${user.emailVerificationToken}`;
+            await sendVerificationEmail(user.email, verificationUrl);
         }
 
-        // If already verified, no need to resend
-        if (user.isEmailVerified) {
-            return res.status(400).json({ success: false, message: "This email is already verified. Please log in." });
-        }
-
-        // Generate a fresh token and reset expiry to 24 hours from now
-        user.emailVerificationToken = crypto.randomBytes(32).toString("hex");
-        user.emailVerificationExpires = new Date(Date.now() + 24 * 60 * 60 * 1000);
-        await user.save();
-
-        const verificationUrl = `${process.env.FRONTEND_URL}/verify-email?token=${user.emailVerificationToken}`;
-        await sendVerificationEmail(user.email, verificationUrl);
-
-        res.json({ success: true, message: "Verification email resent. Please check your inbox." });
+        // Identical response whether the user doesn't exist, is already
+        // verified, or was genuinely sent a new link.
+        return res.json(GENERIC_RESPONSE);
     } catch (error) {
         console.error("Resend verification error:", error);
         res.status(500).json({ success: false, message: "Internal server error occurred" });


### PR DESCRIPTION
The `/api/auth/resend-verification` endpoint returned different responses depending on account state:
- **400** "This email is already verified" when the user existed but was verified (leaked that the email is registered AND verified)
- a distinct success message when the email was genuinely sent
- a generic message only when the user was not found

This let an attacker enumerate registered emails by comparing status codes and message text.

Now every non-error path returns the identical generic success response (`"If this email is registered and unverified, a verification link has been sent."`). The email is only actually sent when a matching unverified user exists, but the response reveals nothing about the account state.

Closes #1414

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._