### PR TITLE
fix : added max length guards on role, company, description and topicsToFocus in ValidateSession

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -10,11 +10,11 @@ const objectId = (label) =>
 
 // Schema for creating a session
 const createSessionSchema = z.object({
-  role: z.string().min(1, "Role is required"),
-  company: z.string().min(1, "Company is required"),
+  role: z.string().min(1, "Role is required").max(120, "Role cannot exceed 120 characters"),
+  company: z.string().min(1, "Company is required").max(120, "Company cannot exceed 120 characters"),
   experience: z.string().min(1, "Experience is required").max(100, "Experience cannot exceed 100 characters"),
-  topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
-  description: z.string().optional(),
+  topicsToFocus: z.array(z.string().max(100, "Topic cannot exceed 100 characters")).min(1, "At least one topic is required"),
+  description: z.string().max(2000, "Description cannot exceed 2000 characters").optional(),
   question: z.array(
     z.object({
       question: z.string().min(1, "Question text is required"),


### PR DESCRIPTION
## Summary of What Has Been Done
Added max length validation on `role`, `company`, `description`, and `topicsToFocus` array items in `ValidateSession.js`.

## Changes Made
- `backend/Input_validators/ValidateSession.js`: Added `.max(120)` on `role` and `company`, `.max(2000)` on `description`, and `.max(100)` on `topicsToFocus` items.

## Impact it Made
Prevents clients from sending arbitrarily long session metadata strings.

Closes #1841

Note: Please assign this PR to the `tmdeveloper007` account.
