### PR TITLE
feat(google-calendar): add backend OAuth2 connect/sync routes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -75,3 +75,16 @@ ADZUNA_APP_ID=your_adzuna_app_id
 ADZUNA_API_KEY=your_adzuna_api_key
 # Country code for job listings: "in"=India, "us"=USA, "gb"=UK, "au"=Australia etc.
 ADZUNA_COUNTRY=in
+
+# Google Calendar Integration (Interview Prep sync)
+# Create OAuth credentials at https://console.cloud.google.com/apis/credentials
+# Enable the Google Calendar API and add the callback URL below to the
+# authorized redirect URIs of your OAuth client.
+GOOGLE_CLIENT_ID=your_google_client_id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your_google_client_secret
+# Strong random string used to derive the AES key that encrypts stored Google
+# refresh tokens. Changing it invalidates previously stored connections.
+GOOGLE_CALENDAR_ENCRYPTION_KEY=your_random_32_byte_secret
+# Optional: absolute callback URL. Leave unset to build it from BASE_URL (or
+# the request host when BASE_URL is empty).
+# GOOGLE_CALENDAR_CALLBACK_URL=https://preppilot-backend.onrender.com/api/google-calendar/callback

--- a/backend/Input_validators/ValidateGoogleCalendar.js
+++ b/backend/Input_validators/ValidateGoogleCalendar.js
@@ -1,0 +1,21 @@
+const { z } = require("zod");
+const { handleValidationError } = require("./ValidateQuestions");
+
+const createGoogleCalendarEventSchema = z.object({
+  title: z.string().trim().min(1, "Title is required").max(200),
+  description: z.string().trim().max(2000).optional().default(""),
+  startTime: z.string().datetime({ offset: true }),
+  endTime: z.string().datetime({ offset: true }),
+  reminderMinutes: z.number().int().min(0).max(60).optional().default(15),
+});
+
+const validateCreateGoogleCalendarEvent = (req, res, next) => {
+  try {
+    req.body = createGoogleCalendarEventSchema.parse(req.body);
+    next();
+  } catch (error) {
+    return handleValidationError(res, error);
+  }
+};
+
+module.exports = { validateCreateGoogleCalendarEvent };

--- a/backend/config/validateEnv.js
+++ b/backend/config/validateEnv.js
@@ -10,6 +10,14 @@ const optionalEnvGroups = Object.freeze([
     feature: "Jobs for You",
     keys: ["ADZUNA_APP_ID", "ADZUNA_API_KEY"],
   },
+  {
+    feature: "Google Calendar sync",
+    keys: [
+      "GOOGLE_CLIENT_ID",
+      "GOOGLE_CLIENT_SECRET",
+      "GOOGLE_CALENDAR_ENCRYPTION_KEY",
+    ],
+  },
 ]);
 
 const validateEnv = () => {

--- a/backend/controllers/googleCalendarController.js
+++ b/backend/controllers/googleCalendarController.js
@@ -1,0 +1,187 @@
+const crypto = require("crypto");
+const GoogleCalendarToken = require("../models/GoogleCalendarToken");
+const GoogleCalendarAuthState = require("../models/GoogleCalendarAuthState");
+const { encrypt, decrypt } = require("../utils/encryption");
+const googleCalendar = require("../utils/googleCalendar");
+
+const FRONTEND_URL = process.env.FRONTEND_ORIGIN || "http://localhost:5173";
+
+/**
+ * @desc Start the Google OAuth2 flow
+ * @route GET /api/google-calendar/connect
+ * @access Private
+ */
+const connectGoogleCalendar = async (req, res) => {
+  if (!googleCalendar.isConfigured()) {
+    return res.status(400).json({
+      success: false,
+      message: "Google Calendar integration is not configured",
+    });
+  }
+
+  try {
+    const state = crypto.randomBytes(24).toString("hex");
+    await GoogleCalendarAuthState.create({ state, userId: req.user._id });
+
+    const redirectUri = googleCalendar.getRedirectUri(req);
+    const authUrl = googleCalendar.buildAuthUrl(state, redirectUri);
+
+    return res.status(200).json({ success: true, authUrl });
+  } catch (error) {
+    console.error("Failed to start Google Calendar connect:", error.message);
+    return res.status(500).json({
+      success: false,
+      message: "Unable to connect Google Calendar",
+    });
+  }
+};
+
+/**
+ * @desc Exchange the OAuth code, persist the refresh token, and return
+ *       the user to the app
+ * @route GET /api/google-calendar/callback
+ * @access Public (OAuth redirect target)
+ */
+const googleCalendarCallback = async (req, res) => {
+  const { code, state } = req.query;
+
+  if (!code || !state) {
+    return res.redirect(FRONTEND_URL);
+  }
+
+  try {
+    const authState = await GoogleCalendarAuthState.findOne({ state });
+    if (!authState) {
+      return res.redirect(FRONTEND_URL);
+    }
+
+    const redirectUri = googleCalendar.getRedirectUri(req);
+    const tokens = await googleCalendar.exchangeCode(code, redirectUri);
+    if (!tokens.refresh_token) {
+      return res.redirect(FRONTEND_URL);
+    }
+
+    const userInfo = await googleCalendar.getGoogleUserInfo(tokens.access_token);
+
+    await GoogleCalendarToken.findOneAndUpdate(
+      { userId: authState.userId },
+      {
+        userId: authState.userId,
+        refreshTokenEnc: encrypt(tokens.refresh_token),
+        email: userInfo.email || "",
+      },
+      { upsert: true, new: true },
+    );
+
+    await GoogleCalendarAuthState.deleteOne({ _id: authState._id });
+
+    return res.redirect(FRONTEND_URL);
+  } catch (error) {
+    console.error("Google Calendar callback failed:", error.message);
+    return res.redirect(FRONTEND_URL);
+  }
+};
+
+/**
+ * @desc Report whether the user's Google Calendar is linked
+ * @route GET /api/google-calendar/status
+ * @access Private
+ */
+const getGoogleCalendarStatus = async (req, res) => {
+  if (!googleCalendar.isConfigured()) {
+    return res.status(200).json({
+      success: false,
+      connected: false,
+      message: "Google Calendar integration is not configured",
+    });
+  }
+
+  try {
+    const tokenDoc = await GoogleCalendarToken.findOne({
+      userId: req.user._id,
+    });
+
+    if (!tokenDoc) {
+      return res.status(200).json({
+        success: true,
+        connected: false,
+        email: null,
+      });
+    }
+
+    return res.status(200).json({
+      success: true,
+      connected: true,
+      email: tokenDoc.email,
+    });
+  } catch (error) {
+    console.error("Failed to load Google Calendar status:", error.message);
+    return res.status(500).json({
+      success: false,
+      message: "Unable to load Google Calendar status",
+    });
+  }
+};
+
+/**
+ * @desc Create a calendar event from the interview prep session
+ * @route POST /api/google-calendar/events
+ * @access Private
+ */
+const createGoogleCalendarEvent = async (req, res) => {
+  if (!googleCalendar.isConfigured()) {
+    return res.status(400).json({
+      success: false,
+      message: "Google Calendar integration is not configured",
+    });
+  }
+
+  try {
+    const tokenDoc = await GoogleCalendarToken.findOne({
+      userId: req.user._id,
+    });
+    if (!tokenDoc) {
+      return res.status(400).json({
+        success: false,
+        message: "Google Calendar is not connected",
+      });
+    }
+
+    const accessToken = await googleCalendar.refreshAccessToken(
+      decrypt(tokenDoc.refreshTokenEnc),
+    );
+
+    const event = {
+      summary: req.body.title,
+      description: req.body.description || "",
+      start: { dateTime: req.body.startTime },
+      end: { dateTime: req.body.endTime },
+      reminders: {
+        useDefault: false,
+        overrides: [
+          { method: "popup", minutes: req.body.reminderMinutes ?? 15 },
+        ],
+      },
+    };
+
+    const createdEvent = await googleCalendar.createCalendarEvent(
+      accessToken,
+      event,
+    );
+
+    return res.status(201).json({ success: true, event: createdEvent });
+  } catch (error) {
+    console.error("Failed to sync Google Calendar event:", error.message);
+    return res.status(500).json({
+      success: false,
+      message: "Unable to sync Google Calendar event",
+    });
+  }
+};
+
+module.exports = {
+  connectGoogleCalendar,
+  googleCalendarCallback,
+  getGoogleCalendarStatus,
+  createGoogleCalendarEvent,
+};

--- a/backend/models/GoogleCalendarAuthState.js
+++ b/backend/models/GoogleCalendarAuthState.js
@@ -1,0 +1,28 @@
+const mongoose = require("mongoose");
+
+// Tracks in-flight OAuth2 connections so the /callback redirect (which cannot
+// carry an Authorization header) can resolve the connecting user securely.
+// State values are unguessable, single-use, and expire after 10 minutes.
+const googleCalendarAuthStateSchema = new mongoose.Schema({
+  state: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true,
+  },
+  userId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "User",
+    required: true,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    expires: 600, // TTL: 10 minutes
+  },
+});
+
+module.exports = mongoose.model(
+  "GoogleCalendarAuthState",
+  googleCalendarAuthStateSchema,
+);

--- a/backend/models/GoogleCalendarToken.js
+++ b/backend/models/GoogleCalendarToken.js
@@ -1,0 +1,29 @@
+const mongoose = require("mongoose");
+
+const googleCalendarTokenSchema = new mongoose.Schema(
+  {
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true,
+      unique: true,
+    },
+    // Google refresh token encrypted with AES-256-GCM
+    // (see backend/utils/encryption.js). Never store it in plain text.
+    refreshTokenEnc: {
+      type: String,
+      required: true,
+    },
+    email: {
+      type: String,
+      trim: true,
+      default: "",
+    },
+  },
+  { timestamps: true },
+);
+
+module.exports = mongoose.model(
+  "GoogleCalendarToken",
+  googleCalendarTokenSchema,
+);

--- a/backend/routes/googleCalendarRoutes.js
+++ b/backend/routes/googleCalendarRoutes.js
@@ -1,0 +1,26 @@
+const express = require("express");
+const router = express.Router();
+const { protect } = require("../middlewares/authMiddleware");
+const {
+  validateCreateGoogleCalendarEvent,
+} = require("../Input_validators/ValidateGoogleCalendar");
+const {
+  connectGoogleCalendar,
+  googleCalendarCallback,
+  getGoogleCalendarStatus,
+  createGoogleCalendarEvent,
+} = require("../controllers/googleCalendarController");
+
+// The callback is a browser redirect from Google, so it cannot carry a Bearer
+// header; the connecting user is resolved via the single-use OAuth state.
+router.get("/connect", protect, connectGoogleCalendar);
+router.get("/callback", googleCalendarCallback);
+router.get("/status", protect, getGoogleCalendarStatus);
+router.post(
+  "/events",
+  protect,
+  validateCreateGoogleCalendarEvent,
+  createGoogleCalendarEvent,
+);
+
+module.exports = router;

--- a/backend/server.js
+++ b/backend/server.js
@@ -159,6 +159,8 @@ const roadmapRoutes = require("./routes/roadmapRoutes");
 app.use("/api/roadmaps", roadmapRoutes);
 const interviewExperienceRoutes = require("./routes/interviewExperienceRoutes");
 app.use("/api/interview-experiences", generalLimiter, interviewExperienceRoutes);
