### PR TITLE
fix: DSA sheet progress never persists — accept object completedTopics shape

### DIFF
--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -60,10 +60,15 @@ exports.saveProgress = async (req, res) => {
     });
   }
 
-  if (completedTopics !== undefined && !Array.isArray(completedTopics)) {
+  if (
+    completedTopics !== undefined &&
+    (typeof completedTopics !== "object" ||
+      completedTopics === null ||
+      Array.isArray(completedTopics))
+  ) {
     return res.status(400).json({
       success: false,
-      error: "Invalid completedTopics field, must be an array",
+      error: "Invalid completedTopics field, must be an object",
     });
   }
 

--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -64,11 +64,15 @@ exports.saveProgress = async (req, res) => {
     completedTopics !== undefined &&
     (typeof completedTopics !== "object" ||
       completedTopics === null ||
-      Array.isArray(completedTopics))
+      Array.isArray(completedTopics) ||
+      Object.values(completedTopics).some(
+        (value) => typeof value !== "boolean"
+      ))
   ) {
     return res.status(400).json({
       success: false,
-      error: "Invalid completedTopics field, must be an object",
+      error:
+        "Invalid completedTopics field, must be an object of boolean flags",
     });
   }
 


### PR DESCRIPTION
Closes #1727

### Problem
`saveProgress` rejected the real payload with `400`:
```js
if (completedTopics !== undefined && !Array.isArray(completedTopics)) { /* 400 "must be an array" */ }
```
The frontend sends `completedTopics` as an object/map (`{ "0-0-0": true }`), and so do the Zod validator (`z.record(z.string(), z.boolean())`), the Mongoose schema (`{ type: Object }`), `resetProgress` (`{}`), and the import util. `!Array.isArray({...})` is `true`, so **every save returned 400** and the frontend `.catch` swallowed it — progress lived only in localStorage and was lost across devices / on cache clear.

### Fix
Validate `completedTopics` as a plain object (reject arrays/null) to match the rest of the system.

### Testing
- `node --check` on the changed controller.

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `saveProgress` validation for `completedTopics`.
- The controller now accepts non-null plain objects with boolean values, such as `{ "0-0-0": true }`.
- The controller rejects arrays, `null`, and non-boolean values.
- Updated the validation error message.
- Verified syntax with `node --check`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->