### PR TITLE
fix : added max length guard on unlockedAchievements array in ValidateAchievement

### DIFF
--- a/backend/Input_validators/ValidateAchievement.js
+++ b/backend/Input_validators/ValidateAchievement.js
@@ -5,7 +5,7 @@ const savedAchievementsSchema = z.object({
   unlockedAchievements: z.array(z.string(), {
     required_error: "unlockedAchievements must be an array",
     invalid_type_error: "unlockedAchievements must be an array of strings",
-  }),
+  }).max(50, "Cannot save more than 50 achievements at once"),
 });
 
 const validateSavedAchievements = (req, res, next) => {


### PR DESCRIPTION
## Summary of What Has Been Done
Added `.max(50)` length guard to the `unlockedAchievements` array in `backend/Input_validators/ValidateAchievement.js`.

Before:
```js
unlockedAchievements: z.array(z.string(), { required_error: "...", invalid_type_error: "..." })
```

After:
```js
unlockedAchievements: z.array(z.string(), { required_error: "...", invalid_type_error: "..." }).max(50, "Cannot save more than 50 achievements at once")
```

## Changes Made
- `backend/Input_validators/ValidateAchievement.js`: Added `.max(50)` to the array

## Impact it Made
- Prevents clients from submitting unbounded arrays of achievement IDs
- There are only 10 valid achievements in `backend/constants/achievements.js`; 50 is a generous upper bound
- Reduces unnecessary database operations and processing overhead

Closes canopus-labs/preppilot#1694

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a `.max(50)` guard to `unlockedAchievements`.

Requests with more than 50 achievements now fail with: “Cannot save more than 50 achievements at once.”

This prevents unbounded input arrays and limits unnecessary processing and database operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->