### PR TITLE
test(progress): mock recordActivity in userSheetProgress unit test

### DIFF
--- a/backend/tests/userSheetProgressController.unit.test.js
+++ b/backend/tests/userSheetProgressController.unit.test.js
@@ -56,6 +56,13 @@ beforeAll(async () => {
     bulkWrite: modelMock.bulkWrite,
   });
 
+  // recordActivity (streakTracker) performs a real Mongoose query that
+  // throws without a DB connection, so stub it as a no-op so saveProgress
+  // reaches the success branch.
+  testDoubles.set("../utils/streakTracker", {
+    recordActivity: vi.fn().mockResolvedValue(null),
+  });
+
   const mod = await import("../controllers/userSheetProgressController.js");
   saveProgress = mod.saveProgress;
   getAllProgress = mod.getAllProgress;


### PR DESCRIPTION
Fixes the `build-and-test` CI job that is red on **every** open PrepPilot PR (e.g. #1414, #2166 and several `feat/*` branches).

> _This PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh._

## Root cause
`backend/tests/userSheetProgressController.unit.test.js` — the `saveProgress > upserts only the explicitly provided fields via findOneAndUpdate` test fails with:

```
AssertionError: expected { success: false, …(1) } to deeply equal { success: true, progress: { …(4) } }
```

The `saveProgress` controller is correct, but after a successful `findOneAndUpdate` it calls `recordActivity(userId)` from `utils/streakTracker`. `recordActivity` performs a real Mongoose `User.findById(userId)` query. The unit test only shims the `UserSheetProgress` model (not `User`/`streakTracker`), so the unmocked query throws, `saveProgress` hits its `catch` block, and it returns a 500 instead of the expected success body.

## Fix
Stub `../utils/streakTracker.recordActivity` as a no-op in the test's module-loader shim so the controller reaches the success branch. No production/controller code is changed.

## Verification
- The targeted test file: `16 passed (16)`
- Full backend suite: `14 test files, 171 tests — all passed` (no regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Stubs `streakTracker.recordActivity` in the `userSheetProgress` unit test to prevent database-dependent queries.

Verification passed:
- 16 targeted tests
- 171 backend tests across 14 files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->