### PR TITLE
feat(question): add DSA study-plan scheduler endpoint

### DIFF
--- a/backend/controllers/questionController.js
+++ b/backend/controllers/questionController.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const Question = require("../models/Question");
+const { buildStudyPlan } = require("../utils/studyPlanScheduler");
 const Session = require("../models/Session");
 
 // Escape regex metacharacters so user search text is treated as a literal
@@ -263,9 +264,38 @@ const updateQuestionNote = async (req, res) => {
   }
 };
 
+/**
+ * Build a balanced day-by-day study plan from a list of problems.
+ * @route POST /api/question/study-plan
+ */
+const buildStudyPlanHandler = async (req, res) => {
+  const { problems, days } = req.body || {};
+
+  if (!Array.isArray(problems) || problems.length === 0) {
+    return res
+      .status(400)
+      .json({ success: false, error: "problems must be a non-empty array" });
+  }
+  if (problems.length > 1000) {
+    return res.status(400).json({ success: false, error: "Too many problems" });
+  }
+
+  const dayCount = Number(days);
+  if (!Number.isInteger(dayCount) || dayCount < 1 || dayCount > 365) {
+    return res.status(400).json({
+      success: false,
+      error: "days must be an integer between 1 and 365",
+    });
+  }
+
+  const result = buildStudyPlan(problems, dayCount);
+  return res.json({ success: true, ...result });
+};
+
 module.exports = {
   addQuestionToSession,
   togglePinQuestion,
   updateQuestionNote,
   getMyQuestions,
+  buildStudyPlanHandler,
 };

--- a/backend/routes/questionRoutes.js
+++ b/backend/routes/questionRoutes.js
@@ -4,6 +4,7 @@ const {
   updateQuestionNote,
   addQuestionToSession,
   getMyQuestions,
+  buildStudyPlanHandler,
 } = require("../controllers/questionController");
 const {protect} = require("../middlewares/authMiddleware");
 
@@ -39,5 +40,11 @@ router.post('/:id/pin',validateTogglePinQuestion,togglePinQuestion);
  * @route POST /api/question/:id/note
  */
 router.post('/:id/note', validateUpdateQuestionNote, updateQuestionNote);
+
+/**
+ * Build a balanced day-by-day study plan from a list of problems.
+ * @route POST /api/question/study-plan
+ */
+router.post('/study-plan', buildStudyPlanHandler);
 
 module.exports = router;

--- a/backend/tests/studyPlanScheduler.unit.test.js
+++ b/backend/tests/studyPlanScheduler.unit.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from "vitest";
+import {
+  problemWeight,
+  buildStudyPlan,
+  DIFFICULTY_WEIGHTS,
+} from "../utils/studyPlanScheduler.js";
+
+describe("problemWeight", () => {
+  it("maps difficulties to weights", () => {
+    expect(problemWeight("easy")).toBe(1);
+    expect(problemWeight("medium")).toBe(2);
+    expect(problemWeight("hard")).toBe(3);
+  });
+
+  it("is case-insensitive and trims", () => {
+    expect(problemWeight("  HARD ")).toBe(3);
+  });
+
+  it("defaults unknown/missing difficulty to medium", () => {
+    expect(problemWeight("insane")).toBe(2);
+    expect(problemWeight(undefined)).toBe(2);
+  });
+});
+
+describe("buildStudyPlan", () => {
+  it("returns one bucket per day with day/problems/load fields", () => {
+    const { plan } = buildStudyPlan([{ difficulty: "easy" }], 3);
+    expect(plan).toHaveLength(3);
+    plan.forEach((entry, i) => {
+      expect(entry.day).toBe(i + 1);
+      expect(Array.isArray(entry.problems)).toBe(true);
+      expect(typeof entry.load).toBe("number");
+    });
+  });
+
+  it("balances load across days (LPT)", () => {
+    const problems = [
+      { difficulty: "hard" },
+      { difficulty: "hard" },
+      { difficulty: "easy" },
+      { difficulty: "easy" },
+    ];
+    const { plan, totalLoad } = buildStudyPlan(problems, 2);
+    expect(plan[0].load).toBe(4);
+    expect(plan[1].load).toBe(4);
+    expect(totalLoad).toBe(8);
+  });
+
+  it("places every problem exactly once", () => {
+    const problems = [
+      { title: "A", difficulty: "easy" },
+      { title: "B", difficulty: "medium" },
+      { title: "C", difficulty: "hard" },
+    ];
+    const { plan } = buildStudyPlan(problems, 2);
+    const placed = plan.flatMap((d) => d.problems);
+    expect(placed).toHaveLength(3);
+    expect(placed.filter((p) => p.title === "B")).toHaveLength(1);
+  });
+
+  it("counts missing difficulty as medium", () => {
+    expect(buildStudyPlan([{ title: "x" }], 1).totalLoad).toBe(2);
+  });
+
+  it("allows more days than problems (empty days)", () => {
+    const { plan } = buildStudyPlan([{ difficulty: "easy" }], 3);
+    expect(plan).toHaveLength(3);
+    expect(plan.filter((d) => d.load === 0)).toHaveLength(2);
+  });
+
+  it("is deterministic", () => {
+    const problems = [
+      { difficulty: "hard" },
+      { difficulty: "easy" },
+      { difficulty: "medium" },
+    ];
+    expect(buildStudyPlan(problems, 2)).toEqual(buildStudyPlan(problems, 2));
+  });
+
+  it("guards invalid input", () => {
+    const empty = { plan: [], totalLoad: 0, days: 0 };
+    expect(buildStudyPlan([], 5)).toEqual(empty);
+    expect(buildStudyPlan("nope", 5)).toEqual(empty);
+    expect(buildStudyPlan([{}], 0)).toEqual(empty);
+    expect(buildStudyPlan([{}], -1)).toEqual(empty);
+    expect(buildStudyPlan([{}], 2.5)).toEqual(empty);
+  });
+
+  it("exposes the difficulty weight table", () => {
+    expect(DIFFICULTY_WEIGHTS).toEqual({ easy: 1, medium: 2, hard: 3 });
+  });
+});

