### PR TITLE
Fix unbounded pagination limit in sheetJsonUpload.js (#1670)

### DIFF
--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -155,7 +155,8 @@ router.delete('/:id', protect, requireAdmin, async (req, res) => {
 router.get('/', async (req, res) => {
   try {
     const page = Math.max(1, parseInt(req.query.page, 10) || 1);
-    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 50));
+    const parsedLimit = parseInt(req.query.limit, 10);
+    const limit = Math.min(100, Math.max(1, isNaN(parsedLimit) ? 50 : parsedLimit));
     const skip = (page - 1) * limit;
 
     const sheets = await Sheet.find({}).skip(skip).limit(limit);

--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -154,8 +154,8 @@ router.delete('/:id', protect, requireAdmin, async (req, res) => {
 // GET / - fetch all sheets (for /api/sheets)
 router.get('/', async (req, res) => {
   try {
-    const page = parseInt(req.query.page, 10) || 1;
-    const limit = parseInt(req.query.limit, 10) || 50;
+    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+    const limit = Math.min(100, Math.max(1, parseInt(req.query.limit, 10) || 50));
     const skip = (page - 1) * limit;
 
     const sheets = await Sheet.find({}).skip(skip).limit(limit);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1670

### Summary
This PR fixes an unbounded pagination limit vulnerability in the `GET /api/sheets/` endpoint (`backend/routes/sheetJsonUpload.js`) that could potentially lead to memory exhaustion (DoS). The `limit` query parameter is now correctly capped at a maximum of 100, and the `page` parameter is enforced to be at least 1. This prevents malicious actors from requesting massively large amounts of data at once and exhausting server memory.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Verified that requesting a small `limit` (e.g., `?limit=10`) correctly applies the requested limit.
- Verified that requesting an excessively large `limit` (e.g., `?limit=100000000`) safely caps the response to a maximum of 100 items.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Caps the `limit` parameter at 100.
- Ensures the `page` parameter is at least 1.
- Preserves defaults of page 1 and limit 50.
- Prevents excessive data loading and potential memory exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->