### PR TITLE
fix: resolve CSRF token error during auth refresh

### DIFF
--- a/backend/middlewares/csrf.js
+++ b/backend/middlewares/csrf.js
@@ -1,0 +1,57 @@
+const { doubleCsrf } = require("csrf-csrf");
+
+const isProduction = process.env.NODE_ENV === "production";
+
+const {
+    generateCsrfToken,
+    validateRequest,
+} = doubleCsrf({
+    getSecret: () => {
+        const secret = process.env.CSRF_SECRET || process.env.JWT_SECRET || "preppilot_csrf_default_secret_key_32bytes";
+        return secret;
+    },
+
+    // PrepPilot authenticates API requests with JWTs and uses
+    // the refresh-token cookie for the refresh flow.
+    getSessionIdentifier: (req) => {
+        return req.cookies?.refreshToken || "anonymous";
+    },
+
+    cookieName: "csrfToken",
+
+    cookieOptions: {
+        httpOnly: true,
+        secure: isProduction,
+        sameSite: isProduction ? "none" : "lax",
+        path: "/api/auth",
+    },
+
+    getCsrfTokenFromRequest: (req) => {
+        return req.headers["x-csrf-token"];
+    },
+});
+
+const csrfProtection = (req, res, next) => {
+    try {
+        if (!validateRequest(req)) {
+            return res.status(403).json({
+                success: false,
+                message: "CSRF token missing or invalid.",
+            });
+        }
+
+        next();
+    } catch (error) {
+        console.error("CSRF validation error:", error);
+
+        return res.status(403).json({
+            success: false,
+            message: "CSRF token missing or invalid.",
+        });
+    }
+};
+
+module.exports = {
+    generateCsrfToken,
+    csrfProtection,
+};

--- a/backend/middlewares/csrfHeaderCheck.js
+++ b/backend/middlewares/csrfHeaderCheck.js
@@ -1,12 +1,3 @@
-const csrfTokenCheck = (req, res, next) => {
-  const cookieToken = req.cookies?.csrfToken;
-  const headerToken = req.headers["x-csrf-token"];
- 
-  if (!cookieToken || !headerToken || cookieToken !== headerToken) {
-    return res.status(403).json({ success: false, message: "CSRF token missing or invalid." });
-  }
- 
-  next();
-};
- 
-module.exports = csrfTokenCheck;
+const { csrfProtection } = require("./csrf");
+
+module.exports = csrfProtection;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "bcryptjs": "^3.0.2",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
+        "csrf-csrf": "^4.0.3",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "express-rate-limit": "^8.2.1",
@@ -35,43 +36,6 @@
         "nodemon": "^3.1.10",
         "supertest": "^7.2.2",
         "vitest": "^4.1.9"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