+const googleCalendarRoutes = require("./routes/googleCalendarRoutes");
+app.use("/api/google-calendar", generalLimiter, googleCalendarRoutes);
 
 
 app.use(

--- a/backend/tests/googleCalendarController.unit.test.js
+++ b/backend/tests/googleCalendarController.unit.test.js
@@ -1,0 +1,314 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const GoogleCalendarToken = require("../models/GoogleCalendarToken.js");
+const GoogleCalendarAuthState = require("../models/GoogleCalendarAuthState.js");
+const googleCalendar = require("../utils/googleCalendar.js");
+const { encrypt } = require("../utils/encryption.js");
+const {
+  connectGoogleCalendar,
+  googleCalendarCallback,
+  getGoogleCalendarStatus,
+  createGoogleCalendarEvent,
+} = require("../controllers/googleCalendarController.js");
+
+const USER_ID = "507f1f77bcf86cd799439011";
+const REDIRECT_URI = "https://backend.example/api/google-calendar/callback";
+
+function makeReq(body = {}, params = {}, query = {}, user = { _id: USER_ID }) {
+  return {
+    body,
+    params,
+    query,
+    user,
+    protocol: "https",
+    get: () => "backend.example",
+  };
+}
+
+function makeRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  res.redirect = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+describe("connectGoogleCalendar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    googleCalendar.isConfigured = vi.fn(() => true);
+    googleCalendar.getRedirectUri = vi.fn(() => REDIRECT_URI);
+    googleCalendar.buildAuthUrl = vi.fn(
+      (state) => `https://accounts.google.com/o/oauth2/v2/auth?state=${state}`,
+    );
+  });
+
+  it("stores a single-use state and returns an OAuth auth URL", async () => {
+    GoogleCalendarAuthState.create = vi.fn().mockResolvedValue({});
+    const res = makeRes();
+
+    await connectGoogleCalendar(makeReq(), res);
+
+    expect(GoogleCalendarAuthState.create).toHaveBeenCalledWith({
+      state: expect.any(String),
+      userId: USER_ID,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        authUrl: expect.stringContaining("state="),
+      }),
+    );
+  });
+
+  it("rejects connect when the integration is not configured", async () => {
+    googleCalendar.isConfigured = vi.fn(() => false);
+    GoogleCalendarAuthState.create = vi.fn();
+    const res = makeRes();
+
+    await connectGoogleCalendar(makeReq(), res);
+
+    expect(GoogleCalendarAuthState.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  it("returns 500 when the state cannot be persisted", async () => {
+    GoogleCalendarAuthState.create = vi
+      .fn()
+      .mockRejectedValue(new Error("db down"));
+    const res = makeRes();
+
+    await connectGoogleCalendar(makeReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+});
+
+describe("googleCalendarCallback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    googleCalendar.getRedirectUri = vi.fn(() => REDIRECT_URI);
+    googleCalendar.exchangeCode = vi.fn(async () => ({
+      access_token: "access-token-123",
+      refresh_token: "refresh-token-123",
+    }));
+    googleCalendar.getGoogleUserInfo = vi.fn(async () => ({
+      email: "user@example.com",
+    }));
+  });
+
+  it("exchanges the code and persists the encrypted refresh token", async () => {
+    GoogleCalendarAuthState.findOne = vi.fn().mockResolvedValue({
+      _id: "state-doc-id",
+      userId: USER_ID,
+    });
+    GoogleCalendarToken.findOneAndUpdate = vi.fn().mockResolvedValue({});
+    GoogleCalendarAuthState.deleteOne = vi.fn().mockResolvedValue({});
+    const res = makeRes();
+
+    await googleCalendarCallback(
+      makeReq({}, {}, { code: "oauth-code", state: "state-123" }),
+      res,
+    );
+
+    expect(googleCalendar.exchangeCode).toHaveBeenCalledWith(
+      "oauth-code",
+      REDIRECT_URI,
+    );
+    expect(GoogleCalendarToken.findOneAndUpdate).toHaveBeenCalledWith(
+      { userId: USER_ID },
+      expect.objectContaining({
+        userId: USER_ID,
+        refreshTokenEnc: expect.any(String),
+        email: "user@example.com",
+      }),
+      { upsert: true, new: true },
+    );
+    const storedToken =
+      GoogleCalendarToken.findOneAndUpdate.mock.calls[0][1].refreshTokenEnc;
+    expect(storedToken).not.toBe("refresh-token-123");
+    expect(GoogleCalendarAuthState.deleteOne).toHaveBeenCalledWith({
+      _id: "state-doc-id",
+    });
+    expect(res.redirect).toHaveBeenCalledWith("http://localhost:5173");
+  });
+
+  it("redirects to the app without persisting when code/state are missing", async () => {
+    GoogleCalendarAuthState.findOne = vi.fn();
+    GoogleCalendarToken.findOneAndUpdate = vi.fn();
+    const res = makeRes();
+
+    await googleCalendarCallback(makeReq({}, {}, {}), res);
+
+    expect(GoogleCalendarAuthState.findOne).not.toHaveBeenCalled();
+    expect(GoogleCalendarToken.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith("http://localhost:5173");
+  });
+
+  it("redirects to the app when the state is unknown or expired", async () => {
+    GoogleCalendarAuthState.findOne = vi.fn().mockResolvedValue(null);
+    GoogleCalendarToken.findOneAndUpdate = vi.fn();
+    const res = makeRes();
+
+    await googleCalendarCallback(
+      makeReq({}, {}, { code: "oauth-code", state: "unknown" }),
+      res,
+    );
+
+    expect(GoogleCalendarToken.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith("http://localhost:5173");
+  });
+});
+
+describe("getGoogleCalendarStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    googleCalendar.isConfigured = vi.fn(() => true);
+  });
+
+  it("reports not connected when the user has no stored token", async () => {
+    GoogleCalendarToken.findOne = vi.fn().mockResolvedValue(null);
+    const res = makeRes();
+
+    await getGoogleCalendarStatus(makeReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      connected: false,
+      email: null,
+    });
+  });
+
+  it("reports the linked account when a token exists", async () => {
+    GoogleCalendarToken.findOne = vi.fn().mockResolvedValue({
+      email: "user@example.com",
+    });
+    const res = makeRes();
+
+    await getGoogleCalendarStatus(makeReq(), res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      success: true,
+      connected: true,
+      email: "user@example.com",
+    });
+  });
+
+  it("reports the feature as disabled when not configured", async () => {
+    googleCalendar.isConfigured = vi.fn(() => false);
+    GoogleCalendarToken.findOne = vi.fn();
+    const res = makeRes();
+
+    await getGoogleCalendarStatus(makeReq(), res);
+
+    expect(GoogleCalendarToken.findOne).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, connected: false }),
+    );
+  });
+});
+
+describe("createGoogleCalendarEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    googleCalendar.isConfigured = vi.fn(() => true);
+    googleCalendar.refreshAccessToken = vi.fn(async () => "access-token-123");
+    googleCalendar.createCalendarEvent = vi.fn(async (_accessToken, event) => ({
+      id: "event-123",
+      ...event,
+    }));
+  });
+
+  it("rejects the sync when the calendar is not connected", async () => {
+    GoogleCalendarToken.findOne = vi.fn().mockResolvedValue(null);
+    const res = makeRes();
+
+    await createGoogleCalendarEvent(
+      makeReq({
+        title: "Interview practice",
+        startTime: "2026-08-11T10:00:00.000Z",
+        endTime: "2026-08-11T11:00:00.000Z",
+      }),
+      res,
+    );
+
+    expect(googleCalendar.createCalendarEvent).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+
+  it("creates a calendar event with the mapped payload", async () => {
+    GoogleCalendarToken.findOne = vi.fn().mockResolvedValue({
+      refreshTokenEnc: encrypt("refresh-token-123"),
+    });
+    const res = makeRes();
+
+    await createGoogleCalendarEvent(
+      makeReq({
+        title: "Interview practice",
+        description: "PrepPilot session",
+        startTime: "2026-08-11T10:00:00.000Z",
+        endTime: "2026-08-11T11:00:00.000Z",
+        reminderMinutes: 15,
+      }),
+      res,
+    );
+
+    expect(googleCalendar.refreshAccessToken).toHaveBeenCalledWith(
+      "refresh-token-123",
+    );
+    expect(googleCalendar.createCalendarEvent).toHaveBeenCalledWith(
+      "access-token-123",
+      {
+        summary: "Interview practice",
+        description: "PrepPilot session",
+        start: { dateTime: "2026-08-11T10:00:00.000Z" },
+        end: { dateTime: "2026-08-11T11:00:00.000Z" },
+        reminders: {
+          useDefault: false,
+          overrides: [{ method: "popup", minutes: 15 }],
+        },
+      },
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, event: expect.any(Object) }),
+    );
+  });
+
+  it("returns 500 when the Calendar API call fails", async () => {
+    GoogleCalendarToken.findOne = vi.fn().mockResolvedValue({
+      refreshTokenEnc: encrypt("refresh-token-123"),
+    });
+    googleCalendar.refreshAccessToken = vi
+      .fn()
+      .mockRejectedValue(new Error("token refresh failed"));
+    const res = makeRes();
+
+    await createGoogleCalendarEvent(
+      makeReq({
+        title: "Interview practice",
+        startTime: "2026-08-11T10:00:00.000Z",
+        endTime: "2026-08-11T11:00:00.000Z",
+      }),
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false }),
+    );
+  });
+});

--- a/backend/utils/encryption.js
+++ b/backend/utils/encryption.js
@@ -1,0 +1,38 @@
+const crypto = require("crypto");
+
+// Google refresh tokens are long-lived credentials, so they are encrypted at
+// rest with AES-256-GCM before being persisted. The key is derived from the
+// GOOGLE_CALENDAR_ENCRYPTION_KEY secret so any strong random string works.
+const getEncryptionKey = () => {
+  const secret =
+    process.env.GOOGLE_CALENDAR_ENCRYPTION_KEY || "preppilot-google-calendar";
+  return crypto.createHash("sha256").update(secret).digest();
+};
+
+const encrypt = (plaintext) => {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", getEncryptionKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(String(plaintext), "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return `${iv.toString("base64")}:${tag.toString("base64")}:${ciphertext.toString("base64")}`;
+};
+
+const decrypt = (token) => {
+  const [iv, tag, data] = String(token).split(":");
+  const decipher = crypto.createDecipheriv(
+    "aes-256-gcm",
+    getEncryptionKey(),
+    Buffer.from(iv, "base64"),
+  );
+  decipher.setAuthTag(Buffer.from(tag, "base64"));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(data, "base64")),
+    decipher.final(),
+  ]);
+  return plaintext.toString("utf8");
+};
+
+module.exports = { encrypt, decrypt };

