### PR TITLE
test: scope interview experience idempotency by submitter

### DIFF
--- a/backend/tests/interviewExperienceController.unit.test.js
+++ b/backend/tests/interviewExperienceController.unit.test.js
@@ -206,7 +206,43 @@ describe("createInterviewExperience", () => {
     expect(res.status).toHaveBeenCalledWith(201);
   });
 
-  it("isolates anonymous submissions by clientKey so different visitors with the same key both persist", async () => {
+  it("returns the existing submission when the same authenticated user retries the same idempotency key", async () => {
+    InterviewExperience.findOne = vi.fn().mockResolvedValue(sampleDoc);
+    InterviewExperience.create = vi.fn();
+
+    const userA = { _id: "507f1f77bcf86cd799439011" };
+    const req = makeReq(
+      {
+        company: "Google",
+        role: "SDE-2",
+        summary: "Summary",
+        idempotencyKey: "submit-key-abc12345",
+      },
+      {},
+      {},
+      userA,
+    );
+    const res = makeRes();
+
+    await createInterviewExperience(req, res);
+
+    expect(InterviewExperience.findOne).toHaveBeenCalledWith({
+      idempotencyKey: "submit-key-abc12345",
+      userId: "507f1f77bcf86cd799439011",
+    });
+    expect(InterviewExperience.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        success: true,
+        experience: expect.objectContaining({
+          id: "507f1f77bcf86cd799439011",
+        }),
+      }),
+    );
+  });
+
+  it("does not deduplicate an anonymous request against an authenticated submission with the same idempotency key", async () => {
     InterviewExperience.findOne = vi.fn().mockResolvedValue(null);
     InterviewExperience.create = vi.fn().mockResolvedValue(sampleDoc);
 
@@ -214,7 +250,7 @@ describe("createInterviewExperience", () => {
       company: "Google",
       role: "SDE-2",
       summary: "Summary",
-      clientKey: "22222222-2222-4222-8222-222222222222",
+      clientKey: "11111111-1111-4111-8111-111111111111",
       idempotencyKey: "shared-key-abc12345",
     });
     const res = makeRes();
@@ -223,9 +259,10 @@ describe("createInterviewExperience", () => {
 
     expect(InterviewExperience.findOne).toHaveBeenCalledWith({
       idempotencyKey: "shared-key-abc12345",
-      clientKey: "22222222-2222-4222-8222-222222222222",
+      clientKey: "11111111-1111-4111-8111-111111111111",
     });
     expect(InterviewExperience.create).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
   });
 });
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #1926

### Summary

Fix interview experience idempotency deduplication so that submissions are scoped to the submitting identity instead of being deduplicated globally by `idempotencyKey`.

* Authenticated submissions are scoped by `(idempotencyKey, userId)`.
* Anonymous submissions are scoped by `(idempotencyKey, clientKey)`.
* Prevents one user/client from receiving another user's/client's interview submission when the same idempotency key is reused.
* Added test coverage for the scoped idempotency behavior.

---

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New feature
* [ ] ♻️ Refactoring
* [ ] 📝 Documentation update
* [ ] 🎨 UI/UX improvement
* [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?

* Added/updated unit tests covering idempotency deduplication for authenticated users and anonymous clients.
* Verified that repeated submissions from the same user/client with the same idempotency key are deduplicated.
* Verified that the same idempotency key used by different users/clients does not return another submitter's submission.
* Ran the relevant backend test/validation checks successfully.

---

### Screenshots (if applicable)

Not applicable — this is a backend-only bug fix.

---

### Checklist

* [x] My code follows the project's guidelines
* [x] I have tested my changes
* [ ] I have updated documentation where necessary
* [x] I have linked the related issue
* [x] My changes do not introduce new warnings or errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Looks good to me. Ready to merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->