### PR TITLE
fix : made getAllProgress pagination limit configurable instead of hardcoded 50

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -7,16 +7,38 @@ const {
 /**
  * Get all sheet progress entries for the authenticated user.
  * @route GET /api/user/sheet-progress
+ * @query page optional page number (default 1)
+ * @query limit optional page size (default 50, max 100)
  */
 exports.getAllProgress = async (req, res) => {
   const userId = req.user._id;
 
+  // Parse and validate pagination params with safe fallbacks
+  const rawPage = Number(req.query.page);
+  const rawLimit = Number(req.query.limit);
+  const page = Number.isFinite(rawPage) && rawPage >= 1 ? Math.floor(rawPage) : 1;
+  const limit = Number.isFinite(rawLimit)
+    ? Math.min(100, Math.max(1, Math.floor(rawLimit)))
+    : 50;
+  const skip = (page - 1) * limit;
+
   try {
-    const progressList = await UserSheetProgress.find({ userId }).limit(50);
+    const [progressList, total] = await Promise.all([
+      UserSheetProgress.find({ userId }).skip(skip).limit(limit).sort({ updatedAt: -1 }),
+      UserSheetProgress.countDocuments({ userId }),
+    ]);
 
     res.json({
       success: true,
       progressList,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.max(1, Math.ceil(total / limit)),
+        hasNextPage: page * limit < total,
+        hasPreviousPage: page > 1,
+      },
     });
   } catch (err) {
     res.status(500).json({


### PR DESCRIPTION
## Summary of What Has Been Done
Updated `getAllProgress` in `backend/controllers/userSheetProgressController.js` to accept optional `page` and `limit` query parameters instead of hardcoding `.limit(50)`.

Key changes:
- Added `page` (default 1) and `limit` (default 50, max 100) query param parsing
- Applied `.skip((page-1)*limit).limit(limit).sort({ updatedAt: -1 })`
- Added `countDocuments` query to return total count
- Response now includes pagination metadata: `page`, `limit`, `total`, `totalPages`, `hasNextPage`, `hasPreviousPage`

## Changes Made
- `backend/controllers/userSheetProgressController.js`: Rewrote `getAllProgress` with pagination support

## Impact it Made
- Allows clients to paginate through large numbers of sheet progress entries
- Fixes the limitation where users with >50 sheets cannot access items beyond the first page
- Backward compatible: default page=1, limit=50 preserves existing behavior

Closes canopus-labs/preppilot#1696

Note: Please assign this PR to the `tmdeveloper007` account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds configurable pagination to `getAllProgress`.
- Supports `page` and `limit` query parameters.
- Uses defaults of `page=1` and `limit=50`.
- Enforces a maximum `limit` of 100.
- Sorts results by `updatedAt` in descending order.
- Returns pagination metadata and preserves existing default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->