### PR TITLE
fix: enforce MAX_SESSIONS atomically to close check-then-insert race

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -13,6 +13,7 @@ const Resume = require("../models/Resume");
 const NotesSummary = require("../models/NotesSummary");
 const RoadmapProject = require("../models/RoadmapProject");
 const UserSheetProgress = require("../models/UserSheetProgress");
+const SessionCount = require("../models/SessionCount");
 
 const ACCESS_TOKEN_EXPIRY = "15m";
 const REFRESH_TOKEN_EXPIRY = "30d";
@@ -614,6 +615,11 @@ const deleteUserAccount = async (req, res) => {
         // Delete user's sheet progress
         deletePromises.push(
             UserSheetProgress.deleteMany({ userId: userId })
+        );
+
+        // Delete user's session-count counter
+        deletePromises.push(
+            SessionCount.deleteOne({ _id: userId })
         );
 
         // Wait for all deletions to complete

--- a/backend/controllers/sessionController.js
+++ b/backend/controllers/sessionController.js
@@ -1,5 +1,6 @@
 const Session = require("../models/Session");
 const Question = require("../models/Question");
+const SessionCount = require("../models/SessionCount");
 const mongoose = require("mongoose");
 const User = require("../models/User");
 
@@ -57,12 +58,39 @@ exports.createSession = async (req, res) => {
                    message: `Years of experience must be between 0 and ${MAX_EXPERIENCE}.`,
              });
             }
-            const sessionCount = await Session.countDocuments({
-                user: userId,
-            }).session(mongoSession);
+            // Atomic per-user limit check. The conditional increment on the
+            // shared SessionCount document is the serialization point: under
+            // concurrent createSession requests, the loser hits a write
+            // conflict, the transaction retries, and the re-run sees the
+            // counter at the limit and aborts — unlike a plain countDocuments
+            // pre-check, which both requests would pass on the same snapshot.
+            const countDoc = await SessionCount.findOneAndUpdate(
+                { _id: userId, count: { $lt: MAX_SESSIONS } },
+                { $inc: { count: 1 } },
+                { new: true, session: mongoSession }
+            );
 
