### PR TITLE
fix : added invalid_type_error to sourceType enum in ValidateNotesSummary

### DIFF
--- a/backend/Input_validators/ValidateNotesSummary.js
+++ b/backend/Input_validators/ValidateNotesSummary.js
@@ -57,7 +57,9 @@ const aiOutputSchema = z.object({
 
 const saveNotesSummarySchema = z.object({
   fileName: z.string().min(1).max(200),
-  sourceType: z.enum(["upload", "platform"]),
+  sourceType: z.enum(["upload", "platform"], {
+    errorMap: () => ({ message: "sourceType must be either 'upload' or 'platform'" }),
+  }),
   sourceUrl: z.string().url().optional().nullable(),
   pageCount: z.number().int().nonnegative().optional().default(0),
   wordCount: z.number().int().nonnegative().optional().default(0),


### PR DESCRIPTION
## Summary of What Has Been Done
Added explicit `errorMap` to the `sourceType` z.enum in `backend/Input_validators/ValidateNotesSummary.js` to provide clear error messages when an invalid type is passed.

Before:
```js
sourceType: z.enum(["upload", "platform"])
```

After:
```js
sourceType: z.enum(["upload", "platform"], {
  errorMap: () => ({ message: "sourceType must be either 'upload' or 'platform'" }),
})
```

## Changes Made
- `backend/Input_validators/ValidateNotesSummary.js`: Added `errorMap` to the `sourceType` enum

## Impact it Made
- Clear, consistent error messages regardless of the input type
- Consistent with Zod error handling patterns used elsewhere in the codebase
- No functional change for correctly-typed inputs

Note: Please assign this PR to the `tmdeveloper007` account.