### PR TITLE
fix : added max length guards on session role and company fields

### DIFF
--- a/backend/Input_validators/ValidateSession.js
+++ b/backend/Input_validators/ValidateSession.js
@@ -10,8 +10,8 @@ const objectId = (label) =>
 
 // Schema for creating a session
 const createSessionSchema = z.object({
-  role: z.string().min(1, "Role is required"),
-  company: z.string().min(1, "Company is required"),
+  role: z.string().min(1, "Role is required").max(120, "Role cannot exceed 120 characters"),
+  company: z.string().min(1, "Company is required").max(120, "Company cannot exceed 120 characters"),
   experience: z.string().min(1, "Experience is required").max(100, "Experience cannot exceed 100 characters"),
   topicsToFocus: z.array(z.string()).min(1, "At least one topic is required"),
   description: z.string().optional(),


### PR DESCRIPTION
## Summary of What Has Been Done
Added `.max(120)` length guards to the `role` and `company` string fields in `createSessionSchema` within `backend/Input_validators/ValidateSession.js`. Both fields previously had only a `.min(1)` constraint, allowing arbitrarily long strings to flow into the `Session` collection.

## Changes Made
- `backend/Input_validators/ValidateSession.js`:
  - `role`: added `.max(120, "Role cannot exceed 120 characters")` (matching the max already used on role in `ValidateInterviewExperience.js`).
  - `company`: added `.max(120, "Company cannot exceed 120 characters")` (matching the max already used on company in `ValidateInterviewExperience.js`).

## Impact it Made
- Prevents excessively long `role` or `company` strings from being stored in the `Session` collection.
- Maintains consistency with other validators in the codebase that already apply max length guards.

## Note: Please assign this PR to the `tmdeveloper007` account.
Closes #1850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds 120-character maximum validation to the `role` and `company` fields in `createSessionSchema`. Retains the existing required-field validation and aligns the fields with related validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->