### PR TITLE
fix : added finite guards on minutes and pages in readingTimeSchema

### DIFF
--- a/backend/Input_validators/ValidateNotesSummary.js
+++ b/backend/Input_validators/ValidateNotesSummary.js
@@ -13,9 +13,9 @@ const difficultySchema = z.object({
 });
 
 const readingTimeSchema = z.object({
-  minutes: z.number().int().positive(),
+  minutes: z.number().int().positive().refine(v => Number.isFinite(v), { message: 'Minutes must be a finite number' }),
   label: z.string().min(1).max(50),
-  pages: z.number().int().nonnegative(),
+  pages: z.number().int().nonnegative().refine(v => Number.isFinite(v), { message: 'Pages must be a finite number' }),
 });
 
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added `.refine()` finite guards to the `minutes` and `pages` fields in `readingTimeSchema` in `backend/Input_validators/ValidateNotesSummary.js` to reject NaN and Infinity values.

## Changes Made

- `backend/Input_validators/ValidateNotesSummary.js`: both `minutes` and `pages` fields now validate finite numbers via `.refine()`

## Impact it Made

- Prevents NaN and Infinity from corrupting reading time metadata
- Consistent with defensive validation used elsewhere in the codebase

## Closes #1761

## Note

Please assign this PR to the `tmdeveloper007` account.
