### PR TITLE
fix : added max length guard on category field in ValidateFlashcard

### DIFF
--- a/backend/Input_validators/ValidateFlashcard.js
+++ b/backend/Input_validators/ValidateFlashcard.js
@@ -4,7 +4,7 @@ const { handleValidationError } = require("./ValidateQuestions");
 const createFlashcardSchema = z.object({
   question: z.string().min(1, "Question text is required").max(5000, "Question text must be at most 5000 characters"),
   answer: z.string().min(1, "Answer text is required").max(10000, "Answer text must be at most 10000 characters"),
-  category: z.string().optional().default("General"),
+  category: z.string().max(100, "Category must be at most 100 characters").optional().default("General"),
   sourceId: z.string().optional().nullable(),
 });
 


### PR DESCRIPTION
## Summary of What Has Been Done
Added `.max(100)` length guard to the `category` field in `backend/Input_validators/ValidateFlashcard.js`.

Before:
```js
category: z.string().optional().default("General")
```

After:
```js
category: z.string().max(100, "Category must be at most 100 characters").optional().default("General")
```

## Changes Made
- `backend/Input_validators/ValidateFlashcard.js`: Added `.max(100)` to the `category` field

## Impact it Made
- Prevents clients from sending extremely long category strings that could bloat the database
- 100 characters is a generous limit for any reasonable category name
- Consistent with max-length patterns used throughout the codebase

Closes canopus-labs/preppilot#1697

Note: Please assign this PR to the `tmdeveloper007` account.