### PR TITLE
fix : added add max length guard on title field in ValidateResume

### DIFF
--- a/backend/Input_validators/ValidateResume.js
+++ b/backend/Input_validators/ValidateResume.js
@@ -18,7 +18,7 @@ const analyzeResumeSchema = z.object({
 });
 
 const saveResumeSchema = z.object({
-  title: z.string({ required_error: "Title is required" }).min(1, "Title is required"),
+  title: z.string({ required_error: "Title is required" }).min(1, "Title is required").max(200, "Title cannot exceed 200 characters"),
   latexCode: z.string({ required_error: "LaTeX code is required" }).min(1, "LaTeX code is required"),
   resumeId: z
     .string()


### PR DESCRIPTION
## Summary of What Has Been Done

Added `.max(200)` to the `title` field in `saveResumeSchema` in `backend/Input_validators/ValidateResume.js`.

## Changes Made

- `backend/Input_validators/ValidateResume.js`: `title` field now has `.max(200, "Title cannot exceed 200 characters")`

## Impact it Made

- Consistent length limit for resume titles across the API
- Follows the same max-length pattern used for `targetRole` in the same file

## Closes #1762

## Note

Please assign this PR to the `tmdeveloper007` account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->