--- a/backend/utils/studyPlanScheduler.js
+++ b/backend/utils/studyPlanScheduler.js
@@ -1,0 +1,65 @@
+// Deterministic DSA study-plan scheduler.
+//
+// Turns a flat list of practice problems (each with an easy/medium/hard
+// difficulty) plus a target number of days into a balanced day-by-day plan.
+// Uses difficulty-weighted LPT (longest-processing-time) scheduling so no
+// single day is overloaded. Pure and deterministic — no I/O.
+
+const DIFFICULTY_WEIGHTS = { easy: 1, medium: 2, hard: 3 };
+const DEFAULT_WEIGHT = DIFFICULTY_WEIGHTS.medium; // unknown/missing difficulty
+
+/**
+ * Weight of a single problem by its difficulty (case-insensitive).
+ * @param {string} difficulty
+ * @returns {number}
+ */
+function problemWeight(difficulty) {
+  if (typeof difficulty !== "string") return DEFAULT_WEIGHT;
+  const key = difficulty.trim().toLowerCase();
+  return DIFFICULTY_WEIGHTS[key] ?? DEFAULT_WEIGHT;
+}
+
+/**
+ * Distribute problems across `days` balanced buckets.
+ * @param {Array<{difficulty?: string}>} problems
+ * @param {number} days
+ * @returns {{ plan: Array<{day: number, problems: any[], load: number}>, totalLoad: number, days: number }}
+ */
+function buildStudyPlan(problems, days) {
+  if (!Array.isArray(problems) || problems.length === 0) {
+    return { plan: [], totalLoad: 0, days: 0 };
+  }
+  if (!Number.isInteger(days) || days < 1) {
+    return { plan: [], totalLoad: 0, days: 0 };
+  }
+
+  const buckets = Array.from({ length: days }, (_, i) => ({
+    day: i + 1,
+    problems: [],
+    load: 0,
+  }));
+
+  // Sort a copy by weight descending, breaking ties by original index so the
+  // result is stable and deterministic.
+  const ordered = problems
+    .map((problem, index) => ({ problem, index, weight: problemWeight(problem?.difficulty) }))
+    .sort((a, b) => b.weight - a.weight || a.index - b.index);
+
+  let totalLoad = 0;
+  for (const { problem, weight } of ordered) {
+    // Assign to the currently least-loaded bucket (ties → lowest day).
+    let target = buckets[0];
+    for (const bucket of buckets) {
+      if (bucket.load < target.load) target = bucket;
+    }
+    target.problems.push(problem);
+    target.load += weight;
+    totalLoad += weight;
+  }
+
+  // ponytail: LPT is a ~4/3-approx heuristic, not an optimal partition — fine
+  // for study plans; swap for full DP only if exact balance ever matters.
+  return { plan: buckets, totalLoad, days };
+}
+
+module.exports = { DIFFICULTY_WEIGHTS, problemWeight, buildStudyPlan };


### PR DESCRIPTION
## What & why

Closes #2305.

Turns a practice sheet into a "prep in N days" plan: given a list of problems and a target number of days, it produces a balanced day-by-day schedule.

## Changes

- **`backend/utils/studyPlanScheduler.js`** (new, pure, CommonJS) — `buildStudyPlan(problems, days)` weights problems by difficulty (easy=1, medium=2, hard=3; unknown/missing→medium via `problemWeight`) and distributes them across `days` buckets with difficulty-weighted **LPT** scheduling (assign each, heaviest-first, to the least-loaded day). Returns `{ plan: [{ day, problems, load }], totalLoad, days }`. Deterministic; guards invalid input.
- **`questionController.js`** — `buildStudyPlanHandler` with inline validation (non-empty array, ≤1000 problems, integer days 1–365), mirroring the existing `atsMatch` style.
- **`questionRoutes.js`** — `POST /api/question/study-plan` (auth + rate-limit already applied globally).

No new dependency; no `package.json`/lockfile changes.

## Testing

- **`backend/tests/studyPlanScheduler.unit.test.js`** — 11 vitest cases (weights, load balancing, exactly-once placement, empty days, default difficulty, determinism, input guards). 
- Full backend `vitest run` → **207 passed** (18 files).

_Contributing as part of Elite Coders Summer of Code (ECSoC 2026)._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adds an authenticated `POST /api/question/study-plan` endpoint.

- Uses deterministic, pure LPT scheduling with difficulty weights: easy `1`, medium `2`, hard `3`.
- Defaults missing or unknown difficulty to medium.
- Supports empty days when `days` exceeds the problem count.
- Validates problem lists and day counts.
- Adds 11 Vitest unit tests.
- Full backend suite passes: 207 tests across 18 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->