### PR TITLE
fix: normalize country parameter in cacheKey to prevent cache fragmentation (#1207)

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -4,7 +4,7 @@ const JobCache = require("../models/JobCache");
 
 const ADZUNA_APP_ID  = process.env.ADZUNA_APP_ID;
 const ADZUNA_API_KEY = process.env.ADZUNA_API_KEY;
-const ADZUNA_COUNTRY = process.env.ADZUNA_COUNTRY || "in";
+const ADZUNA_COUNTRY = (process.env.ADZUNA_COUNTRY || "in").toLowerCase().trim();
 const CACHE_TTL_MS   = 24 * 60 * 60 * 1000;
 
 // The Jobs feature is optional: without Adzuna credentials it stays dormant
@@ -12,25 +12,26 @@ const CACHE_TTL_MS   = 24 * 60 * 60 * 1000;
 const isAdzunaConfigured = () => Boolean(ADZUNA_APP_ID && ADZUNA_API_KEY);
 
 async function fetchFromAdzuna(role, country = ADZUNA_COUNTRY) {
-  const url = `https://api.adzuna.com/v1/api/jobs/${country}/search/1`;
+  const normalizedCountry = country.toLowerCase().trim();
+  const url = `https://api.adzuna.com/v1/api/jobs/${normalizedCountry}/search/1`;
   const { data } = await axios.get(url, {
     params: {
-      app_id:   ADZUNA_APP_ID,
-      app_key:  ADZUNA_API_KEY,
-      what:     role,
+      app_id:           ADZUNA_APP_ID,
+      app_key:          ADZUNA_API_KEY,
+      what:             role,
       results_per_page: 10,
     },
   });
   return (data.results || []).map((j) => ({
-    id:          j.id,
-    title:       j.title,
-    company:     j.company?.display_name || "Unknown",
-    location:    j.location?.display_name || "Remote",
-    salary_min:  j.salary_min || null,
-    salary_max:  j.salary_max ?? null,
-    description: j.description ?? "",
+    id:           j.id,
+    title:        j.title,
+    company:      j.company?.display_name || "Unknown",
+    location:     j.location?.display_name || "Remote",
+    salary_min:   j.salary_min || null,
+    salary_max:   j.salary_max ?? null,
+    description:  j.description ?? "",
     redirect_url: j.redirect_url,
-    created:     j.created,
+    created:      j.created,
   }));
 }
 
@@ -52,9 +53,12 @@ exports.getJobs = async (req, res) => {
       .sort({ createdAt: -1 })
       .select("role");
 
-    const role    = req.query.role || latestSession?.role || "software engineer";
-    const country = req.query.country   || ADZUNA_COUNTRY;
-    const cacheKey = `${role.toLowerCase()}|${country}`;
+    const rawRole    = req.query.role || latestSession?.role || "software engineer";
+    const rawCountry = req.query.country || ADZUNA_COUNTRY;
+
+    const role     = rawRole.toLowerCase().trim();
+    const country  = rawCountry.toLowerCase().trim();
+    const cacheKey = `${role}|${country}`;
 
     const cached = await JobCache.findOne({ cacheKey });
     if (cached && Date.now() - cached.fetchedAt.getTime() < CACHE_TTL_MS) {
@@ -84,14 +88,15 @@ exports.refreshJobCache = async () => {
     });
 
     for (const role of roles) {
-      const cacheKey = `${role.toLowerCase()}|${ADZUNA_COUNTRY}`;
-      const jobs = await fetchFromAdzuna(role);
+      const normalizedRole = role.toLowerCase().trim();
+      const cacheKey = `${normalizedRole}|${ADZUNA_COUNTRY}`;
+      const jobs = await fetchFromAdzuna(normalizedRole, ADZUNA_COUNTRY);
       await JobCache.findOneAndUpdate(
         { cacheKey },
         { jobs, fetchedAt: new Date() },
         { upsert: true, new: true }
       );
-      console.log(`[JobCron] Refreshed cache for: ${role}`);
+      console.log(`[JobCron] Refreshed cache for: ${normalizedRole}`);
     }
   } catch (err) {
     console.error("[JobCron] Refresh failed:", err.message);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1207

### Summary
Fixes cache fragmentation where variations in casing/spacing of the `country` parameter (e.g., `?country=IN` vs `?country=in`) created separate cache entries in MongoDB (`JobCache`). 

`country` is now explicitly lowercased and trimmed alongside `role` when building `cacheKey` values and calling the Adzuna API, preventing duplicate database entries and redundant external API calls.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [x] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Sent `GET` requests to `/api/jobs?role=developer&country=IN` followed by `/api/jobs?role=developer&country=in`.
- Checked MongoDB `JobCache` collection to verify that both requests mapped to a single normalized cache key (`developer|in`).
- Confirmed second request served cached results instead of hitting the Adzuna API again.

---

### Screenshots (if applicable)
N/A

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors