### PR TITLE
fix : added max length guard on name and profileImageUrl in ValidateAuth

### DIFF
--- a/backend/Input_validators/ValidateAuth.js
+++ b/backend/Input_validators/ValidateAuth.js
@@ -4,7 +4,7 @@ const { handleValidationError } = require("./ValidateQuestions");
 // ── Schemas ───────────────────────────────────────────────
 
 const registerUserZod = z.object({
-  name: z.string().min(4, "Name must be at least 4 characters").trim(),
+  name: z.string().min(4, "Name must be at least 4 characters").max(80, "Name cannot exceed 80 characters").trim(),
   email: z.string().email("Enter a valid email").trim(),
   password: z
     .string()
@@ -13,7 +13,7 @@ const registerUserZod = z.object({
     .regex(/[a-z]/, "Password must contain at least one lowercase letter")
     .regex(/[0-9]/, "Password must contain at least one number")
     .regex(/[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?`~]/, "Password must contain at least one special character"),
-  profileImageUrl: z.string().url("Enter a valid URL").trim().optional().or(z.literal("")),
+  profileImageUrl: z.string().url("Enter a valid URL").max(500, "Profile image URL cannot exceed 500 characters").trim().optional().or(z.literal("")),
 });
 
 const loginUserZod = z.object({


### PR DESCRIPTION
## Summary of What Has Been Done
Added max length validation on the `name` and `profileImageUrl` fields in `ValidateAuth.js`.

## Changes Made
- `backend/Input_validators/ValidateAuth.js`: Added `.max(80)` to the `name` field and `.max(500)` to `profileImageUrl`.

## Impact it Made
Prevents clients from submitting excessively long names or profile image URLs.

Closes #1839

Note: Please assign this PR to the `tmdeveloper007` account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->