### PR TITLE
fix : added max length guards on techStackFields array items in ValidateRoadmap

### DIFF
--- a/backend/Input_validators/ValidateRoadmap.js
+++ b/backend/Input_validators/ValidateRoadmap.js
@@ -44,10 +44,10 @@ const milestoneFields = z.object({
 
 const techStackFields = z
   .object({
-    frontend: z.array(z.string()),
-    backend: z.array(z.string()),
-    database: z.array(z.string()),
-    other: z.array(z.string()),
+    frontend: z.array(z.string().max(100, "Technology name cannot exceed 100 characters")),
+    backend: z.array(z.string().max(100, "Technology name cannot exceed 100 characters")),
+    database: z.array(z.string().max(100, "Technology name cannot exceed 100 characters")),
+    other: z.array(z.string().max(100, "Technology name cannot exceed 100 characters")),
   })
   .partial();
 


### PR DESCRIPTION
## Summary of What Has Been Done

Added `.max(100)` length guards to the string items in `techStackFields` in `backend/Input_validators/ValidateRoadmap.js` for `frontend`, `backend`, `database`, and `other` arrays.

## Changes Made

- `backend/Input_validators/ValidateRoadmap.js`: `techStackFields` array items now use `z.string().max(100, "Technology name cannot exceed 100 characters")` instead of plain `z.string()`

## Impact it Made

- Prevents arbitrarily long technology names from being stored in roadmap tech stack data
- Keeps the roadmap data bounded and consistent

## Closes #1786

## Note

Please assign this PR to the `tmdeveloper007` account.