### PR TITLE
fix(experiences): scope idempotency dedup to the author

### DIFF
--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -8,6 +8,12 @@ const SECURE_CLIENT_KEY =
 const isSecureClientKey = (value) =>
   typeof value === "string" && SECURE_CLIENT_KEY.test(value);
 
+// Dedup must be scoped to the author so a re-used idempotencyKey can never
+// return another submitter's experience: the submitting user when
+// authenticated, otherwise the anonymous clientKey.
+const buildAuthorFilter = (req, clientKey) =>
+  req.user?._id ? { userId: req.user._id } : { clientKey };
+
 const toClientShape = (doc) => {
   const obj = typeof doc.toObject === "function" ? doc.toObject() : doc;
   return {
@@ -70,7 +76,10 @@ const createInterviewExperience = async (req, res) => {
       payload.color = `hsl(${(payload.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`;
     }
 
-    const existing = await InterviewExperience.findOne({ idempotencyKey });
+    const existing = await InterviewExperience.findOne({
+      idempotencyKey,
+      ...buildAuthorFilter(req, payload.clientKey),
+    });
     if (existing) {
       return res.status(200).json({
         success: true,
@@ -92,6 +101,7 @@ const createInterviewExperience = async (req, res) => {
       try {
         const existing = await InterviewExperience.findOne({
           idempotencyKey: req.body.idempotencyKey,
+          ...buildAuthorFilter(req, req.body.clientKey),
         });
         if (existing) {
           return res.status(200).json({

--- a/backend/models/InterviewExperience.js
+++ b/backend/models/InterviewExperience.js
@@ -95,11 +95,26 @@ const interviewExperienceSchema = new mongoose.Schema(
   { timestamps: true },
 );
 
+// Idempotency is scoped to the author so a re-used key can never collide
+// with another submitter's document: authenticated submissions dedupe by
+// userId, anonymous submissions by clientKey.
 interviewExperienceSchema.index(
-  { idempotencyKey: 1 },
+  { userId: 1, idempotencyKey: 1 },
   {
     unique: true,
     partialFilterExpression: {
+      userId: { $type: "objectId" },
+      idempotencyKey: { $type: "string", $gt: "" },
+    },
+  },
+);
+
+interviewExperienceSchema.index(
+  { clientKey: 1, idempotencyKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      clientKey: { $type: "string", $gt: "" },
       idempotencyKey: { $type: "string", $gt: "" },
     },
   },

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -164,6 +164,7 @@ describe("createInterviewExperience", () => {
 
     expect(InterviewExperience.findOne).toHaveBeenCalledWith({
       idempotencyKey: "submit-key-abc12345",
+      clientKey: "11111111-1111-4111-8111-111111111111",
     });
     expect(InterviewExperience.create).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
@@ -174,6 +175,90 @@ describe("createInterviewExperience", () => {
           id: "507f1f77bcf86cd799439011",
         }),
       }),
+    );
+  });
+
+  it("scopes the dedup lookup to the authenticated user", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(sampleDoc);
+    InterviewExperience.create = vi.fn();
+
+    const req = makeReq(
+      {
+        company: "Google",
+        role: "SDE-2",
+        summary: "Tough but fair process",
+        idempotencyKey: "submit-key-abc12345",
+      },
+      {},
+      {},
+      { _id: "507f1f77bcf86cd799439011" },
+    );
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "submit-key-abc12345",
+      userId: "507f1f77bcf86cd799439011",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it("lets a different author reuse the same idempotencyKey", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
+    InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Tough but fair process",
+      clientKey: "11111111-1111-4111-8111-111111111111",
+      idempotencyKey: "submit-key-abc12345",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "submit-key-abc12345",
+      clientKey: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(InterviewExperience.create).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("scopes the unique-index race lookup to the author", async () => {
+    InterviewExperience.findOne = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(sampleDoc);
+    InterviewExperience.create = vi
+      .fn()
+      .mockRejectedValue({ code: 11000 });
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Tough but fair process",
+      clientKey: "11111111-1111-4111-8111-111111111111",
+      idempotencyKey: "submit-key-abc12345",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledTimes(2);
+    expect(InterviewExperience.findOne).toHaveBeenNthCalledWith(1, {
+      idempotencyKey: "submit-key-abc12345",
+      clientKey: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(InterviewExperience.findOne).toHaveBeenNthCalledWith(2, {
+      idempotencyKey: "submit-key-abc12345",
+      clientKey: "11111111-1111-4111-8111-111111111111",
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true }),
     );
   });
 });


### PR DESCRIPTION
## Problem

`POST /api/interview-experiences` deduplicates submissions by `idempotencyKey` alone, with no scope to the submitting user or client key. Anyone who re-uses a key gets the first submitter's full submission back (the unscoped `findOne({ idempotencyKey })` plus the same flaw in the `11000` unique-index race branch). Because the model also enforces a global unique index on `idempotencyKey`, a different user re-using the same key can never persist their own fresh submission — their content is silently lost.

## Fix

- Scoped the dedup lookup to the author in both places: `userId` when authenticated, `clientKey` for anonymous submissions.
- Replaced the global unique index on `idempotencyKey` with author-scoped partial unique indexes (`userId + idempotencyKey` and `clientKey + idempotencyKey`), so a different author re-using the same key gets their own new submission instead of someone else's data.

## Files changed

- `backend/controllers/interviewExperienceController.js` — author-scoped `findOne` filters in the pre-create check and the `11000` race branch.
- `backend/models/InterviewExperience.js` — author-scoped partial unique indexes.
- `backend/tests/interviewExperienceController.unit.test.js` — updated existing assertion and added coverage for authenticated scoping, cross-author key reuse, and the race branch.

## Testing

- Ran `cd backend && npm test`: all interview experience tests pass (16/16). The only failing tests in the full suite are the pre-existing `jobCache.boundedKeys` failures that also fail on clean `origin/main` and are unrelated to this change.

Closes #1795


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Scope idempotency deduplication by author for `POST /api/interview-experiences`.
- Match authenticated submissions by `userId`.
- Match anonymous submissions by `clientKey`.
- Apply author-scoped matching during initial lookup and duplicate-key race recovery.
- Replace the global unique index with author-scoped partial unique indexes.
- Add tests for authenticated scoping, cross-author key reuse, and race recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->