### PR TITLE
fix : bound job cache keys with normalized role and country

### DIFF
--- a/backend/controllers/jobController.js
+++ b/backend/controllers/jobController.js
@@ -76,23 +76,26 @@ exports.getJobs = async (req, res) => {
       .select("role");
 
     const role = req.query.role || latestSession?.role || "software engineer";
-    const country = (req.query.country || ADZUNA_COUNTRY).toLowerCase().trim();
+    const country = req.query.country || ADZUNA_COUNTRY;
+
+    const normalizedRole = normalizeRole(role);
+    const normalizedCountry = normalizeCountry(country);
 
     // Validate country against supported Adzuna codes
-    if (!ALLOWED_ADZUNA_COUNTRIES.includes(country)) {
+    if (!ALLOWED_ADZUNA_COUNTRIES.includes(normalizedCountry)) {
       return res.status(400).json({
-        message: `Invalid or unsupported country parameter '${country}'. Supported country codes are: ${ALLOWED_ADZUNA_COUNTRIES.join(", ")}`,
+        message: `Invalid or unsupported country parameter '${normalizedCountry}'. Supported country codes are: ${ALLOWED_ADZUNA_COUNTRIES.join(", ")}`,
       });
     }
 
-    const cacheKey = `${role.toLowerCase()}|${country}`;
+    const cacheKey = `${normalizedRole || "software engineer"}|${normalizedCountry}`;
 
     const cached = await JobCache.findOne({ cacheKey });
     if (cached && Date.now() - cached.fetchedAt.getTime() < CACHE_TTL_MS) {
-      return res.json({ jobs: cached.jobs, role, source: "cache" });
+      return res.json({ jobs: cached.jobs, role: normalizedRole || "software engineer", source: "cache" });
     }
 
-    const jobs = await fetchFromAdzuna(role, country);
+    const jobs = await fetchFromAdzuna(normalizedRole || "software engineer", normalizedCountry);
 
     await JobCache.findOneAndUpdate(
       { cacheKey },


### PR DESCRIPTION
## Summary of What Has Been Done
Applied the existing `normalizeRole()` and `normalizeCountry()` helpers to the incoming `role` and `country` query parameters in `getJobs` before building the cache key and calling the Adzuna API. When `normalizeRole` returns empty string (indicating an invalid/over-length/injection payload), the code falls back to `"software engineer"` before calling the API.

## Changes Made
- `backend/controllers/jobController.js`:
  - Apply `normalizeRole(role)` before building the cache key; use the result (with fallback) in API calls and response.
  - Apply `normalizeCountry(country)` before the existing whitelist check; reorder the check so invalid country never reaches the cache key.
  - Return the normalized role (with fallback) in API responses on both cache hit and miss paths.

## Impact it Made
- Prevents cache key injection via role parameters (e.g. `admin|*` or `x...x|;;DROP TABLE`).
- Fixes all 4 failing tests in `backend/tests/jobCache.boundedKeys.unit.test.js`.
- Aligns `getJobs` behavior with the caching strategy already used in `refreshJobCache`.

## Note: Please assign this PR to the `tmdeveloper007` account.
Closes #1848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Normalizes `role` and `country` before validation, cache-key creation, and Adzuna API requests.
- Prevents unbounded cache-key diversity and cache-key injection.
- Uses `"software engineer"` as the fallback role when normalization returns an empty or invalid value.
- Returns the normalized role for cache hits and API responses.
- Fixes four bounded-cache-key tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->