-            if (sessionCount >= MAX_SESSIONS) {
-                throw new Error("SESSION_LIMIT_REACHED");
+            if (!countDoc) {
+                // No counter yet (pre-existing account) or the limit is hit.
+                // For the missing-counter case, seed it from the user's real
+                // session count so legacy accounts are enforced correctly.
+                const actualCount = await Session.countDocuments({
+                    user: userId,
+                }).session(mongoSession);
+
+                if (actualCount >= MAX_SESSIONS) {
+                    throw new Error("SESSION_LIMIT_REACHED");
+                }
+
+                const seeded = await SessionCount.findOneAndUpdate(
+                    { _id: userId },
+                    { $setOnInsert: { count: actualCount }, $inc: { count: 1 } },
+                    { upsert: true, new: true, session: mongoSession }
+                );
+
+                if (seeded.count > MAX_SESSIONS) {
+                    throw new Error("SESSION_LIMIT_REACHED");
+                }
             }
 
             const createdSession = await Session.create(
@@ -263,6 +291,12 @@ exports.deleteSession = async (req, res) => {
 
             await Session.deleteOne(
                 { _id: session._id },
+                { session: transaction }
+            );
+
+            await SessionCount.updateOne(
+                { _id: userId },
+                { $inc: { count: -1 } },
                 { session: transaction }
             );
         });

--- a/backend/models/SessionCount.js
+++ b/backend/models/SessionCount.js
@@ -1,0 +1,14 @@
+const mongoose = require("mongoose");
+
+// Per-user counter backing the MAX_SESSIONS cap. The _id is the owning
+// user's _id, so the limit check in createSession can run as a single atomic
+// conditional increment (findOneAndUpdate) instead of a racy count-then-insert.
+const sessionCountSchema = new mongoose.Schema(
+  {
+    _id: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    count: { type: Number, default: 0, min: 0 },
+  },
+  { timestamps: true }
+);
+
+module.exports = mongoose.model("SessionCount", sessionCountSchema);

--- a/backend/tests/sessionController.limit.unit.test.js
+++ b/backend/tests/sessionController.limit.unit.test.js
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import Module from 'module';
+
+// ---------------------------------------------------------------------------
+// CJS controller mocks via Module._load shim (vi.mock cannot intercept the
+// require() calls inside the CJS controller).
+// ---------------------------------------------------------------------------
+
+const modelMocks = {};
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+  if (request in modelMocks) return modelMocks[request];
+  return originalLoad.apply(this, arguments);
+};
+
+const mockStartSession = vi.fn();
+const mockSessionCount = vi.fn();
+const mockSessionCreate = vi.fn();
+const mockQuestionInsertMany = vi.fn();
+const mockSessionCountFindOneAndUpdate = vi.fn();
+const mockSessionFindOne = vi.fn();
+const mockQuestionDeleteMany = vi.fn();
+const mockSessionDeleteOne = vi.fn();
+const mockSessionCountUpdateOne = vi.fn();
+const mockUserFindById = vi.fn();
+
+function makeFakeMongoSession() {
+  return {
+    withTransaction: async (fn) => fn(),
+    endSession: vi.fn().mockResolvedValue(),
+  };
+}
+
+modelMocks['mongoose'] = {
+  startSession: (...args) => mockStartSession(...args),
+};
+
+modelMocks['../models/Session'] = {
+  countDocuments: (...args) => mockSessionCount(...args),
+  create: (...args) => mockSessionCreate(...args),
+  findOne: (...args) => mockSessionFindOne(...args),
+  deleteOne: (...args) => mockSessionDeleteOne(...args),
+};
+
+modelMocks['../models/Question'] = {
+  insertMany: (...args) => mockQuestionInsertMany(...args),
+  deleteMany: (...args) => mockQuestionDeleteMany(...args),
+};
+
+modelMocks['../models/SessionCount'] = {
+  findOneAndUpdate: (...args) => mockSessionCountFindOneAndUpdate(...args),
+  updateOne: (...args) => mockSessionCountUpdateOne(...args),
+};
+
+modelMocks['../models/User'] = {
+  findById: (...args) => mockUserFindById(...args),
+};
+
+const { createSession, deleteSession } = require('../controllers/sessionController');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeReq(body = {}, userId = 'user-123') {
+  return { body, user: { _id: userId } };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+const VALID_BODY = {
+  role: 'Backend Engineer',
+  experience: '3',
+  topicsToFocus: ['Node.js', 'Databases'],
+  description: 'Prep',
+  question: [{ question: 'Q', answer: 'A' }],
+};
+
+function countReturning(value) {
+  return { session: vi.fn().mockResolvedValue(value) };
+}
+
+function makeCreatedSession() {
+  const session = { _id: 'session-1', questions: [] };
+  session.save = vi.fn().mockResolvedValue(session);
+  return session;
+}
+
+function makeFakeUser() {
+  return {
+    currentStreak: 1,
+    longestStreak: 0,
+    unlockedAchievements: [],
+    save: vi.fn().mockResolvedValue(),
+  };
+}
+
+// The controller also updates the streak via User.findById(...).session().
+function mockUserQuery() {
+  mockUserFindById.mockReturnValue({
+    session: vi.fn().mockResolvedValue(makeFakeUser()),
+  });
+}
+
+beforeEach(() => {
+  mockStartSession.mockReset();
+  mockSessionCount.mockReset();
+  mockSessionCreate.mockReset();
+  mockQuestionInsertMany.mockReset();
+  mockSessionCountFindOneAndUpdate.mockReset();
+  mockSessionFindOne.mockReset();
+  mockQuestionDeleteMany.mockReset();
+  mockSessionDeleteOne.mockReset();
+  mockSessionCountUpdateOne.mockReset();
+  mockUserFindById.mockReset();
+
+  mockStartSession.mockResolvedValue(makeFakeMongoSession());
+});
+
+describe('createSession — atomic session-limit guard (issue #1633)', () => {
+  it('creates a session when the counter is below the limit', async () => {
+    mockSessionCountFindOneAndUpdate.mockResolvedValue({ count: 50 }); // 49 -> 50
+    const created = makeCreatedSession();
+    mockSessionCreate.mockResolvedValue([created]);
+    mockQuestionInsertMany.mockResolvedValue([{ _id: 'q1' }, { _id: 'q2' }]);
+    mockUserQuery();
+
+    const res = makeRes();
+    await createSession(makeReq(VALID_BODY), res);
+
+    expect(mockSessionCountFindOneAndUpdate).toHaveBeenCalledWith(
+      { _id: 'user-123', count: { $lt: 50 } },
+      { $inc: { count: 1 } },
+      expect.objectContaining({ new: true }),
+    );
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('rejects with the limit message when the counter is already at the limit', async () => {
+    mockSessionCountFindOneAndUpdate.mockResolvedValue(null); // counter at 50
+    mockSessionCount.mockReturnValue(countReturning(50)); // real count at limit
+
+    const res = makeRes();
+    await createSession(makeReq(VALID_BODY), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      success: false,
+      message: 'Maximum of 50 sessions reached.',
+    });
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('seeds the counter from the real count for legacy accounts below the limit', async () => {
+    mockSessionCountFindOneAndUpdate
+      .mockResolvedValueOnce(null) // no counter yet
+      .mockResolvedValueOnce({ count: 4 }); // seeded 3 -> 4
+    mockSessionCount.mockReturnValue(countReturning(3));
+
+    const created = makeCreatedSession();
+    mockSessionCreate.mockResolvedValue([created]);
+    mockQuestionInsertMany.mockResolvedValue([]);
+    mockUserQuery();
+
+    const res = makeRes();
+    await createSession(makeReq(VALID_BODY), res);
+
+    expect(mockSessionCount).toHaveBeenCalledWith({ user: 'user-123' });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('rejects a legacy account that is already at the limit', async () => {
+    mockSessionCountFindOneAndUpdate.mockResolvedValue(null);
+    mockSessionCount.mockReturnValue(countReturning(50));
+
+    const res = makeRes();
+    await createSession(makeReq(VALID_BODY), res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(mockSessionCreate).not.toHaveBeenCalled();
+  });
+
+  it('enforces the cap under concurrent creates (loser fails with the limit message)', async () => {
+    // First caller wins the increment (49 -> 50); the concurrent loser then
+    // sees the counter at the limit (findOneAndUpdate -> null) and the real
+    // count at 50, so it aborts instead of inserting an over-limit session.
+    mockSessionCountFindOneAndUpdate
+      .mockResolvedValueOnce({ count: 50 })
+      .mockResolvedValueOnce(null);
+    mockSessionCount.mockReturnValue(countReturning(50));
+
+    const created = makeCreatedSession();
+    mockSessionCreate.mockResolvedValue([created]);
+    mockQuestionInsertMany.mockResolvedValue([]);
+    mockUserQuery();
+
+    const res1 = makeRes();
+    const res2 = makeRes();
+    await Promise.all([
+      createSession(makeReq(VALID_BODY), res1),
+      createSession(makeReq(VALID_BODY), res2),
+    ]);
+
+    const statuses = [res1.status.mock.calls[0][0], res2.status.mock.calls[0][0]].sort();
+    expect(statuses).toEqual([201, 400]);
+    // Only the winning request inserts a session.
+    expect(mockSessionCreate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('deleteSession — counter decrement', () => {
+  it('decrements the user counter inside the transaction', async () => {
+    mockSessionFindOne.mockReturnValue({
+      session: vi.fn().mockResolvedValue({ _id: 'session-1' }),
+    });
+    mockQuestionDeleteMany.mockResolvedValue({ deletedCount: 2 });
+    mockSessionDeleteOne.mockResolvedValue({ deletedCount: 1 });
+    mockSessionCountUpdateOne.mockResolvedValue({ modifiedCount: 1 });
+
+    const res = makeRes();
+    await deleteSession(
+      { params: { id: 'session-1' }, user: { _id: 'user-123' } },
+      res,
+    );
+
+    expect(mockSessionCountUpdateOne).toHaveBeenCalledWith(
+      { _id: 'user-123' },
+      { $inc: { count: -1 } },
+      expect.objectContaining({ session: expect.anything() }),
+    );
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      message: 'Session deleted successfully.',
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`createSession` enforced `MAX_SESSIONS` with a check-then-insert pattern: `Session.countDocuments({ user })` followed by an insert. Under concurrent requests both could read a count below the cap and both insert, leaving the user with more than `MAX_SESSIONS` sessions. The MongoDB transaction did not make the count-then-insert atomic — both requests could observe the same snapshot and pass the pre-check.

## Fix

Replace the count-then-insert with an atomic conditional increment on a new per-user counter document that acts as the serialization point.

- `backend/models/SessionCount.js` (new) — one document per user (`_id` = user `_id`) holding the session count, so the limit check becomes a single atomic operation.
- `backend/controllers/sessionController.js`
  - `createSession` now runs `SessionCount.findOneAndUpdate({ _id: userId, count: { $lt: MAX_SESSIONS } }, { $inc: { count: 1 } }, { new: true, session })` inside the existing transaction. Concurrent losers hit a write conflict, the transaction retries, and the re-run sees the counter at the limit and aborts with `SESSION_LIMIT_REACHED`.
  - For legacy accounts with no counter yet, it seeds the counter from the real `Session.countDocuments(...)` before incrementing (enforcing the limit even for pre-existing users).
  - `deleteSession` decrements the counter (`$inc: { count: -1 }`) inside the same transaction so freed slots are reusable.
- `backend/controllers/authController.js`
  - `deleteUserAccount` now also deletes the user's `SessionCount` document in the cascade.
- `backend/tests/sessionController.limit.unit.test.js` (new, 6 tests) — counter-below-limit success, limit rejection, legacy seeding below the limit, legacy account already at the limit, concurrent-create cap enforcement (winner 201 / loser 400, only one insert), and delete-session counter decrement.

## Files changed

- `backend/models/SessionCount.js` (new)
- `backend/controllers/sessionController.js`
- `backend/controllers/authController.js`
- `backend/tests/sessionController.limit.unit.test.js` (new)

## Testing

- New unit tests (above) run via the existing `Module._load` shim pattern.
- Backend suite: `npx vitest run --root backend --exclude "tests/achievementController.unit.test.js"` → 101 passed (95 existing + 6 new). Excluded file is a pre-existing empty test file on main that fails vitest suite discovery.
- All modified modules load cleanly (`SessionCount`, `sessionController`, `authController`).

Closes #1633
