### PR TITLE
fix : added max length guard on question and answer in ValidateSession create schema

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -17,8 +17,8 @@ const createSessionSchema = z.object({
   description: z.string().optional(),
   question: z.array(
     z.object({
-      question: z.string().min(1, "Question text is required"),
-      answer: z.string().min(1, "Answer text is required"),
+      question: z.string().min(1, "Question text is required").max(5000, "Question text cannot exceed 5000 characters"),
+      answer: z.string().min(1, "Answer text is required").max(10000, "Answer text cannot exceed 10000 characters"),
     })
   ).max(50, "Maximum 50 questions allowed").optional(),
 });


### PR DESCRIPTION
## Summary of What Has Been Done
Added max length validation on `question` and `answer` string fields inside the `question` array in `ValidateSession.js`.

## Changes Made
- `backend/Input_validators/ValidateSession.js`: Added `.max(5000)` on `question` and `.max(10000)` on `answer`.

## Impact it Made
Prevents clients from submitting very long question/answer text, consistent with `ValidateQuestions.js`.

Closes #1842

Note: Please assign this PR to the `tmdeveloper007` account.
