### PR TITLE
fix : added max length guard on topicsToFocus array in ValidateSession

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -12,7 +12,7 @@ const objectId = (label) =>
 const createSessionSchema = z.object({
   role: z.string().min(1, "Role is required"),
   experience: z.string().min(1, "Experience is required"),
-  topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
+  topicsToFocus: z.array(z.string().min(1)).min(1, "At least one topic is required").max(20, "Cannot specify more than 20 topics"),
   description: z.string().optional(),
   question: z.array(
     z.object({


### PR DESCRIPTION
## Summary of What Has Been Done
Added `.max(20)` to the `topicsToFocus` array in `backend/Input_validators/ValidateSession.js` createSessionSchema, and added `.min(1)` to individual string elements to prevent empty strings.

Before:
```js
topicsToFocus: z.array(z.string()).min(1, "At least one topic is required")
```

After:
```js
topicsToFocus: z.array(z.string().min(1)).min(1, "At least one topic is required").max(20, "Cannot specify more than 20 topics")
```

## Changes Made
- `backend/Input_validators/ValidateSession.js`: Added `.min(1)` to string elements and `.max(20)` to the array

## Impact it Made
- Prevents clients from sending arbitrarily large `topicsToFocus` arrays that could bloat the database
- Consistent validation with `ValidateAi.js` (which also limits topics to max 20)
- Backward compatible for legitimate use cases (20 topics is a generous upper bound)

Closes canopus-labs/preppilot#1693

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds validation for `topicsToFocus` in `createSessionSchema`.

- Limits the array to 20 topics.
- Rejects empty topic strings.
- Retains the requirement for at least one topic.
- Prevents oversized arrays that can increase database size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->