### PR TITLE
feat(resume): add deterministic ATS keyword-match endpoint

### DIFF
--- a/backend/controllers/resumeController.js
+++ b/backend/controllers/resumeController.js
@@ -2,7 +2,9 @@ const axios = require('axios');
 const FormData = require('form-data');
 const fs = require('fs');
 const { generateWithFallback } = require('../utils/geminiHelper');
+const { matchResumeKeywords } = require('../utils/atsKeywordMatch');
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
+const MAX_ATS_INPUT = 50000; // chars; guards against oversized payloads
 
 /**
  * Compile LaTeX resume code to a PDF document.
@@ -354,4 +356,33 @@ const handleDrop = (e) => {
 };
 
 
-module.exports = { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume, getResumeAnalysisHistory ,validateFile,handleFileChange,handleDrop};
+/**
+ * Deterministic ATS keyword match between a resume and a job description.
+ * No AI / no file upload — pure keyword overlap, instant and free.
+ * @route POST /api/resume/ats-match
+ * @param {import('express').Request} req
+ * @param {import('express').Response} res
+ * @returns {Promise<void>}
+ */
+const atsMatch = async (req, res) => {
+  const { resumeText, jobDescription } = req.body || {};
+
+  if (
+    typeof resumeText !== 'string' || resumeText.trim().length === 0 ||
+    typeof jobDescription !== 'string' || jobDescription.trim().length === 0
+  ) {
+    return res.status(400).json({
+      success: false,
+      error: 'resumeText and jobDescription are required strings',
+    });
+  }
+
+  if (resumeText.length > MAX_ATS_INPUT || jobDescription.length > MAX_ATS_INPUT) {
+    return res.status(400).json({ success: false, error: 'Input too large' });
+  }
+
+  const result = matchResumeKeywords(resumeText, jobDescription);
+  return res.json({ success: true, ...result });
+};
+
+module.exports = { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume, getResumeAnalysisHistory ,validateFile,handleFileChange,handleDrop,atsMatch};

--- a/backend/routes/resumeRoutes.js
+++ b/backend/routes/resumeRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const router = express.Router();
-const { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume, getResumeAnalysisHistory } = require('../controllers/resumeController');
+const { compileResume, analyzeResume, saveResume, getMyResumes, deleteResume, getResumeAnalysisHistory, atsMatch } = require('../controllers/resumeController');
 const { protect } = require('../middlewares/authMiddleware');
 const { upload, uploadResume, validateResumeMagicBytes } = require('../middlewares/uploadMiddleware');
 const { aiLimiter } = require('../middlewares/rateLimiter');
@@ -32,6 +32,11 @@ router.get('/my-resumes', getMyResumes);
 // @desc    Get all saved resume analyses for logged-in user
 // @access  Private
 router.get('/analysis-history', getResumeAnalysisHistory);
+
+// @route   POST /api/resume/ats-match
+// @desc    Deterministic keyword-overlap score between a resume and a JD
+// @access  Private — pure keyword match, no AI/file, so no aiLimiter needed
+router.post('/ats-match', atsMatch);
 
 // @route   DELETE /api/resume/:id
 // @desc    Delete a saved resume by ID

--- a/backend/tests/atsKeywordMatch.unit.test.js
+++ b/backend/tests/atsKeywordMatch.unit.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractKeywords,
+  matchResumeKeywords,
+} from "../utils/atsKeywordMatch.js";
+
+// ---------------------------------------------------------------------------
+// atsKeywordMatch unit tests.
+// Covers extractKeywords tokenization and matchResumeKeywords scoring.
+// ---------------------------------------------------------------------------
+
+describe("extractKeywords", () => {
+  it("lowercases and dedupes", () => {
+    expect(extractKeywords("React react REACT")).toEqual(["react"]);
+  });
+
+  it("removes stopwords", () => {
+    expect(extractKeywords("the and or with")).toEqual([]);
+  });
+
+  it("drops tokens shorter than 2 chars", () => {
+    expect(extractKeywords("a x go")).toEqual(["go"]);
+  });
+
+  it("preserves c++, c#, node.js as single tokens", () => {
+    expect(extractKeywords("C++ C# Node.js")).toEqual(["c++", "c#", "node.js"]);
+  });
+
+  it("strips surrounding punctuation but keeps first-seen order", () => {
+    expect(extractKeywords("React, Node; MongoDB.")).toEqual([
+      "react",
+      "node",
+      "mongodb",
+    ]);
+  });
+
+  it("returns [] for non-string or empty input", () => {
+    expect(extractKeywords(null)).toEqual([]);
+    expect(extractKeywords(123)).toEqual([]);
+    expect(extractKeywords("")).toEqual([]);
+  });
+});
+
+describe("matchResumeKeywords", () => {
+  it("scores 100 with full overlap and no missing keywords", () => {
+    const r = matchResumeKeywords("React Node MongoDB", "React Node MongoDB");
+    expect(r.score).toBe(100);
+    expect(r.missing).toEqual([]);
+    expect(r.totalKeywords).toBe(3);
+  });
+
+  it("scores partial overlap and lists matched + missing", () => {
+    const r = matchResumeKeywords("React Node", "React Node GraphQL AWS");
+    expect(r.score).toBe(50);
+    expect(r.matched).toEqual(["react", "node"]);
+    expect(r.missing).toEqual(["graphql", "aws"]);
+    expect(r.totalKeywords).toBe(4);
+  });
+
+  it("scores 0 with no overlap", () => {
+    const r = matchResumeKeywords("Python Django", "React Node");
+    expect(r.score).toBe(0);
+    expect(r.matched).toEqual([]);
+  });
+
+  it("returns a zeroed result for an empty job description", () => {
+    expect(matchResumeKeywords("React Node", "")).toEqual({
+      score: 0,
+      matched: [],
+      missing: [],
+      totalKeywords: 0,
+    });
+  });
+
+  it("handles non-string inputs gracefully", () => {
+    const zero = { score: 0, matched: [], missing: [], totalKeywords: 0 };
+    expect(matchResumeKeywords(null, undefined)).toEqual(zero);
+    expect(matchResumeKeywords(123, 456)).toEqual(zero);
+  });
+
+  it("does not let stopwords inflate totalKeywords", () => {
+    const r = matchResumeKeywords("React", "the React and Node");
+    expect(r.totalKeywords).toBe(2);
+  });
+});

