### PR TITLE
fix(ci): stop swallowing backend test failures (#1576)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,4 +32,4 @@ jobs:
       run: cd frontend && npm run build
       
     - name: Run Tests (Backend)
-      run: cd backend && npm test || echo "No tests configured yet"
+      run: cd backend && npm test


### PR DESCRIPTION
Removes the `|| echo "No tests configured yet"` fallback in the backend test step so CI fails when any backend test fails.

```diff
- run: cd backend && npm test || echo "No tests configured yet"
+ run: cd backend && npm test
```

Previously vitest's non-zero exit code was masked, keeping the check green while tests failed — this let failing tests ship and will mask future regressions.

Closes #1576

_This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._