### PR TITLE
fix : added max length guard on experience field in ValidateSession

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -12,7 +12,7 @@ const objectId = (label) =>
 const createSessionSchema = z.object({
   role: z.string().min(1, "Role is required"),
   company: z.string().min(1, "Company is required"),
-  experience: z.string().min(1, "Experience is required"),
+  experience: z.string().min(1, "Experience is required").max(100, "Experience cannot exceed 100 characters"),
   topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
   description: z.string().optional(),
   question: z.array(


### PR DESCRIPTION
## Summary of What Has Been Done

Added `.max(100)` to the `experience` field in `createSessionSchema` in `backend/Input_validators/ValidateSession.js` to prevent excessively long strings from reaching the database.

## Changes Made

- `backend/Input_validators/ValidateSession.js`: `experience` field now has `.max(100, "Experience cannot exceed 100 characters")`

## Impact it Made

- Prevents arbitrarily long experience strings from being stored in the Session model
- Keeps API payloads lean and consistent with other max-length patterns in the codebase

## Closes #1757

## Note

Please assign this PR to the `tmdeveloper007` account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Adds a 100-character maximum to the `experience` field in `createSessionSchema`.

Values over the limit return: `"Experience cannot exceed 100 characters"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->