### PR TITLE
[Bug]: Copy Rewrite buttons do not copy suggestions

### DIFF
--- a/frontend/src/pages/ResumeBulletEnhancer/ResumeBulletEnhancer.jsx
+++ b/frontend/src/pages/ResumeBulletEnhancer/ResumeBulletEnhancer.jsx
@@ -271,10 +271,11 @@ const ResumeBulletEnhancer = () => {
 
                 </p>
 
-                <button className="mt-6 px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-700 text-white font-semibold">
-
-                  Copy Rewrite
-
+                <button
+                 onClick={() => navigator.clipboard.writeText(text)}
+                className="mt-6 px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-700 text-white font-semibold"
+                >
+                Copy Rewrite
                 </button>
 
               </div>

--- a/frontend/src/pages/ResumeBulletEnhancer/ResumeBulletEnhancer.jsx
+++ b/frontend/src/pages/ResumeBulletEnhancer/ResumeBulletEnhancer.jsx
@@ -272,10 +272,20 @@ const ResumeBulletEnhancer = () => {
                 </p>
 
                 <button
-                 onClick={() => navigator.clipboard.writeText(text)}
-                className="mt-6 px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-700 text-white font-semibold"
-                >
-                Copy Rewrite
+                    onClick={async () => {
+                      try {
+                      if (!navigator.clipboard) {
+                       throw new Error("Clipboard API unavailable");
+                        }
+
+                     await navigator.clipboard.writeText(text);
+                      } catch (error) {
+                         console.error("Failed to copy rewrite:", error);
+                          }
+                       }}
+                       className="mt-6 px-5 py-3 rounded-xl bg-violet-600 hover:bg-violet-700 text-white font-semibold"
+                        >
+                       Copy Rewrite
                 </button>
 
               </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1924

### Summary
Implemented clipboard functionality for the "Copy Rewrite" buttons in the Resume Bullet Enhancer.

Each rewrite suggestion can now be copied directly to the clipboard by clicking its corresponding "Copy Rewrite" button.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
Describe the testing steps performed.
- Opened the Resume Bullet Enhancer page and navigated to the "AI Rewrite Suggestions" section.
- Clicked each "Copy Rewrite" button and verified that the corresponding suggestion was copied successfully to the clipboard.
- Pasted the copied content into a text editor to verify the correct rewrite was copied.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the “Copy Rewrite” buttons in the Resume Bullet Enhancer.
- Each button now copies its corresponding AI rewrite suggestion with `navigator.clipboard.writeText`.
- Added `try/catch` handling for unavailable or failed clipboard operations.
- Preserved the existing button labels and styling.
- Manually verified clipboard behavior for each button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->