### PR TITLE
fix(sheets): soft delete catalog records

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4

--- a/backend/models/Sheet.js
+++ b/backend/models/Sheet.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const { Schema } = mongoose;
 
 // Links Schema
 const LinkSchema = new mongoose.Schema({
@@ -44,7 +45,11 @@ const SheetSchema = new mongoose.Schema({
   questions: { type: Number, default: 0 },
   category: { type: String, default: "general" },
   sections: [SectionSchema],
-  uploadedAt: { type: Date, default: Date.now }
+  uploadedAt: { type: Date, default: Date.now },
+  createdBy: { type: Schema.Types.ObjectId, ref: "User" },
+  updatedBy: { type: Schema.Types.ObjectId, ref: "User" },
+  deletedAt: { type: Date, default: null },
+  deletedBy: { type: Schema.Types.ObjectId, ref: "User" }
 });
 
 module.exports = mongoose.model('Sheet', SheetSchema);

--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -35,10 +35,20 @@ router.post('/upload', protect, requireAdmin, async (req, res) => {
         continue;
       }
 
-      // Insert or update sheet by id
       const sheet = await Sheet.findOneAndUpdate(
         { id: normalized.value.id },
-        normalized.value,
+        {
+          $set: {
+            ...normalized.value,
+            updatedBy: req.user._id,
+            deletedAt: null,
+          },
+          $setOnInsert: {
+            createdBy: req.user._id,
+            uploadedAt: new Date(),
+          },
+          $unset: { deletedBy: "" },
+        },
         { upsert: true, new: true, setDefaultsOnInsert: true }
       );
 
@@ -109,8 +119,13 @@ router.put('/:id', protect, requireAdmin, async (req, res) => {
 
   try {
     const sheet = await Sheet.findOneAndUpdate(
-      { id },
-      normalized.value,
+      { id, deletedAt: null },
+      {
+        $set: {
+          ...normalized.value,
+          updatedBy: req.user._id,
+        },
+      },
       { new: true, setDefaultsOnInsert: true }
     );
 
@@ -136,13 +151,22 @@ router.delete('/:id', protect, requireAdmin, async (req, res) => {
   }
 
   try {
-    const sheet = await Sheet.findOneAndDelete({ id });
+    const sheet = await Sheet.findOneAndUpdate(
+      { id, deletedAt: null },
+      {
+        $set: {
+          deletedAt: new Date(),
+          deletedBy: req.user._id,
+        },
+      },
+      { new: true }
+    );
 
     if (!sheet) {
       return res.status(404).json({ error: 'Sheet not found.' });
     }
 
-    res.json({ message: 'Sheet deleted.', id });
+    res.json({ message: 'Sheet deleted.', id, deletedAt: sheet.deletedAt });
   } catch (err) {
     console.error('Error deleting sheet:', err);
     res.status(500).json({ error: 'Failed to delete sheet.' });
@@ -159,8 +183,9 @@ router.get('/', async (req, res) => {
     const limit = Math.min(100, Math.max(1, isNaN(parsedLimit) ? 50 : parsedLimit));
     const skip = (page - 1) * limit;
 
-    const sheets = await Sheet.find({}).skip(skip).limit(limit);
-    const total = await Sheet.countDocuments({});
+    const visibleSheets = { deletedAt: null };
+    const sheets = await Sheet.find(visibleSheets).skip(skip).limit(limit);
+    const total = await Sheet.countDocuments(visibleSheets);
 
     res.json({ 
       sheets,
@@ -179,7 +204,7 @@ router.get('/', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     // Always find by cust
-    const sheet = await Sheet.findOne({ id: req.params.id });
+    const sheet = await Sheet.findOne({ id: req.params.id, deletedAt: null });
     if (!sheet) {
       return res.status(404).json({ error: 'Sheet not found.' });
     }

--- a/backend/routes/sheetJsonUpload.js
+++ b/backend/routes/sheetJsonUpload.js
@@ -184,7 +184,10 @@ router.get('/', async (req, res) => {
     const skip = (page - 1) * limit;
 
     const visibleSheets = { deletedAt: null };
-    const sheets = await Sheet.find(visibleSheets).skip(skip).limit(limit);
+    const sheets = await Sheet.find(visibleSheets)
+      .select('-createdBy -updatedBy -deletedBy')
+      .skip(skip)
+      .limit(limit);
     const total = await Sheet.countDocuments(visibleSheets);
 
     res.json({ 
@@ -204,7 +207,8 @@ router.get('/', async (req, res) => {
 router.get('/:id', async (req, res) => {
   try {
     // Always find by cust
-    const sheet = await Sheet.findOne({ id: req.params.id, deletedAt: null });
+    const sheet = await Sheet.findOne({ id: req.params.id, deletedAt: null })
+      .select('-createdBy -updatedBy -deletedBy');
     if (!sheet) {
       return res.status(404).json({ error: 'Sheet not found.' });
     }

--- a/backend/tests/sheetRoutes.adminAuthz.unit.test.js
+++ b/backend/tests/sheetRoutes.adminAuthz.unit.test.js
@@ -1,3 +1,4 @@
+import mongoose from "mongoose";
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
@@ -8,6 +9,7 @@ import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 
 let sheetRouter;
 let requireAdmin;
+let Sheet;
 
 beforeAll(async () => {
   const sheetRouterMod = await import("../routes/sheetJsonUpload.js");
@@ -15,6 +17,8 @@ beforeAll(async () => {
 
   const authMod = await import("../middlewares/authMiddleware.js");
   requireAdmin = authMod.requireAdmin;
+
+  Sheet = mongoose.models.Sheet;
 });
 
 afterEach(() => {
@@ -113,5 +117,25 @@ describe("requireAdmin middleware (#1446)", () => {
     };
     requireAdmin({}, res, () => {});
     expect(statusCode).toBe(403);
+  });
+});
+
+describe("/api/sheets mutation audit trail", () => {
+  it("keeps soft-delete audit fields on the sheet model", () => {
+    expect(Sheet.schema.path("createdBy")).toBeTruthy();
+    expect(Sheet.schema.path("updatedBy")).toBeTruthy();
+    expect(Sheet.schema.path("deletedAt")).toBeTruthy();
+    expect(Sheet.schema.path("deletedBy")).toBeTruthy();
+  });
+
+  it("soft-deletes sheets instead of hard-deleting catalog records", () => {
+    const stack = getLayerStack(sheetRouter, "DELETE", "/:id");
+    const deleteHandler = stack[stack.length - 1];
+    const source = deleteHandler.toString();
+
+    expect(source).toContain("findOneAndUpdate");
+    expect(source).toContain("deletedAt");
+    expect(source).toContain("deletedBy");
+    expect(source).not.toContain("findOneAndDelete");
   });
 });

--- a/backend/tests/sheetRoutes.adminAuthz.unit.test.js
+++ b/backend/tests/sheetRoutes.adminAuthz.unit.test.js
@@ -143,6 +143,20 @@ describe("requireAdmin middleware (#1446)", () => {
 });
 
 describe("/api/sheets mutation audit trail", () => {
+  it.each([
+    ["POST", "/upload"],
+    ["PUT", "/:id"],
+    ["DELETE", "/:id"],
+  ])("%s %s stays admin-only while adding audit behavior (#1715)", (method, path) => {
+    const stack = getLayerStack(sheetRouter, method, path);
+    expect(stack).not.toBeNull();
+    const protectIdx = stack.findIndex((fn) => fn && fn.name === "protect");
+    const adminIdx = stack.findIndex((fn) => fn && fn.name === "requireAdmin");
+
+    expect(protectIdx).toBeGreaterThanOrEqual(0);
+    expect(adminIdx).toBe(protectIdx + 1);
+  });
+
   it("keeps soft-delete audit fields on the sheet model", () => {
     expect(Sheet.schema.path("createdBy")).toBeTruthy();
     expect(Sheet.schema.path("updatedBy")).toBeTruthy();

--- a/backend/tests/sheetRoutes.adminAuthz.unit.test.js
+++ b/backend/tests/sheetRoutes.adminAuthz.unit.test.js
@@ -22,6 +22,7 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
 });
 
@@ -34,6 +35,27 @@ function getLayerStack(router, method, path) {
   );
   if (!layer) return null;
   return layer.route.stack.map((s) => s.handle);
+}
+
+function getRouteHandler(method, path) {
+  const stack = getLayerStack(sheetRouter, method, path);
+  return stack[stack.length - 1];
+}
+
+function createRes() {
+  const res = {
+    statusCode: 200,
+    body: null,
+    status: vi.fn((code) => {
+      res.statusCode = code;
+      return res;
+    }),
+    json: vi.fn((body) => {
+      res.body = body;
+      return res;
+    }),
+  };
+  return res;
 }
 
 const WRITE_ROUTES = [
@@ -128,14 +150,124 @@ describe("/api/sheets mutation audit trail", () => {
     expect(Sheet.schema.path("deletedBy")).toBeTruthy();
   });
 
-  it("soft-deletes sheets instead of hard-deleting catalog records", () => {
-    const stack = getLayerStack(sheetRouter, "DELETE", "/:id");
-    const deleteHandler = stack[stack.length - 1];
-    const source = deleteHandler.toString();
+  it("records createdBy and updatedBy when uploading sheets", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const findOneAndUpdate = vi
+      .spyOn(Sheet, "findOneAndUpdate")
+      .mockResolvedValue({ id: "array-basics" });
+    const uploadHandler = getRouteHandler("POST", "/upload");
+    const res = createRes();
 
-    expect(source).toContain("findOneAndUpdate");
-    expect(source).toContain("deletedAt");
-    expect(source).toContain("deletedBy");
-    expect(source).not.toContain("findOneAndDelete");
+    await uploadHandler(
+      {
+        user: { _id: userId },
+        body: {
+          filename: "sheets.json",
+          data: { id: "array-basics", title: "Array Basics" },
+        },
+      },
+      res
+    );
+
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { id: "array-basics" },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          updatedBy: userId,
+          deletedAt: null,
+        }),
+        $setOnInsert: expect.objectContaining({
+          createdBy: userId,
+          uploadedAt: expect.any(Date),
+        }),
+        $unset: { deletedBy: "" },
+      }),
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("records updatedBy when updating a sheet", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const findOneAndUpdate = vi
+      .spyOn(Sheet, "findOneAndUpdate")
+      .mockResolvedValue({ id: "array-basics" });
+    const updateHandler = getRouteHandler("PUT", "/:id");
+    const res = createRes();
+
+    await updateHandler(
+      {
+        user: { _id: userId },
+        params: { id: "array-basics" },
+        body: { id: "array-basics", title: "Array Basics" },
+      },
+      res
+    );
+
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { id: "array-basics", deletedAt: null },
+      {
+        $set: expect.objectContaining({
+          updatedBy: userId,
+        }),
+      },
+      { new: true, setDefaultsOnInsert: true }
+    );
+    expect(res.body).toEqual({ message: "Sheet updated.", sheet: { id: "array-basics" } });
+  });
+
+  it("soft-deletes sheets instead of hard-deleting catalog records", async () => {
+    const userId = new mongoose.Types.ObjectId();
+    const deletedAt = new Date();
+    const findOneAndUpdate = vi
+      .spyOn(Sheet, "findOneAndUpdate")
+      .mockResolvedValue({ id: "array-basics", deletedAt });
+    const findOneAndDelete = vi.spyOn(Sheet, "findOneAndDelete");
+    const deleteHandler = getRouteHandler("DELETE", "/:id");
+    const res = createRes();
+
+    await deleteHandler(
+      {
+        user: { _id: userId },
+        params: { id: "array-basics" },
+        body: { confirmId: "array-basics" },
+      },
+      res
+    );
+
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { id: "array-basics", deletedAt: null },
+      {
+        $set: {
+          deletedAt: expect.any(Date),
+          deletedBy: userId,
+        },
+      },
+      { new: true }
+    );
+    expect(findOneAndDelete).not.toHaveBeenCalled();
+    expect(res.body).toEqual({
+      message: "Sheet deleted.",
+      id: "array-basics",
+      deletedAt,
+    });
+  });
+
+  it("returns 404 when soft-deleting a missing or already deleted sheet", async () => {
+    vi.spyOn(Sheet, "findOneAndUpdate").mockResolvedValue(null);
+    const deleteHandler = getRouteHandler("DELETE", "/:id");
+    const res = createRes();
+
+    await deleteHandler(
+      {
+        user: { _id: new mongoose.Types.ObjectId() },
+        params: { id: "array-basics" },
+        body: { confirmId: "array-basics" },
+      },
+      res
+    );
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.body).toEqual({ error: "Sheet not found." });
   });
 });


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #1715

### Summary
Keeps the existing admin-only sheet mutations, adds audit fields to sheet records, and changes delete to a soft delete so shared catalog records are no longer hard-removed. Public reads now filter out soft-deleted sheets, while upload can restore a soft-deleted sheet id.

---

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] UI/UX improvement
- [ ] Other(please describe) ______

---

### How Has This Been Tested?
- npm test (backend)

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project guidelines
- [x] I have tested my changes
- [x] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restricts sheet mutations to admin and service roles.
- Adds audit fields to sheet records.
- Changes sheet deletion to soft deletion.
- Excludes soft-deleted sheets from public reads.
- Allows uploads to restore soft-deleted sheets by ID.
- Adds tests for audited mutations and soft deletion.
- Updates CI coverage to Node.js 20.x and 22.x.

Backend tests passed with `npm test`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->