### PR TITLE
test: add daily seed utility tests

### DIFF
--- a/frontend/src/utils/dailySeed.test.js
+++ b/frontend/src/utils/dailySeed.test.js
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getDailySeed } from "./dailySeed";
+
+describe("getDailySeed", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it("generates the expected YYYYMMDD seed", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 7, 11));
+
+        expect(getDailySeed()).toBe(20260811);
+    });
+
+    it("returns the same seed for the same date", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 7, 11));
+
+        const firstSeed = getDailySeed();
+        const secondSeed = getDailySeed();
+
+        expect(firstSeed).toBe(secondSeed);
+    });
+
+    it("returns different seeds for different dates", () => {
+        vi.useFakeTimers();
+
+        vi.setSystemTime(new Date(2026, 7, 11));
+        const firstSeed = getDailySeed();
+
+        vi.setSystemTime(new Date(2026, 7, 12));
+        const secondSeed = getDailySeed();
+
+        expect(firstSeed).not.toBe(secondSeed);
+    });
+
+    it("handles month boundaries correctly", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 7, 31));
+
+        expect(getDailySeed()).toBe(20260831);
+
+        vi.setSystemTime(new Date(2026, 8, 1));
+
+        expect(getDailySeed()).toBe(20260901);
+    });
+
+    it("handles year boundaries correctly", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 11, 31));
+
+        expect(getDailySeed()).toBe(20261231);
+
+        vi.setSystemTime(new Date(2027, 0, 1));
+
+        expect(getDailySeed()).toBe(20270101);
+    });
+});


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1779 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.
Added comprehensive unit tests for the getDailySeed utility used by the daily challenge system.

The tests verify deterministic seed generation based on the current calendar date and cover important date-boundary scenarios.
---

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.

-Added Vitest coverage for:

✅ Expected YYYYMMDD seed generation
✅ Deterministic output for the same date
✅ Different seeds for different dates
✅ Month boundary transitions
✅ Year boundary transitions
✅ System date mocking using Vitest fake timers

Test commands executed:

npm test -- src/utils/dailySeed.test.js


---

### Screenshots (if applicable)
Add screenshots or videos to demonstrate the changes.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds Vitest unit tests for `getDailySeed` in `frontend/src/utils/dailySeed.test.js`.

## Coverage

- Validates numeric `YYYYMMDD` seed formatting.
- Confirms deterministic results for the same date.
- Confirms different results for different dates.
- Tests month and year boundaries.
- Uses fake timers and cleans them up after each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->