-      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@google/genai": {
@@ -1369,6 +1333,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/csrf-csrf": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/csrf-csrf/-/csrf-csrf-4.0.3.tgz",
+      "integrity": "sha512-DaygOzelL4Qo1pHwI9LPyZL+X2456/OzpT596kNeZGiTSqKVDOk/9PPJ+FjzZacjMUEusOHw3WJKe1RW4iUhrw==",
+      "license": "ISC",
+      "dependencies": {
+        "http-errors": "^2.0.0"
       }
     },
     "node_modules/debug": {
@@ -2751,67 +2724,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
-      }
-    },
-    "node_modules/mongoose/node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/mongoose/node_modules/gaxios": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
-      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "extend": "^3.0.2",
-        "https-proxy-agent": "^5.0.0",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/gcp-metadata": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
-      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "gaxios": "^5.0.0",
-        "json-bigint": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongoose/node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "bcryptjs": "^3.0.2",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
+    "csrf-csrf": "^4.0.3",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "express-rate-limit": "^8.2.1",

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -3,7 +3,7 @@ const { registerUser, loginUser, verifyEmail, resendVerificationEmail, getUserPr
 const { protect } = require("../middlewares/authMiddleware");
 const { upload, validateImageUpload } = require("../middlewares/uploadMiddleware");
 const { validateUserLogin, validateUserSignup, validateRefreshToken, validateResendEmail } = require("../Input_validators/ValidateAuth");
-const csrfHeaderCheck = require("../middlewares/csrfHeaderCheck");
+const { generateCsrfToken, csrfProtection } = require("../middlewares/csrf");
 const router = express.Router();
 
 const {
@@ -13,23 +13,18 @@ const {
   sensitiveAuthLimiter,
 } = require("../middlewares/rateLimiter");
 
-// CSRF protection is applied globally in server.js via lusca.csrf(), with a
-// blocklist exempting every JWT-bearer-only route. Only /refresh and /logout
-// (below) are actually enforced at runtime, since they're the two routes
-// that authenticate off the ambient refreshToken cookie.
-
 // Auth Routes
 router.post("/register", authLimiter, validateUserSignup, registerUser);
 router.post("/login", loginLimiter, validateUserLogin, loginUser);
 
-// Frontend should GET this once on app load to prime the XSRF-TOKEN cookie
-// before it ever needs to call /refresh or /logout.
+// Frontend GETs this endpoint to receive CSRF token and set the csrfToken cookie
 router.get("/csrf-token", generalLimiter, (req, res) => {
-  res.json({ success: true });
+  const csrfToken = generateCsrfToken(req, res);
+  res.json({ success: true, csrfToken });
 });
 
-router.post("/refresh", authLimiter, csrfHeaderCheck, validateRefreshToken, refreshToken);
-router.post("/logout", authLimiter, csrfHeaderCheck, validateRefreshToken, logoutUser);
+router.post("/refresh", authLimiter, csrfProtection, validateRefreshToken, refreshToken);
+router.post("/logout", authLimiter, csrfProtection, validateRefreshToken, logoutUser);
 router.get("/profile", protect, generalLimiter, getUserProfile);
 router.put("/profile", protect, generalLimiter, updateUserProfile);
 router.put("/change-password", protect, sensitiveAuthLimiter, changePassword);

--- a/frontend/src/utils/axiosinstance.js
+++ b/frontend/src/utils/axiosinstance.js
@@ -26,6 +26,32 @@ axiosInstance.interceptors.request.use(
     (error) => Promise.reject(error)
 );
 
+// ── CSRF Token Manager ───────────────────────────────────────────────────
+let cachedCsrfToken = null;
+
+async function getCsrfToken() {
+    if (cachedCsrfToken) {
+        return cachedCsrfToken;
+    }
+
+    const { data } = await axios.get(
+        `${BASE_URL}/api/auth/csrf-token`,
+        {
+            withCredentials: true,
+            headers: {
+                "X-Requested-With": "XMLHttpRequest",
+            },
+        }
+    );
+
+    if (!data?.csrfToken) {
+        throw new Error("CSRF token was not returned by the server");
+    }
+
+    cachedCsrfToken = data.csrfToken;
+    return cachedCsrfToken;
+}
+
 // ── Token refresh state ───────────────────────────────────────────────────
 let isRefreshing = false;
 let refreshSubscribers = [];   // subscribers waiting for the new token
@@ -83,13 +109,18 @@ axiosInstance.interceptors.response.use(
             isRefreshing = true;
 
             try {
-                // The refresh token is in an httpOnly cookie — just POST
+                const csrfToken = await getCsrfToken();
+
+                // The refresh token is in an httpOnly cookie — send X-CSRF-Token header
                 const { data } = await axios.post(
                     `${BASE_URL}/api/auth/refresh`,
                     {},
                     {
                         withCredentials: true,
-                        headers: { "X-Requested-With": "XMLHttpRequest" },
+                        headers: {
+                            "X-Requested-With": "XMLHttpRequest",
+                            "X-CSRF-Token": csrfToken,
+                        },
                     }
                 );
 
@@ -113,6 +144,7 @@ axiosInstance.interceptors.response.use(
                 originalRequest.headers.Authorization = `Bearer ${newToken}`;
                 return axiosInstance(originalRequest);
             } catch (refreshError) {
+                cachedCsrfToken = null;
                 // Refresh failed — reject all queued requests before clearing
                 refreshSubscribers.forEach((subscriber) => {
                     if (subscriber.reject) {


### PR DESCRIPTION
## Summary

Fixes the CSRF validation failure that prevents the AI Assistant from completing requests when the access token requires a refresh.

## Root Cause

The `/api/auth/csrf-token` endpoint did not generate a CSRF token.

When the access token expired, the Axios interceptor attempted to refresh the token through `/api/auth/refresh`, but the backend CSRF middleware received neither a valid CSRF cookie nor an `X-CSRF-Token` header.

This resulted in:

`403 CSRF token missing or invalid.`

## Changes

- Added `csrf-csrf` based CSRF token generation and validation
- Updated `/api/auth/csrf-token` to generate and return a CSRF token
- Protected refresh and logout routes with CSRF validation
- Updated Axios to retrieve and cache the CSRF token
- Added the `X-CSRF-Token` header to refresh requests
- Cleared the cached CSRF token when refresh fails

## Testing

- Frontend production build passes
- Backend tests pass
- CSRF token endpoint verified locally
- `/api/test` verified locally

Closes #2173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CSRF token generation and validation with `csrf-csrf`.
- Protected refresh and logout routes.
- Updated Axios to fetch, cache, and send `X-CSRF-Token`.
- Cleared the cached token after failed refresh requests.
- Added CSRF endpoint verification and backend/frontend build tests.

These changes fix CSRF validation failures during authentication refresh and allow the AI Assistant to complete requests after access-token expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->