--- a/backend/utils/atsKeywordMatch.js
+++ b/backend/utils/atsKeywordMatch.js
@@ -1,0 +1,75 @@
+// Deterministic ATS-style keyword overlap between a resume and a job
+// description. Unlike the Gemini-based /analyze flow, this is instant, free,
+// and fully unit-testable — a quick "does my resume cover this JD" check.
+
+// Common words that carry no signal for keyword matching. Kept small and
+// obvious rather than a full linguistic stopword list.
+const STOPWORDS = new Set([
+  'the', 'a', 'an', 'and', 'or', 'of', 'to', 'in', 'for', 'on', 'with',
+  'at', 'by', 'is', 'are', 'be', 'as', 'that', 'this', 'it', 'you', 'your',
+  'we', 'our', 'will', 'from', 'have', 'has', 'using', 'use', 'able', 'etc',
+]);
+
+// Strip leading/trailing punctuation from a token. '+' and '#' are kept at the
+// ends so "c++" and "c#" survive; '.' is allowed only *internally* (so
+// "node.js" survives) but trimmed at the ends (so a sentence-final "MongoDB."
+// becomes "mongodb"). We never split on these, so multi-char tech tokens stay
+// whole.
+const trimPunctuation = (token) => token.replace(/^[^a-z0-9+#]+|[^a-z0-9+#]+$/g, '');
+
+/**
+ * Extract unique, lowercased keywords from free text, preserving first-seen
+ * order. Stopwords and tokens shorter than 2 chars are dropped.
+ * @param {string} text
+ * @returns {string[]}
+ */
+function extractKeywords(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+
+  const seen = new Set();
+  const keywords = [];
+
+  for (const raw of text.toLowerCase().split(/\s+/)) {
+    const token = trimPunctuation(raw);
+    if (token.length < 2 || STOPWORDS.has(token) || seen.has(token)) continue;
+    seen.add(token);
+    keywords.push(token);
+  }
+
+  return keywords;
+}
+
+/**
+ * Score how well a resume covers a job description's keywords.
+ * The JD drives the keyword set; `matched` are JD keywords present in the
+ * resume, `missing` are the rest. Score is the matched percentage (0-100).
+ * @param {string} resumeText
+ * @param {string} jobDescription
+ * @returns {{ score: number, matched: string[], missing: string[], totalKeywords: number }}
+ */
+function matchResumeKeywords(resumeText, jobDescription) {
+  const jdKeywords = extractKeywords(jobDescription);
+  const totalKeywords = jdKeywords.length;
+
+  if (totalKeywords === 0) {
+    return { score: 0, matched: [], missing: [], totalKeywords: 0 };
+  }
+
+  const resumeSet = new Set(extractKeywords(resumeText));
+  const matched = [];
+  const missing = [];
+
+  for (const keyword of jdKeywords) {
+    if (resumeSet.has(keyword)) matched.push(keyword);
+    else missing.push(keyword);
+  }
+
+  return {
+    score: Math.round((matched.length / totalKeywords) * 100),
+    matched,
+    missing,
+    totalKeywords,
+  };
+}
+
+module.exports = { extractKeywords, matchResumeKeywords, STOPWORDS };


### PR DESCRIPTION
## What & why

Closes #2268.

The existing `/analyze` endpoint is Gemini-based: it needs a PDF upload, hits an external (rate-limited) API, and is non-deterministic. This adds a fast, free, deterministic keyword-overlap check so a user can instantly see whether their resume covers a given job description.

## Changes

- **`POST /api/resume/ats-match`** (`atsMatch`) — takes `{ resumeText, jobDescription }`, returns `{ score, matched, missing, totalKeywords }`. 400 on missing/blank inputs or payloads over 50k chars. No `aiLimiter` — there are no external calls.
- **`utils/atsKeywordMatch.js`** — pure `extractKeywords` + `matchResumeKeywords`. Tokenization lowercases, dedupes (first-seen order), drops stopwords and <2-char tokens, and keeps tech tokens like `c++`, `c#`, `node.js` whole while trimming sentence punctuation. The JD drives the keyword set.

## Testing

- `tests/atsKeywordMatch.unit.test.js` — 12 unit tests (tokenization, tech-token preservation, punctuation trimming, full/partial/zero overlap, empty JD, non-string inputs, stopword handling).
- Full backend `vitest run` green (188 passed).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->