### PR TITLE
Fix/streak milestone toast property

### DIFF
--- a/backend/controllers/flashcardController.js
+++ b/backend/controllers/flashcardController.js
@@ -198,7 +198,7 @@ const reviewFlashcard = async (req, res) => {
 
     await flashcard.save();
 
-    const { newlyUnlocked } = await recordActivity(userId);
+    const { newlyUnlockedMilestones } = await recordActivity(userId);
 
     return res.status(200).json({
       success: true,
@@ -206,7 +206,7 @@ const reviewFlashcard = async (req, res) => {
       flashcard,
       // Streak milestones (e.g. "7-Day Streak") unlocked by this activity,
       // if any — lets the frontend show a toast.
-      newlyUnlockedAchievements: newlyUnlocked,
+      newlyUnlockedAchievements: newlyUnlockedMilestones || [],
     });
   } catch (error) {
     return res.status(500).json({

--- a/backend/controllers/userSheetProgressController.js
+++ b/backend/controllers/userSheetProgressController.js
@@ -109,7 +109,7 @@ exports.saveProgress = async (req, res) => {
   let newlyUnlocked = [];
   try {
     const streakResult = await recordActivity(userId);
-    newlyUnlocked = streakResult?.newlyUnlocked || [];
+    newlyUnlocked = streakResult?.newlyUnlockedMilestones || [];
   } catch (streakErr) {
     console.error("Streak tracking failed:", streakErr);
   }
@@ -136,12 +136,12 @@ exports.saveProgress = async (req, res) => {
           }
         );
 
-        const { newlyUnlocked: retryNewlyUnlocked } = await recordActivity(userId);
+        const { newlyUnlockedMilestones: retryNewlyUnlocked } = await recordActivity(userId);
 
         return res.json({
           success: true,
           progress,
-          newlyUnlockedAchievements: retryNewlyUnlocked,
+          newlyUnlockedAchievements: retryNewlyUnlocked || [],
         });
       } catch (retryErr) {
         return res.status(500).json({

--- a/backend/tests/userSheetProgressController.unit.test.js
+++ b/backend/tests/userSheetProgressController.unit.test.js
@@ -92,7 +92,7 @@ beforeEach(() => {
   // Sensible default so tests that don't care about streaks don't need to
   // stub this individually; override with .mockResolvedValue(...) in any
   // test that needs specific newlyUnlocked values.
-  streakTrackerMock.recordActivity.mockResolvedValue({ newlyUnlocked: [] });
+  streakTrackerMock.recordActivity.mockResolvedValue({ newlyUnlockedMilestones: [] });
 });
 
 afterEach(() => {
@@ -187,7 +187,7 @@ describe("saveProgress", () => {
       percentage: 80,
     };
     modelMock.findOneAndUpdate.mockResolvedValue(fakeProgress);
-    streakTrackerMock.recordActivity.mockResolvedValue({ newlyUnlocked: [] });
+    streakTrackerMock.recordActivity.mockResolvedValue({ newlyUnlockedMilestones: [] });
 
     const req = {
       user: { _id: "user-1" },
@@ -206,6 +206,28 @@ describe("saveProgress", () => {
       success: true,
       progress: fakeProgress,
       newlyUnlockedAchievements: [],
+    });
+  });
+
+  it("propagates newly unlocked streak milestones in newlyUnlockedAchievements (#2288)", async () => {
+    const fakeProgress = { sheetId: "arrays", percentage: 100 };
+    modelMock.findOneAndUpdate.mockResolvedValue(fakeProgress);
+    streakTrackerMock.recordActivity.mockResolvedValue({
+      newlyUnlockedMilestones: ["7-Day Streak"],
+    });
+
+    const req = {
+      user: { _id: "user-1" },
+      body: { sheetId: "arrays", percentage: 100 },
+    };
+    const res = mockRes();
+
+    await saveProgress(req, res);
+
+    expect(res.body).toEqual({
+      success: true,
+      progress: fakeProgress,
+      newlyUnlockedAchievements: ["7-Day Streak"],
     });
   });
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #2288

### Summary
Fix streak milestone notifications that were not being propagated after flashcard reviews and sheet-progress saves.

`recordActivity()` returns `newlyUnlockedMilestones`, but the affected controllers were still reading the old `newlyUnlocked` property. This caused `newlyUnlockedAchievements` to be empty or undefined even when a milestone was unlocked.

This PR:
- Updates the flashcard review flow to use `newlyUnlockedMilestones`.
- Updates the sheet-progress flow and retry path to use `newlyUnlockedMilestones`.
- Adds regression test coverage for the corrected milestone propagation.

---

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔥 Other(please describe) ______

---

### How Has This Been Tested?
- Added/updated regression tests for streak milestone propagation.
- Verified that newly unlocked milestones are correctly passed as `newlyUnlockedAchievements`.
- Verified the sheet-progress retry path uses the updated property.
- Ran the relevant backend unit tests successfully.

---

### Screenshots (if applicable)
Not applicable — this is a backend data-flow fix.

---

### Checklist
- [x] My code follows the project's guidelines
- [x] I have tested my changes
- [ ] I have updated documentation where necessary
- [x] I have linked the related issue
- [x] My changes do not introduce new warnings or errors