### PR TITLE
fix : added max length guard on compileResume code field in ValidateResume

### DIFF
--- a/backend/Input_validators/ValidateResume.js
+++ b/backend/Input_validators/ValidateResume.js
@@ -5,7 +5,7 @@ const mongoose = require("mongoose");
 // ── Schemas ───────────────────────────────────────────────────────────────────
 
 const compileResumeSchema = z.object({
-  code: z.string({ required_error: "LaTeX code is required" }).min(1, "LaTeX code is required"),
+  code: z.string({ required_error: "LaTeX code is required" }).min(1, "LaTeX code is required").max(50000, "LaTeX code cannot exceed 50000 characters"),
 });
 
 const analyzeResumeSchema = z.object({


### PR DESCRIPTION
## Summary of What Has Been Done
Added max length validation (50,000 characters) on the `code` field in `compileResumeSchema` in `ValidateResume.js`.

## Changes Made
- `backend/Input_validators/ValidateResume.js`: Added `.max(50000)` to `compileResumeSchema.code`.

## Impact it Made
Prevents clients from submitting extremely large LaTeX documents.

Closes #1840

Note: Please assign this PR to the `tmdeveloper007` account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds a 50,000-character maximum to `compileResumeSchema.code`. The validator now rejects oversized LaTeX input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->