--- a/backend/utils/googleCalendar.js
+++ b/backend/utils/googleCalendar.js
@@ -1,0 +1,96 @@
+const axios = require("axios");
+
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+const GOOGLE_CALENDAR_EVENTS_URL =
+  "https://www.googleapis.com/calendar/v3/calendars/primary/events";
+
+const GOOGLE_CALENDAR_SCOPE = "https://www.googleapis.com/auth/calendar.events";
+
+// The feature is opt-in: without the OAuth credentials and an encryption key
+// for the refresh token, every endpoint reports the integration as disabled.
+const isConfigured = () =>
+  Boolean(
+    process.env.GOOGLE_CLIENT_ID &&
+      process.env.GOOGLE_CLIENT_SECRET &&
+      process.env.GOOGLE_CALENDAR_ENCRYPTION_KEY,
+  );
+
+// The redirect URI must exactly match the one authorized in the Google Cloud
+// Console. Prefer an explicit callback URL, then BASE_URL, then the request
+// host as a last resort.
+const getRedirectUri = (req) =>
+  process.env.GOOGLE_CALENDAR_CALLBACK_URL ||
+  `${
+    process.env.BASE_URL || `${req.protocol}://${req.get("host")}`
+  }/api/google-calendar/callback`;
+
+const buildAuthUrl = (state, redirectUri) => {
+  const params = new URLSearchParams({
+    client_id: process.env.GOOGLE_CLIENT_ID,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: GOOGLE_CALENDAR_SCOPE,
+    access_type: "offline",
+    prompt: "consent",
+    state,
+  });
+  return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+};
+
+const exchangeCode = async (code, redirectUri) => {
+  const { data } = await axios.post(
+    GOOGLE_TOKEN_URL,
+    new URLSearchParams({
+      code,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: redirectUri,
+      grant_type: "authorization_code",
+    }),
+    { headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+  );
+  return data;
+};
+
+const refreshAccessToken = async (refreshToken) => {
+  const { data } = await axios.post(
+    GOOGLE_TOKEN_URL,
+    new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: process.env.GOOGLE_CLIENT_ID,
+      client_secret: process.env.GOOGLE_CLIENT_SECRET,
+      grant_type: "refresh_token",
+    }),
+    { headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+  );
+  return data.access_token;
+};
+
+const getGoogleUserInfo = async (accessToken) => {
+  const { data } = await axios.get(GOOGLE_USERINFO_URL, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  return data;
+};
+
+const createCalendarEvent = async (accessToken, event) => {
+  const { data } = await axios.post(GOOGLE_CALENDAR_EVENTS_URL, event, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+  });
+  return data;
+};
+
+module.exports = {
+  isConfigured,
+  getRedirectUri,
+  buildAuthUrl,
+  exchangeCode,
+  refreshAccessToken,
+  getGoogleUserInfo,
+  createCalendarEvent,
+};


### PR DESCRIPTION
## Problem

The Interview Prep page ships Google Calendar connect/sync functionality in the frontend, but the backend has no `/api/google-calendar/*` routes at all. Every calendar action fails:

- `frontend/src/utils/apiPaths.js` defines `GOOGLE_CALENDAR.CONNECT` (`GET /api/google-calendar/connect`), `CALLBACK`, `STATUS`, and `EVENTS` (`POST /api/google-calendar/events`).
- `frontend/src/pages/InterviewPrep/InterviewPrep.jsx` calls `/status` on every page load, `/connect` when the user clicks "Connect your Google Calendar", and `/events` to sync.
- Express returns its default 404 HTML body for each of these, so `/status` logs `Calendar status error` on every visit, Connect shows "Unable to connect Google Calendar", Sync shows "Unable to sync Google Calendar event", and the calendar banner is permanently stuck in the empty "Connect" state.

## Fix

Added the missing backend implementation (multi-file):

- `backend/routes/googleCalendarRoutes.js` — `GET /connect`, `GET /callback`, `GET /status`, and `POST /events`, mounted at `/api/google-calendar` with `generalLimiter` and `protect` on the authed routes. `POST /events` matches the route the current frontend calls (`GOOGLE_CALENDAR.EVENTS`).
- `backend/controllers/googleCalendarController.js` — OAuth2 flow: `connect` generates a single-use unguessable state and returns the Google auth URL; `callback` exchanges the code, stores the refresh token encrypted per user, and redirects back to the app; `status` reports whether the account is linked (and which email); `events` refreshes the access token and creates a calendar event for the session.
- `backend/models/GoogleCalendarToken.js` — per-user encrypted refresh token storage (user-scoped).
- `backend/models/GoogleCalendarAuthState.js` — single-use OAuth state mapping with a 10-minute TTL so the callback (which cannot carry a Bearer header) resolves the connecting user securely.
- `backend/utils/googleCalendar.js` — minimal OAuth2 + Calendar API client (auth URL, code exchange, token refresh, user info, event creation) using the already-available `axios`, scoped to `https://www.googleapis.com/auth/calendar.events`.
- `backend/utils/encryption.js` — AES-256-GCM encryption for the stored Google refresh token.
- `backend/Input_validators/ValidateGoogleCalendar.js` — Zod validation for the event payload (title, description, ISO start/end times, reminder minutes).
- `backend/server.js` — mounts `app.use("/api/google-calendar", generalLimiter, googleCalendarRoutes)`.
- `backend/config/validateEnv.js` and `backend/.env.example` — document the optional `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_CALENDAR_ENCRYPTION_KEY`, and `GOOGLE_CALENDAR_CALLBACK_URL` env vars; when they are missing the integration reports itself as disabled instead of 404ing.

## Files changed

- `backend/server.js`
- `backend/routes/googleCalendarRoutes.js`
- `backend/controllers/googleCalendarController.js`
- `backend/models/GoogleCalendarToken.js`
- `backend/models/GoogleCalendarAuthState.js`
- `backend/utils/googleCalendar.js`
- `backend/utils/encryption.js`
- `backend/Input_validators/ValidateGoogleCalendar.js`
- `backend/tests/googleCalendarController.unit.test.js`
- `backend/config/validateEnv.js`
- `backend/.env.example`

## Testing

- Added `backend/tests/googleCalendarController.unit.test.js` (12 tests) covering connect (auth URL + state persistence), callback (code exchange, encrypted token storage, redirects), status (connected/not connected/disabled), and event creation (mapped payload, not-connected rejection, API failure).
- Ran `cd backend && npm test`: the new tests and all existing tests pass except the pre-existing `jobCache.boundedKeys` failures that also fail on clean `origin/main` and are unrelated to this change.
- Verified the auth URL builder, encryption round-trip, and the Zod event validator directly with Node.

Closes #1793


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->