### PR TITLE
fix: use captured file size for cached note summaries

### DIFF
--- a/backend/controllers/notesSummaryController.js
+++ b/backend/controllers/notesSummaryController.js
@@ -151,7 +151,7 @@ const summarizeNotes = async (req, res) => {
       return res.status(200).json({
         success: true,
         fileName,
-        fileSize: buffer.length,
+        fileSize,
         sourceType,
         sourceUrl,
         pageCount: pdfStats.numPages,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1728 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.
Fixed a cache-hit crash in the notes summary controller.

When a PDF is processed, its buffer is intentionally released by setting `buffer = null` after the file size and Base64 data are captured. However, the cached-summary response was still attempting to access `buffer.length`, causing a `TypeError` and returning a 500 response.

The cache-hit branch now uses the already-captured `fileSize` value instead.
---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
-Verified the affected code path and confirmed that the cache-hit response now uses the captured `fileSize` value instead of accessing the released buffer.

- Confirmed the change is limited to the cache-hit response and does not alter the existing summarization logic.

---

### Screenshots (if applicable)
Add screenshots or videos to demonstrate the changes.
N/A
---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixes the cache-hit crash in the notes summary controller. Cached PDF responses now use the captured `fileSize` after releasing the PDF buffer. Re-summarizing a cached PDF no longer returns an HTTP 500 error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->