### PR TITLE
fix(backend): scope interview experience idempotency dedup to author

### DIFF
--- a/backend/controllers/interviewExperienceController.js
+++ b/backend/controllers/interviewExperienceController.js
@@ -70,7 +70,17 @@ const createInterviewExperience = async (req, res) => {
       payload.color = `hsl(${(payload.company.charCodeAt(0) * 37) % 360}, 55%, 50%)`;
     }
 
-    const existing = await InterviewExperience.findOne({ idempotencyKey });
+    // Scope idempotency to the author so a re-used key only matches the same
+    // submitter — otherwise a different user/anonymous visitor re-using a key
+    // receives the first author's full submission and their own is lost.
+    const authorFilter = req.user?._id
+      ? { userId: req.user._id }
+      : { clientKey: payload.clientKey };
+
+    const existing = await InterviewExperience.findOne({
+      idempotencyKey,
+      ...authorFilter,
+    });
     if (existing) {
       return res.status(200).json({
         success: true,
@@ -87,11 +97,16 @@ const createInterviewExperience = async (req, res) => {
       experience: toClientShape(experience),
     });
   } catch (error) {
-    // Concurrent retry won the unique index race — return the first write.
+    // Concurrent retry won the unique index race — return the first write by
+    // the same author (scoped, not a global key lookup).
     if (error?.code === 11000 && req.body?.idempotencyKey) {
       try {
+        const raceAuthorFilter = req.user?._id
+          ? { userId: req.user._id }
+          : { clientKey: req.body?.clientKey };
         const existing = await InterviewExperience.findOne({
           idempotencyKey: req.body.idempotencyKey,
+          ...raceAuthorFilter,
         });
         if (existing) {
           return res.status(200).json({

--- a/backend/models/InterviewExperience.js
+++ b/backend/models/InterviewExperience.js
@@ -96,11 +96,23 @@ const interviewExperienceSchema = new mongoose.Schema(
 );
 
 interviewExperienceSchema.index(
-  { idempotencyKey: 1 },
+  { idempotencyKey: 1, userId: 1 },
   {
     unique: true,
     partialFilterExpression: {
       idempotencyKey: { $type: "string", $gt: "" },
+      userId: { $type: "objectId" },
+    },
+  },
+);
+
+interviewExperienceSchema.index(
+  { idempotencyKey: 1, clientKey: 1 },
+  {
+    unique: true,
+    partialFilterExpression: {
+      idempotencyKey: { $type: "string", $gt: "" },
+      clientKey: { $type: "string", $gt: "" },
     },
   },
 );

--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -164,6 +164,7 @@ describe("createInterviewExperience", () => {
 
     expect(InterviewExperience.findOne).toHaveBeenCalledWith({
       idempotencyKey: "submit-key-abc12345",
+      clientKey: "11111111-1111-4111-8111-111111111111",
     });
     expect(InterviewExperience.create).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(200);
@@ -175,6 +176,56 @@ describe("createInterviewExperience", () => {
         }),
       }),
     );
+  });
+
+  it("scopes the dedup to the authenticated user so a re-used key does not leak another author's submission", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
+    InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
+
+    const userA = { _id: "507f1f77bcf86cd799439011" };
+    const req = makeReq(
+      {
+        company: "Google",
+        role: "SDE-2",
+        summary: "Summary",
+        idempotencyKey: "shared-key-abc12345",
+      },
+      {},
+      {},
+      userA,
+    );
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "shared-key-abc12345",
+      userId: "507f1f77bcf86cd799439011",
+    });
+    expect(InterviewExperience.create).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it("isolates anonymous submissions by clientKey so different visitors with the same key both persist", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
+    InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
+
+    const req = makeReq({
+      company: "Google",
+      role: "SDE-2",
+      summary: "Summary",
+      clientKey: "22222222-2222-4222-8222-222222222222",
+      idempotencyKey: "shared-key-abc12345",
+    });
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "shared-key-abc12345",
+      clientKey: "22222222-2222-4222-8222-222222222222",
+    });
+    expect(InterviewExperience.create).toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What changed

`POST /api/interview-experiences` deduplicated submissions by `idempotencyKey` alone, with no scope to the author. Re-using a key returned the **first submitter's full submission** (`company`, `role`, `rounds`, `tips`, `summary`) and silently dropped the new author's content. The key is client-supplied and guessable (`submit-<timestamp>-<random>`), and the route is public with optional auth.

### Controller — `backend/controllers/interviewExperienceController.js`
Scope the dedup lookup to the author in both places:
- initial `findOne` (line ~73)
- the `11000` unique-index race branch

```js
const authorFilter = req.user?._id
  ? { userId: req.user._id }
  : { clientKey: payload.clientKey };

const existing = await InterviewExperience.findOne({
  idempotencyKey,
  ...authorFilter,
});
```

### Model — `backend/models/InterviewExperience.js`
Replaced the single `{ idempotencyKey: 1 }` unique partial index with **two compound partial unique indexes** so different authors can reuse a key without colliding:
- `{ idempotencyKey: 1, userId: 1 }` — partialFilter scoped to docs with an `objectId` `userId` (authenticated)
- `{ idempotencyKey: 1, clientKey: 1 }` — partialFilter scoped to docs with a string `clientKey` (anonymous)

The type-scoped partial filters ensure authenticated docs (with `clientKey = null`) don't collide on the clientKey index, and vice versa.

## Tests
Updated `backend/tests/interviewExperienceController.unit.test.js`:
- updated the existing retry test to assert the scoped `{ idempotencyKey, clientKey }` lookup
- added: authenticated user dedup scopes to `{ idempotencyKey, userId }` and a re-used key still creates the new author's submission
- added: anonymous submissions isolated by `clientKey` — different visitors with the same key both persist

All 15 tests pass (`npx vitest run tests/interviewExperienceController.unit.test.js`).

Closes #1795

---

_This PR was created by an AI agent (OpenHands) on behalf of @saidai-bhuvanesh._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updates interview experience idempotency handling to scope deduplication by authenticated `userId` or anonymous `clientKey`. Adds matching compound partial indexes and test coverage for author isolation and scoped retries. All 15 targeted tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->