### PR TITLE
fix : added max length guards on notes summary URL fields

### DIFF
--- a/backend/Input_validators/ValidateNotesSummary.js
+++ b/backend/Input_validators/ValidateNotesSummary.js
@@ -20,7 +20,7 @@ const readingTimeSchema = z.object({
 
 
 const summarizeRequestSchema = z.object({
-  url: z.string().url("Provide a valid PDF URL").optional(),
+  url: z.string().url("Provide a valid PDF URL").max(2048).optional(),
   fileName: z.string().max(200).optional(),
 });
 
@@ -58,7 +58,7 @@ const aiOutputSchema = z.object({
 const saveNotesSummarySchema = z.object({
   fileName: z.string().min(1).max(200),
   sourceType: z.enum(["upload", "platform"]),
-  sourceUrl: z.string().url().optional().nullable(),
+  sourceUrl: z.string().url().max(2048).optional().nullable(),
   pageCount: z.number().int().nonnegative().optional().default(0),
   wordCount: z.number().int().nonnegative().optional().default(0),
   contentHash: z.string().max(128).optional().nullable(),


### PR DESCRIPTION
## Summary of What Has Been Done
Added `.max(2048)` length guards to the `url` field in `summarizeRequestSchema` and the `sourceUrl` field in `saveNotesSummarySchema` within `backend/Input_validators/ValidateNotesSummary.js`. Both fields previously had no max length, allowing arbitrarily long URL strings (e.g. from maliciously long query parameters) to flow into MongoDB.

## Changes Made
- `backend/Input_validators/ValidateNotesSummary.js`:
  - `summarizeRequestSchema.url`: added `.max(2048)` before `.optional()`.
  - `saveNotesSummarySchema.sourceUrl`: added `.max(2048)` before `.optional().nullable()`.

## Impact it Made
- Prevents excessively long URL strings from being stored in the `NotesSummary` collection.
- 2048 characters is the standard max URL length supported by most web servers and proxies.

## Note: Please assign this PR to the `tmdeveloper007` account.
Closes #1851